### PR TITLE
h264dec: fix poc bug.

### DIFF
--- a/decoder/vaapipicture.h
+++ b/decoder/vaapipicture.h
@@ -140,7 +140,7 @@ class VaapiPicture {
 
   public:
     uint64_t m_timeStamp;
-    uint32_t m_POC;
+    int32_t  m_POC;
     uint32_t m_flags;
     VaapiPictureStructure m_picStructure;
     VaapiPictureType m_type;


### PR DESCRIPTION
 The type definition of picture poc difinitaion
 error, then output picture with minimal poc might
 be error.

Signed-off-by: Zhong Cong congx.zhong@intel.com
