### PR TITLE
h264dec: fix marking picture bug.

### DIFF
--- a/decoder/vaapidecoder_h264.cpp
+++ b/decoder/vaapidecoder_h264.cpp
@@ -1148,6 +1148,7 @@ bool VaapiDecoderH264::markingPicture(VaapiPictureH264 * pic)
     if (m_prevPicHasMMCO5) {
         m_frameNum = 0;
         m_frameNumOffset = 0;
+        m_prevFrame = NULL;
     }
 
     m_prevPicStructure = pic->m_structure;


### PR DESCRIPTION
if previous picture has mmco5, m_prevFrame in Class VaapiDecoderH264
should be set NULL,Or there will be buggy in VaapiDecoderH264::
storeDecodedPicture() when decoding the current picture.
Code as follows:
/\*    if (m_prevFrame && !m_prevFrame->hasFrame()) {
-        RETURN_VAL_IF_FAIL(m_prevFrame->m_numBuffers == 1, false);
  *
-        m_prevFrame->addPicture(m_currentPicture);
  */

Signed-off-by: Zhong Cong congx.zhong@intel.com
