### PR TITLE
h264dec: fix leak of surface bug.

### DIFF
--- a/decoder/vaapidecoder_h264.cpp
+++ b/decoder/vaapidecoder_h264.cpp
@@ -1175,11 +1175,11 @@ bool VaapiDecoderH264::storeDecodedPicture(VaapiPictureH264 * pic)
 
     m_prevFrame = frameStore;
 
-    if (!m_DPBManager->addDPB(frameStore, pic))
-        return false;
-
     if (m_prevFrame && m_prevFrame->hasFrame())
         m_currentPicture = NULL;
+
+    if (!m_DPBManager->addDPB(m_prevFrame, pic))
+        return false;
 
     return true;
 }

--- a/decoder/vaapidecoder_h264.h
+++ b/decoder/vaapidecoder_h264.h
@@ -132,7 +132,7 @@ class VaapiDPBManager {
     bool bumpDPB();
     void clearDPB();
     void flushDPB();
-    bool addDPB(VaapiFrameStore * newFrameStore, VaapiPictureH264 * pic);
+    bool addDPB(VaapiFrameStore * &newFrameStore, VaapiPictureH264 * pic);
     void resetDPB(H264SPS * sps);
     /* initialize and reorder reference list */
     void initPictureRefs(VaapiPictureH264 * pic,


### PR DESCRIPTION
 when a picture is not a reference frame and dpb is full, decoder outputs the picture directly.
 But the DECODING state of surface, current frame store, and current picture haven't been cleared.

Signed-off-by: Zhong Cong congx.zhong@intel.com
