### PR TITLE
add build option for each codec & fix jpeg mimetype

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,6 +29,42 @@ if test "$enable_baytrail" = "yes"; then
 AC_DEFINE([__PLATFORM_BYT__], [1], [Defined to 1 if --enable-baytrail="yes" ])
 fi
 
+dnl vp8 decoder
+AC_ARG_ENABLE(vp8dec,
+    [AC_HELP_STRING([--enable-vp8dec], [build with vp8 decoder support @<:@default=no@:>@])],
+    [], [enable_vp8dec="yes"])
+if test "$enable_vp8dec" = "yes"; then
+AC_DEFINE([__BUILD_VP8_DECODER__], [1], [Defined to 1 if --enable-vp8dec="yes" ])
+fi
+AM_CONDITIONAL(BUILD_VP8_DECODER, test "x$enable_vp8dec" = "xyes")
+
+dnl jpeg decoder
+AC_ARG_ENABLE(jpegdec,
+    [AC_HELP_STRING([--enable-jpegdec], [build with jpeg decoder support @<:@default=no@:>@])],
+    [], [enable_jpegdec="yes"])
+if test "$enable_jpegdec" = "yes"; then
+AC_DEFINE([__BUILD_JPEG_DECODER__], [1], [Defined to 1 if --enable-jpegdec="yes" ])
+fi
+AM_CONDITIONAL(BUILD_JPEG_DECODER, test "x$enable_jpegdec" = "xyes")
+
+dnl h264 decoder
+AC_ARG_ENABLE(h264dec,
+    [AC_HELP_STRING([--enable-h264dec], [build with h264 decoder support @<:@default=no@:>@])],
+    [], [enable_h264dec="yes"])
+if test "$enable_h264dec" = "yes"; then
+AC_DEFINE([__BUILD_H264_DECODER__], [1], [Defined to 1 if --enable-h264dec="yes" ])
+fi
+AM_CONDITIONAL(BUILD_H264_DECODER, test "x$enable_h264dec" = "xyes")
+
+dnl h264 encoder
+AC_ARG_ENABLE(h264enc,
+    [AC_HELP_STRING([--enable-h264enc], [build with h264 encoder support @<:@default=no@:>@])],
+    [], [enable_h264enc="yes"])
+if test "$enable_h264enc" = "yes"; then
+AC_DEFINE([__BUILD_H264_ENCODER__], [1], [Defined to 1 if --enable-h264enc="yes" ])
+fi
+AM_CONDITIONAL(BUILD_H264_ENCODER, test "x$enable_h264enc" = "xyes")
+
 # Checks for programs.
 AC_DISABLE_STATIC
 AC_PROG_CXX

--- a/decoder/Makefile.am
+++ b/decoder/Makefile.am
@@ -6,13 +6,22 @@ INCLUDES = -I$(top_srcdir) \
 libyami_decoder_source_c = \
         vaapipicture.cpp \
         vaapidecoder_base.cpp \
-        vaapidecoder_h264.cpp \
-        vaapidecoder_h264_dpb.cpp \
-        vaapidecoder_vp8.cpp \
-        vaapidecoder_jpeg.cpp \
         vaapidecoder_host.cpp \
         vaapisurfacebuf_pool.cpp \
 	$(NULL)
+
+if BUILD_H264_DECODER
+        libyami_decoder_source_c += vaapidecoder_h264.cpp
+        libyami_decoder_source_c += vaapidecoder_h264_dpb.cpp
+endif
+
+if BUILD_VP8_DECODER
+        libyami_decoder_source_c += vaapidecoder_vp8.cpp
+endif
+
+if BUILD_JPEG_DECODER
+        libyami_decoder_source_c += vaapidecoder_jpeg.cpp
+endif
 
 libyami_decoder_source_h = \
         ../interface/VideoDecoderDefs.h      \
@@ -23,11 +32,20 @@ libyami_decoder_source_h = \
 libyami_decoder_source_h_priv = \
         vaapipicture.h    \
         vaapidecoder_base.h \
-        vaapidecoder_h264.h \
-        vaapidecoder_vp8.h \
-        vaapidecoder_jpeg.h \
         vaapisurfacebuf_pool.h \
 	$(NULL)
+
+if BUILD_H264_DECODER
+        libyami_decoder_source_h_priv += vaapidecoder_h264.h
+endif
+
+if BUILD_VP8_DECODER
+        libyami_decoder_source_h_priv += vaapidecoder_vp8.h
+endif
+
+if BUILD_JPEG_DECODER
+        libyami_decoder_source_h_priv += vaapidecoder_jpeg.h
+endif
 
 libyami_decoder_la_LIBADD = \
 		$(top_builddir)/common/libyami_common.la \

--- a/decoder/vaapidecoder_host.cpp
+++ b/decoder/vaapidecoder_host.cpp
@@ -25,19 +25,35 @@
 
 #include "common/log.h"
 #include "interface/VideoDecoderHost.h"
+#if __BUILD_H264_DECODER__
 #include "vaapidecoder_h264.h"
+#endif
+#if __BUILD_VP8_DECODER__
 #include "vaapidecoder_vp8.h"
+#endif
+#if __BUILD_JPEG_DECODER__
 #include "vaapidecoder_jpeg.h"
+#endif
 #include "vaapi_host.h"
 #include <string.h>
 
 DEFINE_CLASS_FACTORY(Decoder)
 static const DecoderEntry g_decoderEntries[] = {
+#if __BUILD_H264_DECODER__
     DEFINE_DECODER_ENTRY("video/avc", H264),
     DEFINE_DECODER_ENTRY("video/h264", H264),
-    DEFINE_DECODER_ENTRY("video/jpeg", Jpeg),
+#endif
+#if __BUILD_JPEG_DECODER__
+    DEFINE_DECODER_ENTRY("image/jpeg", Jpeg),
+#endif
+#if __BUILD_VP8_DECODER__
     DEFINE_DECODER_ENTRY("video/x-vnd.on2.vp8", VP8)
+#endif
 };
+
+#ifndef N_ELEMENTS
+#define N_ELEMENTS(array) (sizeof(array)/sizeof(array[0]))
+#endif
 
 IVideoDecoder *createVideoDecoder(const char *mimeType)
 {

--- a/encoder/Makefile.am
+++ b/encoder/Makefile.am
@@ -7,9 +7,12 @@ libyami_encoder_source_c = \
         vaapicodedbuffer.cpp \
         vaapiencpicture.cpp \
         vaapiencoder_base.cpp \
-        vaapiencoder_h264.cpp \
         vaapiencoder_host.cpp \
 	$(NULL)
+
+if BUILD_H264_ENCODER
+        libyami_encoder_source_c += vaapiencoder_h264.cpp
+endif
 
 libyami_encoder_source_h = \
         ../interface/VideoEncoderDef.h      \
@@ -21,8 +24,11 @@ libyami_encoder_source_h_priv = \
         vaapicodedbuffer.h \
         vaapiencpicture.h \
         vaapiencoder_base.h \
-        vaapiencoder_h264.h \
 	$(NULL)
+
+if BUILD_H264_ENCODER
+        libyami_encoder_source_h_priv += vaapiencoder_h264.h
+endif
 
 libyami_encoder_la_LIBADD = \
 		$(top_builddir)/common/libyami_common.la \

--- a/encoder/vaapiencoder_host.cpp
+++ b/encoder/vaapiencoder_host.cpp
@@ -26,14 +26,18 @@
 #include "basictype.h"
 #include "common/log.h"
 #include "interface/VideoEncoderHost.h"
+#if __BUILD_H264_ENCODER__
 #include "vaapiencoder_h264.h"
+#endif
 #include "vaapi_host.h"
 #include <string.h>
 
 DEFINE_CLASS_FACTORY(Encoder)
 static const EncoderEntry g_encoderEntries[] = {
+#if __BUILD_H264_ENCODER__
     DEFINE_ENCODER_ENTRY("video/avc", H264),
     DEFINE_ENCODER_ENTRY("video/h264", H264)
+#endif
 };
 
 IVideoEncoder* createVideoEncoder(const char* mimeType) {


### PR DESCRIPTION
all codecs are built by default,
you can explicitly disable one (for example jpegdec) by '--enable-jpegdec=no'
fix mistake on jpeg mimetype: image/jpeg
