### PR TITLE
h264dec: fix spliteFields for PAFF

### DIFF
--- a/decoder/vaapidecoder_h264.cpp
+++ b/decoder/vaapidecoder_h264.cpp
@@ -334,6 +334,11 @@ bool VaapiFrameStore::splitFields()
     if (!secondField)
         return false;
 
+    secondField->m_picStructure = VAAPI_PICTURE_STRUCTURE_BOTTOM_FIELD;
+    secondField->m_flags |= VAAPI_PICTURE_FLAG_INTERLACED ;
+    secondField->m_flags |= VAAPI_PICTURE_FLAGS(firstField) & VAAPI_PICTURE_FLAGS_REFERENCE;
+    secondField->m_POC = firstField->m_POC;
+
     m_buffers[m_numBuffers++] = secondField;
 
     secondField->m_frameNum = firstField->m_frameNum;


### PR DESCRIPTION
for picture-adaptive frame-fields, when we build a ref list for field, we
need splite frame to fields. and seconds field need inherit first fields's
poc and reference states (short or long).
