### PR TITLE
h264dec: fix long term ref picture mark as unused for reference bug.

### DIFF
--- a/decoder/vaapidecoder_h264_dpb.cpp
+++ b/decoder/vaapidecoder_h264_dpb.cpp
@@ -1039,10 +1039,10 @@ bool VaapiDPBManager::execRefPicMarkingAdaptive1(VaapiPictureH264 *
                                                  refPicMarking,
                                                  uint32_t MMCO)
 {
-    uint32_t picNumX, longTermFrameIdx;
+    uint32_t picNumX, i;
+    int32_t longTermFrameIdx;
     VaapiPictureH264 *refPicture;
     int32_t foundIdx = 0;
-    uint32_t i;
 
     switch (MMCO) {
     case 1:


### PR DESCRIPTION
Follow 8.2.5.4.4 All pictures for which LongTermFrameIdx
is greater than max_long_term_frame_idx_plus1 ? 1 and
that are marked as "used for long-term reference" are
 marked as "unused for reference".

VaapiPictureH264 use int32_t hold longTermFrameIdx,
but uint32_t is used to held longTermFrameIdx in
_execRefPicMarkingAdaptive1_ function, and some clips
have nagtive longTermFrameIdx(-1) when mmco equals to 4,
like MR3_TANDBERG_B.264.

No long term ref picture will be marked as "unused for reference",
because DPBLayer->longRef[i]->longTermFrameIdx can not larger than
(unsigned -1).

Code is as follows:
/*
-           for (i = 0; i < DPBLayer->longRefCount; i++) {
-               if (DPBLayer->longRef[i]->m_longTermFrameIdx <=
-                   longTermFrameIdx)
-                   continue;
-               setH264PictureReference(DPBLayer->longRef[i], 0, false);
-               ARRAY_REMOVE_INDEX(DPBLayer->longRef, i);
-               i--;
-           }
  */

Signed-off-by: Zhong Cong congx.zhong@intel.com
