### PR TITLE
h264dec: fix miss frame when negtive poc in stream

### DIFF
--- a/decoder/vaapisurfacebuf_pool.cpp
+++ b/decoder/vaapisurfacebuf_pool.cpp
@@ -314,7 +314,7 @@ bool VaapiSurfaceBufferPool::setReferenceInfo(VideoSurfaceBuffer * buf,
 }
 
 bool VaapiSurfaceBufferPool::outputBuffer(VideoSurfaceBuffer * buf,
-                                          uint64_t timeStamp, uint32_t poc)
+                                          uint64_t timeStamp, int32_t poc)
 {
     DEBUG("Pool: set surface(ID:0x%x, poc:%d) to be rendered",
           buf->renderBuffer.surface, poc);
@@ -452,7 +452,7 @@ VideoSurfaceBuffer *VaapiSurfaceBufferPool::getOutputByMinTimeStamp()
 VideoSurfaceBuffer *VaapiSurfaceBufferPool::getOutputByMinPOC()
 {
     uint32_t i;
-    uint32_t poc = INVALID_POC;
+    int32_t poc = INVALID_POC;
     VideoSurfaceBuffer *buf = NULL;
 
     pthread_mutex_lock(&m_lock);
@@ -464,7 +464,7 @@ VideoSurfaceBuffer *VaapiSurfaceBufferPool::getOutputByMinPOC()
             m_bufArray[i]->pictureOrder == INVALID_POC)
             continue;
 
-        if ((uint64_t) (m_bufArray[i]->pictureOrder) < poc) {
+        if (m_bufArray[i]->pictureOrder < poc) {
             poc = m_bufArray[i]->pictureOrder;
             buf = m_bufArray[i];
         }

--- a/decoder/vaapisurfacebuf_pool.h
+++ b/decoder/vaapisurfacebuf_pool.h
@@ -27,6 +27,7 @@
 #ifndef vaapisurfacebuf_pool_h
 #define vaapisurfacebuf_pool_h
 
+#include "basictype.h"
 #include "common/vaapisurface.h"
 #include "interface/VideoDecoderDefs.h"
 #include <pthread.h>
@@ -34,7 +35,7 @@
 #include <deque>
 
 #define INVALID_PTS ((uint64_t)-1)
-#define INVALID_POC ((uint32_t)-1)
+#define INVALID_POC INT32_MAX
 #define MAXIMUM_POC  0x7FFFFFFF
 #define MINIMUM_POC  0x80000000
 
@@ -58,7 +59,7 @@ class VaapiSurfaceBufferPool {
     VideoSurfaceBuffer *getBufferByIndex(uint32_t index);
     VaapiSurface *getVaapiSurface(VideoSurfaceBuffer * buf);
     bool outputBuffer(VideoSurfaceBuffer * buf,
-                      uint64_t timeStamp, uint32_t poc);
+                      uint64_t timeStamp, int32_t poc);
     bool setReferenceInfo(VideoSurfaceBuffer * buf,
                           bool referenceFrame, bool asReference);
 


### PR DESCRIPTION
getOutputByMinPOC will return surface with smallest poc.
But surface pool use uint32_t hold poc.some bit stream have negtive poc, like CVMANL1_TOSHIBA_B.264.
The surface with negtive poc will never get chance to output
