### PR TITLE
When decode nalu, skip SPS Extension NALs and skip Slice Aux NALs

### DIFF
--- a/decoder/vaapidecoder_h264.cpp
+++ b/decoder/vaapidecoder_h264.cpp
@@ -1259,6 +1259,14 @@ Decode_Status VaapiDecoderH264::decodeNalu(H264NalUnit * nalu)
         /* skip all Filler Data NALs */
         status = DECODE_SUCCESS;
         break;
+    case H264_NAL_SPS_EXT:
+        /* skip SPS Extension NALs */
+        status = DECODE_SUCCESS;
+        break;
+    case H264_NAL_SLICE_AUX:
+        /* skip Slice Aux NALs */
+        status = DECODE_SUCCESS;
+        break;
     default:
         WARNING("unsupported NAL unit type %d", nalu->type);
         status = DECODE_PARSER_FAIL;


### PR DESCRIPTION
Fix the issue of alpha about miss parse pps.
When decode nalu, if you do not skip sps_ext and slice aux nals, the function will  return DECODE_PARSER_FAIL,  the left nalu will  not parsed,  so there is no frame display.
