### PR TITLE
h264: support process for gaps in frame_num

### DIFF
--- a/codecparsers/h264parser.c
+++ b/codecparsers/h264parser.c
@@ -533,6 +533,14 @@ h264_parser_parse_scaling_list (NalReader * nr,
 {
   uint32_t i;
 
+  static const uint8_t *default_lists[12] = {
+    default_4x4_intra, default_4x4_intra, default_4x4_intra,
+    default_4x4_inter, default_4x4_inter, default_4x4_inter,
+    default_8x8_intra, default_8x8_inter,
+    default_8x8_intra, default_8x8_inter,
+    default_8x8_intra, default_8x8_inter
+  };
+
   DEBUG ("parsing scaling lists");
 
   for (i = 0; i < 12; i++) {
@@ -569,7 +577,8 @@ h264_parser_parse_scaling_list (NalReader * nr,
             next_scale = (last_scale + delta_scale) & 0xff;
           }
           if (j == 0 && next_scale == 0) {
-            use_default = TRUE;
+            /* Use default scaling lists (7.4.2.1.1.1) */
+            memcpy (scaling_list, default_lists[i], size);
             break;
           }
           last_scale = scaling_list[scan[j]] =


### PR DESCRIPTION
Follow 8.2.5.2 when frame_num is not equeal to
PreRefFrameNum and is not equal to
(PreRefFrameNum+1)%MaxFrameNum, there would be
"non-existing" picture "used for short-term reference".

Because the driver needs to test the effectiveness
of the picture, dummy picture needs a surfaceID.
And according to the provisions of spec, the dummy
pictures is not used for reference,so surfaceID of
current picture is set to the dummy picture.

Signed-off-by: Zhong Cong congx.zhong@intel.com
