### PR TITLE
codecparsers: h264: fix derivation of default scaling lists.

### DIFF
--- a/codecparsers/h264parser.c
+++ b/codecparsers/h264parser.c
@@ -533,6 +533,14 @@ h264_parser_parse_scaling_list (NalReader * nr,
 {
   uint32_t i;
 
+  static const uint8_t *default_lists[12] = {
+    default_4x4_intra, default_4x4_intra, default_4x4_intra,
+    default_4x4_inter, default_4x4_inter, default_4x4_inter,
+    default_8x8_intra, default_8x8_inter,
+    default_8x8_intra, default_8x8_inter,
+    default_8x8_intra, default_8x8_inter
+  };
+
   DEBUG ("parsing scaling lists");
 
   for (i = 0; i < 12; i++) {
@@ -569,7 +577,8 @@ h264_parser_parse_scaling_list (NalReader * nr,
             next_scale = (last_scale + delta_scale) & 0xff;
           }
           if (j == 0 && next_scale == 0) {
-            use_default = TRUE;
+            /* Use default scaling lists (7.4.2.1.1.1) */
+            memcpy (scaling_list, default_lists[i], size);
             break;
           }
           last_scale = scaling_list[scan[j]] =


### PR DESCRIPTION
When useDefaultScalingMatrixFlag is computed to be 1 while parsing
scaling_list(), then the scaling list shall be inferred to be equal
to the default list (7.4.2.1.1.1). That default list is really one
of Default_4x4_{Intra,Inter} or Default_8x8_{Intra,Inter} and not
one from fall-back rule sets A or B.

This fixes parsing for FRExt1_Panasonic_D, FRExt2_Panasonic_C,
FRExt3_Panasonic_E and FRExt4_Panasonic_B.

https://bugzilla.gnome.org/show_bug.cgi?id=724518

Signed-off-by: Gwenole Beauchesne gwenole.beauchesne@intel.com
Signed-off-by: Zhong Cong congx.zhong@intel.com
