### PR TITLE
h264: support process for gaps in frame_num

### DIFF
--- a/decoder/vaapidecoder_h264.h
+++ b/decoder/vaapidecoder_h264.h
@@ -205,6 +205,11 @@ class VaapiDPBManager {
                          const SliceHeaderPtr& sliceHdr, int32_t frameNum);
     /* marking pic after slice decoded */
     bool execRefPicMarking(const PicturePtr& pic, bool * hasMMCO5);
+    PicturePtr addDummyPicture(const PicturePtr& pic,
+                               int32_t frameNum);
+    bool execDummyPictureMarking(const PicturePtr& dummyPic,
+                                 const SliceHeaderPtr& sliceHdr,
+                                 int32_t frameNum);
   private:
     bool outputImmediateBFrame();
     /* prepare reference list before decoding slice */
@@ -336,6 +341,8 @@ class VaapiDecoderH264:public VaapiDecoderBase {
     Decode_Status decodeNalu(H264NalUnit * nalu);
     bool decodeCodecData(uint8_t * buf, uint32_t bufSize);
     void updateFrameInfo();
+    bool processForGapsInFrameNum(const PicturePtr& pic,
+                                  const SliceHeaderPtr& sliceHdr);
 
   private:
     PicturePtr m_currentPicture;


### PR DESCRIPTION
Follow 8.2.5.2 when frame_num is not equeal to
PreRefFrameNum and is not equal to
(PreRefFrameNum+1)%MaxFrameNum, there would be
"non-existing" picture "used for short-term reference".

Because the driver needs to test the effectiveness
of the picture, dummy picture needs a surfaceID.
And according to the provisions of spec, the dummy
pictures is not used for reference,so surfaceID of
current picture is set to the dummy picture.

Signed-off-by: Zhong Cong congx.zhong@intel.com
