### PR TITLE
vaapidisplay: add drm backend support

### DIFF
--- a/common/log.h
+++ b/common/log.h
@@ -29,6 +29,7 @@
 #define DEBUG(...)   ALOGV(__VA_ARGS__);
 #else
 #include <stdio.h>
+#include <assert.h>
 extern int yamiLogFlag;
 extern FILE* yamiLogFn;
 extern int isIni;

--- a/decoder/vaapidecoder_base.cpp
+++ b/decoder/vaapidecoder_base.cpp
@@ -42,8 +42,7 @@
 namespace YamiMediaCodec{
 typedef VaapiDecoderBase::PicturePtr PicturePtr;
 
-VaapiDecoderBase::VaapiDecoderBase()
-:m_externalDisplay(NULL),
+VaapiDecoderBase::VaapiDecoderBase():
 m_renderTarget(NULL),
 m_lastReference(NULL),
 m_forwardReference(NULL),
@@ -51,6 +50,8 @@ m_VAStarted(false),
 m_currentPTS(INVALID_PTS), m_enableNativeBuffersFlag(false)
 {
     INFO("base: construct()");
+    m_externalDisplay.handle = 0,
+    m_externalDisplay.type = NATIVE_DISPLAY_AUTO,
     memset(&m_videoFormatInfo, 0, sizeof(VideoFormatInfo));
     memset(&m_configBuffer, 0, sizeof(m_configBuffer));
 }
@@ -329,23 +330,22 @@ Decode_Status VaapiDecoderBase::terminateVA(void)
     m_surfacePool.reset();
     m_context.reset();
     m_display.reset();
-    m_externalDisplay = NULL;
+    m_externalDisplay.type = NATIVE_DISPLAY_AUTO;
+    m_externalDisplay.handle = 0;
 
     m_VAStarted = false;
     return DECODE_SUCCESS;
 }
 
-/* not used funtion here */
-void VaapiDecoderBase::setXDisplay(Display * xDisplay)
+void VaapiDecoderBase::setNativeDisplay(NativeDisplay * nativeDisplay)
 {
-    if (m_externalDisplay) {
-        WARNING
-            ("it may be buggy that va context has been setup with self X display");
-    }
+    if (!nativeDisplay || nativeDisplay->type == NATIVE_DISPLAY_AUTO)
+        return;
 
-    m_externalDisplay = xDisplay;
+    m_externalDisplay = *nativeDisplay;
 }
 
+/* not used funtion here */
 void VaapiDecoderBase::enableNativeBuffers(void)
 {
 }

--- a/decoder/vaapidecoder_base.h
+++ b/decoder/vaapidecoder_base.h
@@ -67,7 +67,7 @@ class VaapiDecoderBase:public IVideoDecoder {
     virtual void renderDone(VideoRenderBuffer * renderBuf);
 
     /* native window related functions */
-    void setXDisplay(Display * xDisplay);
+    void setNativeDisplay(NativeDisplay * nativeDisplay);
     void enableNativeBuffers(void);
     Decode_Status getClientNativeWindowBuffer(void *bufferHeader,
                                               void *nativeBufferHandle);
@@ -81,7 +81,7 @@ class VaapiDecoderBase:public IVideoDecoder {
     Decode_Status outputPicture(const PicturePtr& picture);
     SurfacePtr createSurface();
 
-    Display*   m_externalDisplay;
+    NativeDisplay   m_externalDisplay;
     DisplayPtr m_display;
     ContextPtr m_context;
     bool m_VAStarted;

--- a/encoder/vaapiencoder_base.cpp
+++ b/encoder/vaapiencoder_base.cpp
@@ -38,11 +38,13 @@ const uint32_t MaxOutputBuffer=5;
 namespace YamiMediaCodec{
 VaapiEncoderBase::VaapiEncoderBase():
     m_entrypoint(VAEntrypointEncSlice),
-    m_externalDisplay(NULL),
     m_maxOutputBuffer(MaxOutputBuffer),
     m_maxCodedbufSize(0)
 {
     FUNC_ENTER();
+    m_externalDisplay.handle = 0,
+    m_externalDisplay.type = NATIVE_DISPLAY_AUTO,
+
     m_videoParamCommon.rawFormat = RAW_FORMAT_NV12;
     m_videoParamCommon.frameRate.frameRateNum = 30;
     m_videoParamCommon.frameRate.frameRateDenom = 1;
@@ -66,9 +68,12 @@ VaapiEncoderBase::~VaapiEncoderBase()
     INFO("~VaapiEncoderBase");
 }
 
-void VaapiEncoderBase::setXDisplay(Display * xdisplay)
+void VaapiEncoderBase::setNativeDisplay(NativeDisplay * nativeDisplay)
 {
-    m_externalDisplay = xdisplay;
+    if (!nativeDisplay || nativeDisplay->type == NATIVE_DISPLAY_AUTO)
+        return;
+
+    m_externalDisplay = *nativeDisplay;
 }
 
 Encode_Status VaapiEncoderBase::start(void)

--- a/encoder/vaapiencoder_base.h
+++ b/encoder/vaapiencoder_base.h
@@ -45,7 +45,7 @@ public:
     VaapiEncoderBase();
     virtual ~VaapiEncoderBase();
 
-    virtual void  setXDisplay(Display * xdisplay);
+    virtual void  setNativeDisplay(NativeDisplay * nativeDisplay);
     virtual Encode_Status start(void) = 0;
     virtual void flush(void) = 0;
     virtual Encode_Status stop(void) = 0;
@@ -135,7 +135,7 @@ protected:
 private:
     bool initVA();
     void cleanupVA();
-    Display* m_externalDisplay;
+    NativeDisplay m_externalDisplay;
 
     bool updateMaxOutputBufferCount() {
         if (m_maxOutputBuffer < m_videoParamCommon.leastInputCount + 3)

--- a/interface/VideoCommonDefs.h
+++ b/interface/VideoCommonDefs.h
@@ -1,0 +1,38 @@
+/*
+ *  VideoCommonDefs.h - basic va decoder for video
+ *
+ *  Copyright (C) 2013 Intel Corporation
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2.1
+ *  of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA
+ */
+
+#ifndef VIDEO_COMMON_DEFS_H_
+#define VIDEO_COMMON_DEFS_H_
+#include <stdint.h>
+
+typedef enum {
+    NATIVE_DISPLAY_AUTO,    // decided by yami
+    NATIVE_DISPLAY_X11,
+    NATIVE_DISPLAY_DRM,
+    NATIVE_DISPLAY_WAYLAND,
+} NativeDisplayType;
+
+typedef struct {
+    intptr_t handle;
+    NativeDisplayType type;
+} NativeDisplay;
+
+#endif                          // VIDEO_COMMON_DEFS_H_

--- a/interface/VideoDecoderDefs.h
+++ b/interface/VideoDecoderDefs.h
@@ -24,6 +24,7 @@
 
 #include <va/va.h>
 #include <stdint.h>
+#include "VideoCommonDefs.h"
 
 namespace YamiMediaCodec {
 

--- a/interface/VideoDecoderInterface.h
+++ b/interface/VideoDecoderInterface.h
@@ -99,8 +99,8 @@ public:
     */
     virtual void renderDone(VideoRenderBuffer* buffer) = 0;
 
-    /// todo: move the x_display to VideoConfigBuffer and mark this API as obsolete
-    virtual void  setXDisplay(Display * x_display) = 0;
+    /// set native display
+    virtual void  setNativeDisplay( NativeDisplay * display = NULL) = 0;
     /// obsolete, make all cached video frame output-able, it can be done by getOutput(draining=true) as well
     virtual void flushOutport(void) = 0;
     /// not interest for now, may be used by Android to accept external video frame memory from gralloc

--- a/interface/VideoEncoderDef.h
+++ b/interface/VideoEncoderDef.h
@@ -24,6 +24,7 @@
 
 #include <va/va.h>
 #include <stdint.h>
+#include "VideoCommonDefs.h"
 
 namespace YamiMediaCodec{
 #define STRING_TO_FOURCC(format) ((uint32_t)(((format)[0])|((format)[1]<<8)|((format)[2]<<16)|((format)[3]<<24)))

--- a/interface/VideoEncoderInterface.h
+++ b/interface/VideoEncoderInterface.h
@@ -36,8 +36,8 @@ namespace YamiMediaCodec{
 class IVideoEncoder {
   public:
     virtual ~ IVideoEncoder() {}
-    ///set external display
-    virtual void  setXDisplay(Display * xdisplay) = 0;
+    /// set native display
+    virtual void  setNativeDisplay( NativeDisplay * display = NULL) = 0;
     /** \brief start encode, make sure you setParameters before start, else if will use default.
     */
     virtual Encode_Status start(void) = 0;

--- a/tests/decode.cpp
+++ b/tests/decode.cpp
@@ -187,6 +187,7 @@ int main(int argc, char** argv)
     Window window = 0;
     int64_t timeStamp = 0;
     int32_t videoWidth = 0, videoHeight = 0;
+    NativeDisplay nativeDisplay;
 
     if (argc <2) {
         fprintf(stderr, "no input file to decode\n");
@@ -202,7 +203,9 @@ int main(int argc, char** argv)
 
     x11Display = XOpenDisplay(NULL);
     decoder = createVideoDecoder("video/h264");
-    decoder->setXDisplay(x11Display);
+    nativeDisplay.type = NATIVE_DISPLAY_X11;
+    nativeDisplay.handle = (intptr_t)x11Display;
+    decoder->setNativeDisplay(&nativeDisplay);
 
     configBuffer.data = NULL;
     configBuffer.size = 0;

--- a/tests/h264encode.cpp
+++ b/tests/h264encode.cpp
@@ -192,7 +192,6 @@ void setEncoderParameters(VideoParamsCommon * encVideoParams)
 int main(int argc, char** argv)
 {
     IVideoEncoder *encoder = NULL;
-    Display *x11Display = NULL;
     uint32_t maxOutSize = 0;
     StreamInput input;
     StreamOutput output;
@@ -207,9 +206,7 @@ int main(int argc, char** argv)
         return -1;
     }
 
-    x11Display = XOpenDisplay(NULL);
     encoder = createVideoEncoder("video/h264");
-    encoder->setXDisplay(x11Display);
 
     //configure encoding parameters
     VideoParamsCommon encVideoParams;
@@ -250,5 +247,6 @@ int main(int argc, char** argv)
     encoder->stop();
     releaseVideoEncoder(encoder);
 
+    fprintf(stderr, "encode done\n");
     return 0;
 }

--- a/vaapi/vaapidisplay.h
+++ b/vaapi/vaapidisplay.h
@@ -30,26 +30,37 @@
 #ifdef HAVE_VA_X11
 #include <va/va_x11.h>
 #endif
+#include <va/va_drm.h>
+#include "interface/VideoCommonDefs.h"
 
 ///abstract for all display, x11, wayland, ozone, android etc.
+class NativeDisplayBase;
 class VaapiDisplay
 {
-friend class DisplayCache;
+    typedef std::tr1::shared_ptr<NativeDisplayBase> NativeDisplayPtr;
+    friend class DisplayCache;
+
 public:
+    ~VaapiDisplay();
     //FIXME: add more create functions.
-    static DisplayPtr create(Display*);
+    static DisplayPtr create(const NativeDisplay& display);
 
     virtual bool setRotation(int degree);
 
-    VADisplay getID() const { return m_display; }
+    VADisplay getID() const { return m_vaDisplay; }
 
 protected:
     /// for display cache management.
-    virtual bool isCompatible(const Display*) {return false;}
+    virtual bool isCompatible(const NativeDisplay& other);
 
-    VaapiDisplay(VADisplay vaDisplay):m_display(vaDisplay){}
-    VADisplay   m_display;
-    DISALLOW_COPY_AND_ASSIGN(VaapiDisplay);
+private:
+    VaapiDisplay(const NativeDisplayPtr& nativeDisplay, VADisplay vaDisplay)
+    :m_vaDisplay(vaDisplay), m_nativeDisplay(nativeDisplay) { };
+
+    VADisplay   m_vaDisplay;
+    NativeDisplayPtr m_nativeDisplay;
+
+DISALLOW_COPY_AND_ASSIGN(VaapiDisplay);
 };
 
 #endif


### PR DESCRIPTION
1. client and yami shares the same display when it provides both native
   display (x11 Display or drm fd) and display type in setNativeDisplay().
   client owns the native display
2. when client set native display type only, yami will create a native
   display and owns it.
3. when client doesn't set any native display, or set display type to
   NATIVE_DISPLAY_AUTO; yami will try to open a x11 display first. if fail,
   drm display will try next
4. A x11 display is compatible to drm display, while not reverse.
   it means, when there is a VADisplay created from x11 display,
   yami will not create a new display when drm display is requested,
   simplely reuse the VADisplay.
