### PR TITLE
encode: release derived image of input surface after data uploading

### DIFF
--- a/encoder/vaapiencoder_base.cpp
+++ b/encoder/vaapiencoder_base.cpp
@@ -218,7 +218,7 @@ SurfacePtr VaapiEncoderBase::createSurface(VideoEncRawBuffer* inBuffer)
     if (!surface)
         return surface;
 
-    VaapiImage* image = surface->getDerivedImage();
+    ImagePtr image = surface->getDerivedImage();
     if (!image) {
         ERROR("surface->getDerivedImage() failed");
         surface.reset();

--- a/vaapi/vaapiptrs.h
+++ b/vaapi/vaapiptrs.h
@@ -27,6 +27,9 @@ namespace YamiMediaCodec{
 class VaapiSurface;
 typedef std::tr1::shared_ptr < VaapiSurface > SurfacePtr;
 
+class VaapiImage;
+typedef std::tr1::shared_ptr < VaapiImage> ImagePtr;
+
 class VaapiCodedBuffer;
 typedef std::tr1::shared_ptr < VaapiCodedBuffer > CodedBufferPtr;
 

--- a/vaapi/vaapisurface.cpp
+++ b/vaapi/vaapisurface.cpp
@@ -100,8 +100,7 @@ VaapiSurface::VaapiSurface(const DisplayPtr& display,
                            uint32_t width,
                            uint32_t height, uint32_t externalBufHandle)
 :m_display(display), m_chromaType(chromaType), m_width(width),
-m_height(height),m_externalBufHandle(externalBufHandle), m_ID(id),
-m_derivedImage(NULL)
+m_height(height),m_externalBufHandle(externalBufHandle), m_ID(id)
 {
 
 }
@@ -109,8 +108,6 @@ m_derivedImage(NULL)
 VaapiSurface::~VaapiSurface()
 {
     VAStatus status;
-
-    delete m_derivedImage;
 
     status = vaDestroySurfaces(m_display->getID(), &m_ID, 1);
 
@@ -198,24 +195,21 @@ bool VaapiSurface::putImage(VaapiImage * image)
     return true;
 }
 
-VaapiImage *VaapiSurface::getDerivedImage()
+ImagePtr VaapiSurface::getDerivedImage()
 {
     VAImage va_image;
     VAStatus status;
-
-    if (m_derivedImage)
-        return m_derivedImage;
+    ImagePtr image;
 
     va_image.image_id = VA_INVALID_ID;
     va_image.buf = VA_INVALID_ID;
 
     status = vaDeriveImage(m_display->getID(), m_ID, &va_image);
     if (!checkVaapiStatus(status, "vaDeriveImage()"))
-        return NULL;
+        return image;
 
-    m_derivedImage = new VaapiImage(m_display->getID(), &va_image);
-
-    return m_derivedImage;
+    image.reset(new VaapiImage(m_display->getID(), &va_image));
+    return image;
 }
 
 bool VaapiSurface::sync()

--- a/vaapi/vaapisurface.h
+++ b/vaapi/vaapisurface.h
@@ -72,7 +72,7 @@ class VaapiSurface {
 
     bool getImage(VaapiImage * image);
     bool putImage(VaapiImage * image);
-    VaapiImage *getDerivedImage();
+    ImagePtr getDerivedImage();
 
   private:
     VaapiSurface(const DisplayPtr&,
@@ -90,7 +90,6 @@ class VaapiSurface {
     uint32_t m_height;
     uint32_t m_fourcc;
     uint32_t m_externalBufHandle;   //allocate surface from extenal buf
-    VaapiImage *m_derivedImage;
 };
 }
 #endif                          /* VAAPI_SURFACE_H */


### PR DESCRIPTION
driver does strict check on buffer owership upon vaBeginPicture() now.
