### PR TITLE
tests: do not set encoder param base on nothing

### DIFF
--- a/tests/encodehelp.h
+++ b/tests/encodehelp.h
@@ -146,7 +146,6 @@ void setEncoderParameters(VideoParamsCommon * encVideoParams)
 
     //picture type and bitrate
     encVideoParams->intraPeriod = kIPeriod;
-    encVideoParams->rcMode = RATE_CONTROL_CBR;
     encVideoParams->rcParams.bitRate = bitRate;
     //encVideoParams->rcParams.initQP = 26;
     //encVideoParams->rcParams.minQP = 1;
@@ -155,6 +154,5 @@ void setEncoderParameters(VideoParamsCommon * encVideoParams)
  //   encVideoParams->profile = VAProfileVP8Version0_3;
     encVideoParams->rawFormat = RAW_FORMAT_YUV420;
 
-    encVideoParams->level = 31;
 }
 #endif


### PR DESCRIPTION
libva will not return if we set RATE_CONTROL_CBR, maybe we did not set bit rate control param correctly in vaapiencoder_h264.cpp. Here we just remove useless param setting in decodehelp as workaround. In final solution we need adjust input param (bitrate, level) in vaapiencoder_h264.cpp.
