### PR TITLE
interface: remove config.h from headers

### DIFF
--- a/decoder/vaapidecoder_base.cpp
+++ b/decoder/vaapidecoder_base.cpp
@@ -23,6 +23,9 @@
 #include "config.h"
 #endif
 
+#ifdef __ENABLE_X11__
+#include <X11/Xlib.h>
+#endif
 #include "vaapidecoder_base.h"
 #include "common/log.h"
 #include "vaapi/vaapicontext.h"

--- a/decoder/vaapidecoder_base.h
+++ b/decoder/vaapidecoder_base.h
@@ -60,7 +60,7 @@ class VaapiDecoderBase:public IVideoDecoder {
     virtual void flush(void);
     virtual void flushOutport(void);
     virtual const VideoRenderBuffer *getOutput(bool draining = false);
-    virtual Decode_Status getOutput(Drawable draw, int64_t *timeStamp
+    virtual Decode_Status getOutput(unsigned long draw, int64_t *timeStamp
         , int drawX, int drawY, int drawWidth, int drawHeight, bool draining = false
         , int frameX = -1, int frameY = -1, int frameWidth = -1, int frameHeight = -1);
     virtual Decode_Status getOutput(VideoFrameRawData* frame, bool draining = false);

--- a/interface/VideoCommonDefs.h
+++ b/interface/VideoCommonDefs.h
@@ -21,6 +21,8 @@
 
 #ifndef VIDEO_COMMON_DEFS_H_
 #define VIDEO_COMMON_DEFS_H_
+// config.h should NOT be included in header file, especially for the header file used by external
+
 #include <stdint.h>
 
 #ifdef __cplusplus

--- a/interface/VideoDecoderDefs.h
+++ b/interface/VideoDecoderDefs.h
@@ -21,6 +21,7 @@
 
 #ifndef VIDEO_DECODER_DEFS_H_
 #define VIDEO_DECODER_DEFS_H_
+// config.h should NOT be included in header file, especially for the header file used by external
 
 #include <va/va.h>
 #include <stdint.h>

--- a/interface/VideoDecoderInterface.h
+++ b/interface/VideoDecoderInterface.h
@@ -22,14 +22,9 @@
 
 #ifndef VIDEO_DECODER_INTERFACE_H_
 #define VIDEO_DECODER_INTERFACE_H_
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
+// config.h should NOT be included in header file, especially for the header file used by external
 
 #include "VideoDecoderDefs.h"
-#ifdef __ENABLE_X11__
-#include <X11/Xlib.h>
-#endif
 
 namespace YamiMediaCodec {
 /**
@@ -66,7 +61,7 @@ public:
     virtual const VideoRenderBuffer* getOutput(bool draining = false) = 0;
     /**
      * \brief  render one available video frame to draw
-     * @param[in] draw a X11 drawable, Pixmap or Window ID
+     * @param[in] draw a X11 drawable, Pixmap or Window ID. we do not use Drawable/XID type from X11/X.h because interface should be unique unconditionally
      * @param[in/out] timeStamp, time stamp of current rendering frame (it is passed from client before)
      * @param[in] drawX/drawY/drawWidth/drawHeight specify a rect to render on the draw
      * @param[in] drawX horizontal offset to render on the draw
@@ -86,11 +81,9 @@ public:
      * @return RENDER_FAIL when driver fail to do vaPutSurface
      * @return RENDER_INVALID_PARAMETER
      */
-#if __ENABLE_X11__
-    virtual Decode_Status getOutput(Drawable draw, int64_t *timeStamp
+    virtual Decode_Status getOutput(unsigned long draw, int64_t *timeStamp
         , int drawX, int drawY, int drawWidth, int drawHeight, bool draining = false
         , int frameX = -1, int frameY = -1, int frameWidth = -1, int frameHeight = -1) = 0;
-#endif
     /**
      * \brief export one frame to client buffer;
      * there are four type to export one frame (VideoDataMemoryType); after rendering, client return the buffer back by renderDone(VideoFrameRawData*);

--- a/interface/VideoEncoderDefs.h
+++ b/interface/VideoEncoderDefs.h
@@ -22,9 +22,8 @@
 #ifndef __VIDEO_ENCODER_DEF_H__
 #define __VIDEO_ENCODER_DEF_H__
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
+// config.h should NOT be included in header file, especially for the header file used by external
+// XXX __ENABLE_CAPI__ still seems ok in this file
 
 #include <va/va.h>
 #include <stdint.h>

--- a/interface/VideoEncoderInterface.h
+++ b/interface/VideoEncoderInterface.h
@@ -21,9 +21,7 @@
 
 #ifndef VIDEO_ENCODER_INTERFACE_H_
 #define VIDEO_ENCODER_INTERFACE_H_
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
+// config.h should NOT be included in header file, especially for the header file used by external
 
 #include "VideoEncoderDefs.h"
 #undef None // work around for compile in chromeos


### PR DESCRIPTION
header file should NOT include config.h,
it may create different class interface between library and client.
