### PR TITLE
Fix out-of-tree builds

### DIFF
--- a/codecparsers/Makefile.am
+++ b/codecparsers/Makefile.am
@@ -1,3 +1,5 @@
+INCLUDES = -I$(top_srcdir)
+
 libcodecparser_source_c = \
         bitreader.c \
         bytereader.c \

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -1,3 +1,5 @@
+INCLUDES = -I$(top_srcdir)
+
 libyami_common_source_c = \
 	log.cpp \
 	$(NULL)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,3 +1,5 @@
+INCLUDES = -I$(top_srcdir)
+
 if ENABLE_CAPI
 bin_PROGRAMS = decodecapi encodecapi
 else

--- a/vaapi/Makefile.am
+++ b/vaapi/Makefile.am
@@ -1,3 +1,5 @@
+INCLUDES = -I$(top_srcdir)
+
 libyami_vaapi_source_c = \
         vaapipicture.cpp \
         vaapibuffer.cpp \


### PR DESCRIPTION
Building anywhere else then from the toplevel source dir was broken, due to missing includes.
This adds the missing include paths.
