### PR TITLE
v4l2: work around a strange x11 exception during XFreePixmap

### DIFF
--- a/v4l2/v4l2_codecbase.h
+++ b/v4l2/v4l2_codecbase.h
@@ -63,6 +63,7 @@ class V4l2CodecBase {
     virtual void* mmap(void* addr, size_t length,
                          int prot, int flags, unsigned int offset) {return NULL;};
     // virtual int32_t munmap(void* addr, size_t length) {return 0;};
+    virtual bool stop() = 0;
 #if __ENABLE_V4L2_GLX__
     bool setXDisplay(Display *x11Display) { m_x11Display = x11Display; };
     virtual int32_t usePixmap(int bufferIndex, Pixmap pixmap) {return 0;};
@@ -74,7 +75,6 @@ class V4l2CodecBase {
 
   protected:
     virtual bool start() = 0;
-    virtual bool stop() = 0;
     virtual bool acceptInputBuffer(struct v4l2_buffer *qbuf) = 0;
     virtual bool giveOutputBuffer(struct v4l2_buffer *dqbuf) = 0;
     virtual bool inputPulse(int32_t index) = 0;

--- a/v4l2/v4l2_wrapper.cpp
+++ b/v4l2/v4l2_wrapper.cpp
@@ -173,6 +173,20 @@ int32_t YamiV4L2_UsePixmap(int fd, int bufferIndex, Pixmap pixmap)
 
      return ret;
 }
+
+int32_t YamiV4L2_Stop(int32_t fd)
+{
+    V4l2CodecPtr v4l2Codec = _findCodecFromFd(fd);
+    bool ret = true;
+
+    ASSERT(v4l2Codec);
+    ret &= v4l2Codec->stop();
+    INFO("stop codec(fd:%d) , ret: %d", fd, ret);
+    ASSERT(ret);
+
+    return ret ? 0 : -1;
+}
+
 #else
 int32_t YamiV4L2_UseEglImage(int fd, EGLDisplay eglDisplay, EGLContext eglContext, unsigned int bufferIndex, void* eglImage)
 {

--- a/v4l2/v4l2_wrapper.h
+++ b/v4l2/v4l2_wrapper.h
@@ -47,6 +47,8 @@ int32_t YamiV4L2_Munmap(void* addr, size_t length);
 int32_t YamiV4L2_SetXDisplay(int32_t fd, Display *x11Display);
 /// pixmap=0 means the previous set rendering target becomes invalid, stop rendering to it.
 int32_t YamiV4L2_UsePixmap(int fd, int bufferIndex, Pixmap pixmap);
+/// terminate vaapi before XFreePixmap work around a strange X11 exception; otherwise there is "BadDrawable" exception though the Pixmap is valid.
+int32_t YamiV4L2_Stop(int32_t fd);
 #else
 int32_t YamiV4L2_UseEglImage(int fd, EGLDisplay eglDisplay, EGLContext eglContext, unsigned int buffer_index, void* egl_image);
 #endif


### PR DESCRIPTION
terminate vaapi before XFreePixmap work around the exception;
otherwise there is "BadDrawable" exception though the Pixmap is valid.

maybe driver 'lock' the Pixmap at that time, or dri protocol issue.
