### PR TITLE
v4l2: fix mistake when using fewer number of outputbuffer

### DIFF
--- a/v4l2/v4l2_decode.cpp
+++ b/v4l2/v4l2_decode.cpp
@@ -524,7 +524,7 @@ int32_t V4l2Decoder::useEglImage(EGLDisplay eglDisplay, EGLContext eglContext, u
 
     ASSERT(m_memoryType == VIDEO_DATA_MEMORY_TYPE_DRM_NAME || m_memoryType == VIDEO_DATA_MEMORY_TYPE_DMA_BUF);
     ASSERT(bufferIndex>=0 && bufferIndex<m_maxBufferCount[OUTPUT]);
-    bufferIndex = std::min(bufferIndex, m_actualOutBufferCount);
+    bufferIndex = std::min(bufferIndex, m_actualOutBufferCount-1);
     *(EGLImageKHR*)eglImage = m_eglImages[bufferIndex];
 
     return 0;


### PR DESCRIPTION
fix the random ASSERT fail of v4l2decode
