### PR TITLE
v4l2dec: fixes for seek

### DIFF
--- a/decoder/vaapidecoder_base.cpp
+++ b/decoder/vaapidecoder_base.cpp
@@ -437,13 +437,12 @@ Decode_Status VaapiDecoderBase::flagNativeBuffer(void *pBuffer)
     return DECODE_SUCCESS;
 }
 
-void VaapiDecoderBase::releaseLock()
+void VaapiDecoderBase::releaseLock(bool lockable=false)
 {
     if (!m_surfacePool)
         return;
 
-    // seems it is only used upon end of playback, no necessary to setWaitable(true) -- next start() will create a new surface pool
-    m_surfacePool->setWaitable(false);
+    m_surfacePool->setWaitable(lockable);
 }
 
 SurfacePtr VaapiDecoderBase::createSurface()

--- a/decoder/vaapidecoder_base.h
+++ b/decoder/vaapidecoder_base.h
@@ -75,7 +75,7 @@ class VaapiDecoderBase:public IVideoDecoder {
     Decode_Status getClientNativeWindowBuffer(void *bufferHeader,
                                               void *nativeBufferHandle);
     Decode_Status flagNativeBuffer(void *pBuffer);
-    void releaseLock();
+    void releaseLock(bool lockable=false);
 
   protected:
     Decode_Status setupVA(uint32_t numSurface, VAProfile profile);

--- a/decoder/vaapidecsurfacepool.cpp
+++ b/decoder/vaapidecsurfacepool.cpp
@@ -300,9 +300,9 @@ void VaapiDecSurfacePool::setWaitable(bool waitable)
 
     if (!waitable) {
         m_cond.signal();
-        if (m_imagePool)
-            m_imagePool->setWaitable(false);
     }
+    if (m_imagePool)
+        m_imagePool->setWaitable(waitable);
 }
 
 void VaapiDecSurfacePool::flush()

--- a/interface/VideoDecoderInterface.h
+++ b/interface/VideoDecoderInterface.h
@@ -122,8 +122,9 @@ public:
     /// set native display
     virtual void  setNativeDisplay( NativeDisplay * display = NULL) = 0;
 
-    /// escape decode thread from potential waiting
-    virtual void releaseLock(void) = 0;
+    /// lockable is set to false when seek begins and reset to true after seek is done
+    /// EOS also set lockable to false
+    virtual void releaseLock(bool lockable=false) = 0;
 
     /// obsolete, make all cached video frame output-able, it can be done by getOutput(draining=true) as well
     virtual void flushOutport(void) = 0;

--- a/v4l2/v4l2_codecbase.cpp
+++ b/v4l2/v4l2_codecbase.cpp
@@ -305,6 +305,10 @@ int32_t V4l2CodecBase::ioctl(int command, void* arg)
                 ERROR("unkown stream type: %d", type);
                 break;
             }
+            if (port == INPUT) {
+                DEBUG("INPUT port got STREAMON, escape from flushing state");
+                releaseCodecLock(true);
+            }
 
             m_streamOn[port] = true;
             if (pthread_create(&m_worker[port], NULL, _workerThread, this) != 0) {
@@ -333,7 +337,7 @@ int32_t V4l2CodecBase::ioctl(int command, void* arg)
             while (m_threadOn[port]) {
                 if (port == INPUT) {
                     DEBUG("INPUT port got STREAMOFF, release internal lock");
-                    releaseCodecLock();
+                    releaseCodecLock(false);
                 }
                 DEBUG("%s port got STREAMOFF, wait until the worker thread exit/cleanup", THREAD_NAME(port));
                 m_threadCond[port]->broadcast();

--- a/v4l2/v4l2_codecbase.h
+++ b/v4l2/v4l2_codecbase.h
@@ -83,7 +83,7 @@ class V4l2CodecBase {
     virtual bool hasCodecEvent() {return m_hasEvent;}
     virtual void setCodecEvent();
     virtual void clearCodecEvent();
-    virtual void releaseCodecLock() {};
+    virtual void releaseCodecLock(bool lockable) {};
 
     VideoDataMemoryType m_memoryType;
     int m_maxBufferCount[2];

--- a/v4l2/v4l2_decode.h
+++ b/v4l2/v4l2_decode.h
@@ -54,7 +54,7 @@ class V4l2Decoder : public V4l2CodecBase
     virtual bool inputPulse(int32_t index);
     virtual bool outputPulse(int32_t &index);
     virtual bool recycleOutputBuffer(int32_t index);
-    virtual void releaseCodecLock();
+    virtual void releaseCodecLock(bool lockable);
 
   private:
 #if !__ENABLE_V4L2_GLX__


### PR DESCRIPTION
- seek releaseCodecLock at start and clear it after done
- enqued buffers in v4l2 wrapper are required to flush (deque by client)
  during seek
