### PR TITLE
v4l2decoder: do not wait on POLLOUT event

### DIFF
--- a/v4l2/v4l2_codecbase.cpp
+++ b/v4l2/v4l2_codecbase.cpp
@@ -500,7 +500,7 @@ int32_t V4l2CodecBase::poll(bool poll_device, bool* event_pending)
     if (poll_device) {
       DEBUG("Poll(): adding device fd to poll() set");
       pollfds[nfds].fd = m_fd[0];
-      pollfds[nfds].events = POLLIN | POLLOUT | POLLERR | POLLPRI;
+      pollfds[nfds].events = POLLIN | POLLERR;
       pollfd = nfds;
       nfds++;
     }


### PR DESCRIPTION
else it will wakeup by it self. Make current thread busy waiting.