### PR TITLE
Update Libyami for VP9 decode playback on Chrome.

### DIFF
--- a/decoder/vaapidecoder_base.cpp
+++ b/decoder/vaapidecoder_base.cpp
@@ -423,8 +423,6 @@ Decode_Status VaapiDecoderBase::terminateVA(void)
     DEBUG("surface pool is reset");
     m_context.reset();
     m_display.reset();
-    m_externalDisplay.type = NATIVE_DISPLAY_AUTO;
-    m_externalDisplay.handle = 0;
 
     m_VAStarted = false;
     return DECODE_SUCCESS;

--- a/decoder/vaapidecoder_vp9.h
+++ b/decoder/vaapidecoder_vp9.h
@@ -54,7 +54,7 @@ class VaapiDecoderVP9:public VaapiDecoderBase {
     //reference related
     bool fillReference(VADecPictureParameterBufferVP9* , const Vp9FrameHdr*);
     void updateReference(const PicturePtr&, const Vp9FrameHdr*);
-
+    uint32_t m_hasContext:1;
     typedef std::tr1::shared_ptr<Vp9Parser> ParserPtr;
     ParserPtr m_parser;
     std::vector<SurfacePtr> m_reference;


### PR DESCRIPTION
Fix resolution change handling when running VP9 on
Chrome OS with Libyami. Ported similar change from
VP8 to VP9. After these changes VP9 works fine
on Chrome OS with Libyami.

Signed-off-by: Sameer Kibey <sameer.kibey@intel.com>