### PR TITLE
handle vp9 resolution change

### DIFF
--- a/decoder/vaapidecoder_base.cpp
+++ b/decoder/vaapidecoder_base.cpp
@@ -405,8 +405,6 @@ Decode_Status VaapiDecoderBase::terminateVA(void)
     DEBUG("surface pool is reset");
     m_context.reset();
     m_display.reset();
-    m_externalDisplay.type = NATIVE_DISPLAY_AUTO;
-    m_externalDisplay.handle = 0;
 
     m_VAStarted = false;
     return DECODE_SUCCESS;

--- a/decoder/vaapidecoder_vp9.cpp
+++ b/decoder/vaapidecoder_vp9.cpp
@@ -106,6 +106,13 @@ Decode_Status VaapiDecoderVP9::ensureContext(const Vp9FrameHdr* hdr)
         if (status != DECODE_SUCCESS)
             return status;
         return DECODE_FORMAT_CHANGE;
+    } else if (m_videoFormatInfo.width != hdr->width
+        || m_videoFormatInfo.height != hdr->height) {
+        // notify client of resolution change, no need to reset hw context
+            INFO("frame size changed, reconfig codec. orig size %d x %d, new size: %d x %d\n", m_videoFormatInfo.width, m_videoFormatInfo.height, hdr->width, hdr->height);
+            m_videoFormatInfo.width = hdr->width;
+            m_videoFormatInfo.height = hdr->height;
+            return DECODE_FORMAT_CHANGE;
     }
     return DECODE_SUCCESS;
 


### PR DESCRIPTION
1. do not reset the external display in VaapiDecoderBase::terminateVA. else it will lost display when we change video size to larger resolution.
2. report every frame change to caller. Not just silent set the output format in getOutput.