### PR TITLE
v4l2dec: flush the decoder when input is streamoff

### DIFF
--- a/v4l2/v4l2_codecbase.cpp
+++ b/v4l2/v4l2_codecbase.cpp
@@ -228,6 +228,8 @@ void V4l2CodecBase::workerThread()
             for (i=0; i<m_maxBufferCount[OUTPUT]; i++)
                 recycleOutputBuffer(i);
             DEBUG("recycle all output buffer to make sure internal surface/image are released");
+        } else {
+            flush();
         }
         DEBUG("%s worker thread exit", THREAD_NAME(thread));
     }

--- a/v4l2/v4l2_codecbase.h
+++ b/v4l2/v4l2_codecbase.h
@@ -84,6 +84,7 @@ class V4l2CodecBase {
     virtual void setCodecEvent();
     virtual void clearCodecEvent();
     virtual void releaseCodecLock(bool lockable) {};
+    virtual void flush() {}
 
     VideoDataMemoryType m_memoryType;
     int m_maxBufferCount[2];

--- a/v4l2/v4l2_decode.cpp
+++ b/v4l2/v4l2_decode.cpp
@@ -444,6 +444,12 @@ void* V4l2Decoder::mmap (void* addr, size_t length,
     }
 }
 
+void V4l2Decoder::flush()
+{
+    if (m_decoder)
+        m_decoder->flush();
+}
+
 #if __ENABLE_V4L2_GLX__
 int32_t V4l2Decoder::usePixmap(int bufferIndex, Pixmap pixmap)
 {

--- a/v4l2/v4l2_decode.h
+++ b/v4l2/v4l2_decode.h
@@ -55,6 +55,7 @@ class V4l2Decoder : public V4l2CodecBase
     virtual bool outputPulse(int32_t &index);
     virtual bool recycleOutputBuffer(int32_t index);
     virtual void releaseCodecLock(bool lockable);
+    virtual void flush();
 
   private:
 #if !__ENABLE_V4L2_GLX__


### PR DESCRIPTION
when you seek a video in chrome, it will report "NOTREEACHED hit in GetBufferData" this will fix it.