### PR TITLE
libyami-drm: allow client to set the drm_fd

### DIFF
--- a/v4l2/v4l2_codecbase.cpp
+++ b/v4l2/v4l2_codecbase.cpp
@@ -79,6 +79,8 @@ V4l2CodecBase::V4l2CodecBase()
     , m_eosState(EosStateNormal)
 #if __ENABLE_V4L2_GLX__
     , m_x11Display(NULL)
+#else
+    , m_drmfd(0)
 #endif
 {
     m_streamOn[INPUT] = false;

--- a/v4l2/v4l2_codecbase.h
+++ b/v4l2/v4l2_codecbase.h
@@ -69,6 +69,8 @@ class V4l2CodecBase {
     virtual int32_t usePixmap(int bufferIndex, Pixmap pixmap) {return 0;};
 #else
     virtual int32_t useEglImage(EGLDisplay eglDisplay, EGLContext eglContext, uint32_t buffer_index, void* egl_image) {return 0;};
+    bool setDrmFd(int drm_fd) {m_drmfd = drm_fd; };
+
 #endif
     void workerThread();
     int32_t fd() { return m_fd[0];};
@@ -96,6 +98,8 @@ class V4l2CodecBase {
     bool m_started;
 #if __ENABLE_V4L2_GLX__
     Display *m_x11Display;
+#else
+    int m_drmfd;
 #endif
 
     enum EosState{

--- a/v4l2/v4l2_decode.cpp
+++ b/v4l2/v4l2_decode.cpp
@@ -94,7 +94,7 @@ bool V4l2Decoder::start()
     nativeDisplay.handle = (intptr_t)m_x11Display;
 #else
     nativeDisplay.type = NATIVE_DISPLAY_DRM;
-    nativeDisplay.handle = 0;
+    nativeDisplay.handle = m_drmfd;
 #endif
     m_decoder->setNativeDisplay(&nativeDisplay);
     status = m_decoder->start(&m_configBuffer);

--- a/v4l2/v4l2_wrapper.cpp
+++ b/v4l2/v4l2_wrapper.cpp
@@ -194,4 +194,15 @@ int32_t YamiV4L2_UseEglImage(int fd, EGLDisplay eglDisplay, EGLContext eglContex
     ASSERT(v4l2Codec);
     return v4l2Codec->useEglImage(eglDisplay, eglContext, bufferIndex, eglImage);
 }
+
+int32_t YamiV4L2_SetDrmFd(int32_t fd, int drm_fd)
+{
+    V4l2CodecPtr v4l2Codec = _findCodecFromFd(fd);
+     bool ret = true;
+
+     ASSERT(v4l2Codec);
+     ret &= v4l2Codec->setDrmFd(drm_fd);
+
+     return ret;
+}
 #endif

--- a/v4l2/v4l2_wrapper.h
+++ b/v4l2/v4l2_wrapper.h
@@ -51,6 +51,7 @@ int32_t YamiV4L2_UsePixmap(int fd, int bufferIndex, Pixmap pixmap);
 int32_t YamiV4L2_Stop(int32_t fd);
 #else
 int32_t YamiV4L2_UseEglImage(int fd, EGLDisplay eglDisplay, EGLContext eglContext, unsigned int buffer_index, void* egl_image);
+int32_t YamiV4L2_SetDrmFd(int32_t fd, int drm_fd);
 #endif
 } // extern "C"
 #endif


### PR DESCRIPTION
client can share the drm_fd with libyami to perform vaapi
operations within the same process

Signed-off-by: Daniel Charles <daniel.charles@intel.com>