### PR TITLE
v4l2dec: do not submit negtive timestamp buffer to caller

### DIFF
--- a/v4l2/v4l2_decode.cpp
+++ b/v4l2/v4l2_decode.cpp
@@ -180,8 +180,7 @@ bool V4l2Decoder::outputPulse(int32_t &index)
 
         if (eosState() > EosStateNormal) {
             DEBUG("seek/EOS flush, return empty buffer");
-            m_outputRawFrames[index].timeStamp = -2;
-            return true;
+            return false;
         }
     }
 


### PR DESCRIPTION
the old code will submit empty buffer with negtive timestamp to calller at the end of stream. chrome will complain NOTREACH error for this.