### PR TITLE
seek or close the video window in chrome will messup the graphic system.

### DIFF
--- a/v4l2/v4l2_codecbase.cpp
+++ b/v4l2/v4l2_codecbase.cpp
@@ -134,6 +134,9 @@ bool V4l2CodecBase::close()
         timeOut--;
     }
 
+    for (int i=0; i<m_maxBufferCount[OUTPUT]; i++)
+        recycleOutputBuffer(i);
+
     ASSERT(!m_threadOn[INPUT]);
     ASSERT(!m_threadOn[OUTPUT]);
     ret = stop();
@@ -225,12 +228,7 @@ void V4l2CodecBase::workerThread()
         AutoLock locker(m_frameLock[thread]);
         m_framesTodo[thread].clear();
         m_framesDone[thread].clear();
-        if (thread == OUTPUT) {
-            int i;
-            for (i=0; i<m_maxBufferCount[OUTPUT]; i++)
-                recycleOutputBuffer(i);
-            DEBUG("recycle all output buffer to make sure internal surface/image are released");
-        } else {
+        if (thread == INPUT) {
             flush();
         }
         DEBUG("%s worker thread exit", THREAD_NAME(thread));

--- a/v4l2/v4l2_decode.cpp
+++ b/v4l2/v4l2_decode.cpp
@@ -50,11 +50,7 @@ V4l2Decoder::V4l2Decoder()
     m_bufferPlaneCount[OUTPUT] = 2;
 
     m_maxBufferCount[INPUT] = 8;
-#if __ENABLE_V4L2_GLX__
-    m_maxBufferCount[OUTPUT] = 8; // Pixmap is alloc at client side, in order to save memory we have to tell them the reality. [it requires chrome change as well]
-#else
-    m_maxBufferCount[OUTPUT] = 26; // use a bigger # to satify chrome, the effective count is m_actualOutBufferCount
-#endif
+    m_maxBufferCount[OUTPUT] = 8;
     m_actualOutBufferCount = m_maxBufferCount[OUTPUT];
 
     m_inputFrames.resize(m_maxBufferCount[INPUT]);


### PR DESCRIPTION
v4l2dec: do not recycle buffers after seek
        v4l2 client in chrome still hold the buffers after seek