### PR TITLE
h264enc: use cabac as default entropy mode

### DIFF
--- a/encoder/vaapiencoder_h264.cpp
+++ b/encoder/vaapiencoder_h264.cpp
@@ -682,7 +682,7 @@ public:
 };
 
 VaapiEncoderH264::VaapiEncoderH264():
-    m_useCabac(false),
+    m_useCabac(true),
     m_useDct8x8(false),
     m_reorderState(VAAPI_ENC_REORD_WAIT_FRAMES),
     m_streamFormat(AVC_STREAM_FORMAT_ANNEXB)


### PR DESCRIPTION
it can save bits