### PR TITLE
vaapiimagepool: Added a fix to properly release the Vaapi Image pool on VA terminate

### DIFF
--- a/vaapi/vaapiimagepool.cpp
+++ b/vaapi/vaapiimagepool.cpp
@@ -69,6 +69,7 @@ struct VaapiImagePool::ImageRecycler
         if (!image)
             return;
         m_pool->recycleID(image->getID());
+        m_pool.reset();
     }
 private:
     ImagePoolPtr m_pool;


### PR DESCRIPTION
 This fixes the memory leak issue during the repetitive
VP8 decode in the same process.

Signed-off-by: Manasi <manasi.d.navare@intel.com>