### PR TITLE
image: do not inherit from enable_shared_from_this

### DIFF
--- a/decoder/vaapidecsurfacepool.cpp
+++ b/decoder/vaapidecsurfacepool.cpp
@@ -183,7 +183,7 @@ bool VaapiDecSurfacePool::exportFrame(ImagePtr image, VideoFrameRawData &frame, 
         return false;
 
     VideoDataMemoryType memoryType = frame.memoryType;
-    ImageRawPtr rawImage = image->map(memoryType);
+    ImageRawPtr rawImage = mapVaapiImage(image, memoryType);
 
     if (!rawImage)
         return false;

--- a/encoder/vaapiencoder_base.cpp
+++ b/encoder/vaapiencoder_base.cpp
@@ -270,7 +270,7 @@ SurfacePtr VaapiEncoderBase::createSurface(VideoFrameRawData* frame)
         ERROR("VaapiImage::derive() failed");
         return nil;
     }
-    ImageRawPtr raw = image->map();
+    ImageRawPtr raw = mapVaapiImage(image);
     if (!raw) {
         ERROR("image->map() failed");
         return nil;

--- a/vaapi/vaapiimage.cpp
+++ b/vaapi/vaapiimage.cpp
@@ -264,9 +264,9 @@ VaapiImage::~VaapiImage()
         return;
 }
 
-ImageRawPtr VaapiImage::map(VideoDataMemoryType memoryType)
+ImageRawPtr mapVaapiImage(ImagePtr img, VideoDataMemoryType memoryType)
 {
-    ImageRawPtr raw = m_rawImage.lock();
+    ImageRawPtr raw = img->m_rawImage.lock();
     if (raw) {
         if (raw->getMemoryType() != memoryType) {
             ERROR("map image to different memory type, wanted %d, mapped = %d", memoryType, raw->getMemoryType());
@@ -274,8 +274,8 @@ ImageRawPtr VaapiImage::map(VideoDataMemoryType memoryType)
         }
         return raw;
     }
-    raw = VaapiImageRaw::create(m_display, shared_from_this(), memoryType);
-    m_rawImage = raw;
+    raw = VaapiImageRaw::create(img->m_display, img, memoryType);
+    img->m_rawImage = raw;
     return raw;
 }
 

--- a/vaapi/vaapiimage.h
+++ b/vaapi/vaapiimage.h
@@ -37,7 +37,7 @@
 
 namespace YamiMediaCodec{
 
-class VaapiImage : public std::tr1::enable_shared_from_this<VaapiImage>
+class VaapiImage
 {
   private:
     typedef std::tr1::shared_ptr<VAImage> VAImagePtr;
@@ -54,7 +54,7 @@ class VaapiImage : public std::tr1::enable_shared_from_this<VaapiImage>
     uint32_t getWidth();
     uint32_t getHeight();
 
-    ImageRawPtr map(VideoDataMemoryType memoryType = VIDEO_DATA_MEMORY_TYPE_RAW_COPY);
+    friend ImageRawPtr mapVaapiImage(ImagePtr, VideoDataMemoryType memoryType);
 
   private:
     VaapiImage(const DisplayPtr& display, const VAImagePtr& image);
@@ -68,6 +68,13 @@ class VaapiImage : public std::tr1::enable_shared_from_this<VaapiImage>
     ImageRawWeakPtr m_rawImage;
     DISALLOW_COPY_AND_ASSIGN(VaapiImage);
 };
+
+//wired thing happend when we do two things together
+// 1. make VaapiImage public shared_from_this (if you make map as VaapiImage's member, you do this)
+// 2. alloc and set ImagePtr's deleter in VaapiImagePool. We also add ImagePoolPtr as Image's member.
+// it will call deleter's operator(), but the deleter will never out of scope. So ImagePoolPtr will never get chance to be del.
+// make map a standalone function can break 1.
+ImageRawPtr mapVaapiImage(ImagePtr, VideoDataMemoryType memoryType = VIDEO_DATA_MEMORY_TYPE_RAW_COPY);
 
 /* Raw image to store mapped image*/
 class VaapiImageRaw {


### PR DESCRIPTION
wired thing happend when we do two things together
1. make VaapiImage inherit from shared_from_this (if you make map as VaapiImage's member, you need this)
2. set ImagePtr's deleter in VaapiImagePool. and hold a renference of ImagePoolPtr in ImageRecycler's member.
It will call deleter's operator(), but the deleter will never out of scope. So ImagePoolPtr will never get chance to be del.Make map a standalone function can break 1.
This patch bigger than mdnavare's #198, But it will make ImageRecycler out of scope in somewhere.
This patch have same result as mdnavare's . It fix VaapiDisplay leak problem.But it still not fix open file failed issue.
