### PR TITLE
getOutput: while flushing some images might not be available

### DIFF
--- a/decoder/vaapidecsurfacepool.cpp
+++ b/decoder/vaapidecsurfacepool.cpp
@@ -249,7 +249,10 @@ bool VaapiDecSurfacePool::getOutput(VideoFrameRawData* frame)
             return false;
 
         image = m_imagePool->acquireWithWait();
-        ASSERT(image);
+        if (!image) {
+            DEBUG("No image available");
+            return false;
+        }
         if (!surface->getImage(image)) {
             ASSERT(0);
             return false;


### PR DESCRIPTION
some images will not be available when flushing before
shutdown and that should not be asserted.

Signed-off-by: Daniel Charles <daniel.charles@intel.com>