### PR TITLE
Update decodeoutput.cpp

### DIFF
--- a/tests/decodeoutput.cpp
+++ b/tests/decodeoutput.cpp
@@ -320,7 +320,7 @@ bool DecodeOutputX11::init()
         fprintf(stderr, "Failed to XOpenDisplay during DecodeOutputX11::%s\n", __FUNCTION__);
         return false;
     }
-
+    m_window = 0;
     NativeDisplay nativeDisplay;
     if (renderMode == 0) {
         nativeDisplay.type = NATIVE_DISPLAY_DRM;


### PR DESCRIPTION
m_window was uninitialized, thus preventing creation of an xwindow in the function 

bool DecodeOutputX11::setVideoSize(int width, int height)

Which was getting called for a format change in the video upon decoding  the first frame.