### PR TITLE
Libyami V4L2 decoder: Stop the decoder only if it is has been started…

### DIFF
--- a/v4l2/v4l2_decode.cpp
+++ b/v4l2/v4l2_decode.cpp
@@ -102,7 +102,8 @@ bool V4l2Decoder::start()
 
 bool V4l2Decoder::stop()
 {
-    m_decoder->stop();
+    if (m_started)
+      m_decoder->stop();
 
     m_started = false;
     return true;


### PR DESCRIPTION
… In the Yami Close sequence, it closes V4L2 CodecBase that calls V4L2decoder::Stop() The decoder is only started in case the Yami device is opened during media decode. If the Yami device is opened only to obtain the configuration information like supported profiles then the decoder is not started. So the decoder::Stop should only be called if decoder_started flag is set to avoid segmentation fault.

Signed-off-by: Manasi Navare <manasi.d.navare@intel.com>