### PR TITLE
Modify five patchs commit log info.

### DIFF
--- a/codecparsers/Makefile.am
+++ b/codecparsers/Makefile.am
@@ -4,6 +4,7 @@ libyami_codecparser_source_c = \
         bitreader.c \
         bytereader.c \
         h264parser.c \
+        h265parser.c \
         mpegvideoparser.c \
         mpeg4parser.c \
         vc1parser.c \
@@ -20,6 +21,7 @@ libyami_codecparser_source_h_priv = \
         bitreader.h \
         bytereader.h \
         h264parser.h \
+        h265parser.h \
         mpegvideoparser.h \
         mpeg4parser.h \
         vc1parser.h \

--- a/codecparsers/h265parser.c
+++ b/codecparsers/h265parser.c
@@ -1,0 +1,2729 @@
+/* H.265 bitstream parser
+ * Copyright (C) 2012 Intel Corporation
+ * Copyright (C) 2013 Sreerenj Balachandran <sreerenj.balachandran@intel.com>
+ *
+ * Contact: Sreerenj Balachandran <sreerenj.balachandran@intel.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+/**
+ * SECTION:h265parser
+ * @short_description: Convenience library for h265 video bitstream parsing.
+ *
+ * It offers you bitstream parsing in HEVC mode and non-HEVC mode. To identify
+ * Nals in a bitstream and parse its headers, you should call:
+ * <itemizedlist>
+ *   <listitem>
+ *      h265_parser_identify_nalu() to identify the following nalu in
+ *        non-HEVC bitstreams
+ *   </listitem>
+ *   <listitem>
+ *      h265_parser_identify_nalu_hevc() to identify the nalu in
+ *        HEVC bitstreams
+ *   </listitem>
+ * </itemizedlist>
+ *
+ * Then, depending on the #H265NalUnitType of the newly parsed #H265NalUnit,
+ * you should call the differents functions to parse the structure:
+ * <itemizedlist>
+ *   <listitem>
+ *      From #H265_NAL_SLICE_TRAIL_N to #H265_NAL_SLICE_CRA_NUT: h265_parser_parse_slice_hdr()
+ *   </listitem>
+ *   <listitem>
+ *      #H265_NAL_SEI: h265_parser_parse_sei()
+ *   </listitem>
+ *   <listitem>
+ *      #H265_NAL_VPS: h265_parser_parse_vps()
+ *   </listitem>
+ *   <listitem>
+ *      #H265_NAL_SPS: h265_parser_parse_sps()
+ *   </listitem>
+ *   <listitem>
+ *      #H265_NAL_PPS: #h265_parser_parse_pps()
+ *   </listitem>
+ *   <listitem>
+ *      Any other: h265_parser_parse_nal()
+ *   </listitem>
+ * </itemizedlist>
+ *
+ * Note: You should always call h265_parser_parse_nal() if you don't
+ * actually need #H265NalUnitType to be parsed for your personal use, in
+ * order to guarantee that the #H265Parser is always up to date.
+ *
+ * For more details about the structures, look at the ITU-T H.265
+ * specifications, you can download them from:
+ *
+ * <itemizedlist>
+ *   <listitem>
+ *     ITU-T H.265: http://www.itu.int/rec/T-REC-H.265
+ *   </listitem>
+ * </itemizedlist>
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include "nalreader.h"
+#include "h265parser.h"
+#include "parserutils.h"
+
+#include <stdlib.h>
+#include <bytereader.h>
+#include <bitreader.h>
+#include <string.h>
+#include <math.h>
+
+#if 0
+DEBUG_CATEGORY (h265_parser_debug);
+#define CAT_DEFAULT h265_parser_debug
+
+static BOOL initialized = FALSE;
+#define INITIALIZE_DEBUG_CATEGORY \
+  if (!initialized) { \
+    DEBUG_CATEGORY_INIT (h265_parser_debug, "codecparsers_h265", 0, \
+        "h265 parser library"); \
+    initialized = TRUE; \
+  }
+#endif
+
+/**** Default scaling_lists according to Table 7-5 and 7-6 *****/
+
+/* Table 7-5 */
+static const uint8_t default_scaling_list0[16] = {
+  16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16,
+  16, 16, 16, 16
+};
+
+/*  Combined the values in Table  7-6 to make the calculation easier
+ *  Default scaling list of 8x8 and 16x16 matrices for matrixId = 0, 1 and 2
+ *  Default scaling list of 32x32 matrix for matrixId = 0
+ */
+static const uint8_t default_scaling_list1[64] = {
+  16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 17, 16,
+  17, 16, 17, 18, 17, 18, 18, 17, 18, 21, 19, 20,
+  21, 20, 19, 21, 24, 22, 22, 24, 24, 22, 22, 24,
+  25, 25, 27, 30, 27, 25, 25, 29, 31, 35, 35, 31,
+  29, 36, 41, 44, 41, 36, 47, 54, 54, 47, 65, 70,
+  65, 88, 88, 115
+};
+
+/*  Combined the values in Table 7-6 to make the calculation easier
+ *  Default scaling list of 8x8 and 16x16 matrices for matrixId = 3, 4 and 5
+ *  Default scaling list of 32x32 matrix for matrixId = 1
+ */
+static const uint8_t default_scaling_list2[64] = {
+  16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 17,
+  17, 17, 17, 17, 18, 18, 18, 18, 18, 20, 20, 20,
+  20, 20, 20, 20, 24, 24, 24, 24, 24, 24, 24, 24,
+  25, 25, 25, 25, 25, 25, 25, 28, 28, 28, 28, 28,
+  28, 33, 33, 33, 33, 33, 41, 41, 41, 41, 54, 54,
+  54, 71, 71, 91
+};
+
+static const uint8_t zigzag_4x4[16] = {
+  0, 1, 4, 8,
+  5, 2, 3, 6,
+  9, 12, 13, 10,
+  7, 11, 14, 15,
+};
+
+static const uint8_t zigzag_8x8[64] = {
+  0, 1, 8, 16, 9, 2, 3, 10,
+  17, 24, 32, 25, 18, 11, 4, 5,
+  12, 19, 26, 33, 40, 48, 41, 34,
+  27, 20, 13, 6, 7, 14, 21, 28,
+  35, 42, 49, 56, 57, 50, 43, 36,
+  29, 22, 15, 23, 30, 37, 44, 51,
+  58, 59, 52, 45, 38, 31, 39, 46,
+  53, 60, 61, 54, 47, 55, 62, 63
+};
+
+typedef struct
+{
+  uint32_t par_n, par_d;
+} PAR;
+
+/* Table E-1 - Meaning of sample aspect ratio indicator (1..16) */
+static const PAR aspect_ratios[17] = {
+  {0, 0},
+  {1, 1},
+  {12, 11},
+  {10, 11},
+  {16, 11},
+  {40, 33},
+  {24, 11},
+  {20, 11},
+  {32, 11},
+  {80, 33},
+  {18, 11},
+  {15, 11},
+  {64, 33},
+  {160, 99},
+  {4, 3},
+  {3, 2},
+  {2, 1}
+};
+
+// lyb add
+#define NAL_CHECK_ALLOWED(val, min, max) { \
+  if (val < min || val > max) { \
+    WARNING ("value not in allowed range. value: %d, range %d-%d", \
+                     val, min, max); \
+    goto error; \
+  } \
+}
+
+#define NAL_READ_UINT8(nr, val, nbits) { \
+  if (!nal_reader_get_bits_uint8 (nr, &val, nbits)) { \
+    WARNING ("failed to read uint8_t, nbits: %d", nbits); \
+    goto error; \
+  } \
+}
+
+#define NAL_READ_UINT16(nr, val, nbits) { \
+  if (!nal_reader_get_bits_uint16 (nr, &val, nbits)) { \
+  WARNING ("failed to read uint16_t, nbits: %d", nbits); \
+    goto error; \
+  } \
+}
+
+#define NAL_READ_UE(nr, val) { \
+  if (!nal_reader_get_ue (nr, &val)) { \
+    WARNING ("failed to read UE"); \
+    goto error; \
+  } \
+}
+
+#define NAL_READ_UE_ALLOWED(nr, val, min, max) { \
+  uint32_t tmp; \
+  NAL_READ_UE (nr, tmp); \
+  NAL_CHECK_ALLOWED (tmp, min, max); \
+  val = tmp; \
+}
+
+#define NAL_READ_UINT32(nr, val, nbits) { \
+  if (!nal_reader_get_bits_uint32 (nr, &val, nbits)) { \
+  WARNING ("failed to read uint32_t, nbits: %d", nbits); \
+    goto error; \
+  } \
+}
+
+#define NAL_READ_SE(nr, val) { \
+  if (!nal_reader_get_se (nr, &val)) { \
+    WARNING ("failed to read SE"); \
+    goto error; \
+  } \
+}
+
+#define NAL_READ_SE_ALLOWED(nr, val, min, max) { \
+  int32_t tmp; \
+  NAL_READ_SE (nr, tmp); \
+  NAL_CHECK_ALLOWED (tmp, min, max); \
+  val = tmp; \
+}
+
+#define READ_UE_ALLOWED(nr, val, min, max) { \
+  uint32_t tmp; \
+  NAL_READ_UE (nr, tmp); \
+  NAL_CHECK_ALLOWED (tmp, min, max); \
+  val = tmp; \
+}
+
+#define CHECK_ALLOWED_MAX(val, max) { \
+  if (val > max) { \
+    WARNING ("value greater than max. value: %d, max %d", \
+                     val, max); \
+    goto error; \
+  } \
+}
+
+static inline int32_t
+scan_for_start_codes (const uint8_t * data, uint32_t size)
+{
+  ByteReader br;
+  byte_reader_init (&br, data, size);
+
+  /* NALU not empty, so we can at least expect 1 (even 2) bytes following sc */
+  return byte_reader_masked_scan_uint32 (&br, 0xffffff00, 0x00000100,
+      0, size);
+}
+
+static uint32_t
+ceil_log2 (uint32_t v)
+{
+  uint32_t r, shift;
+
+  v--;
+  r = (v > 0xFFFF) << 4;
+  v >>= r;
+  shift = (v > 0xFF) << 3;
+  v >>= shift;
+  r |= shift;
+  shift = (v > 0xF) << 2;
+  v >>= shift;
+  r |= shift;
+  shift = (v > 0x3) << 1;
+  v >>= shift;
+  r |= shift;
+  r |= (v >> 1);
+  return r + 1;
+}
+
+static BOOL
+nal_reader_is_byte_aligned (NalReader * nr)
+{
+  if (nr->bits_in_cache != 0)
+    return FALSE;
+  return TRUE;
+}
+
+static BOOL
+nal_reader_skip_long (NalReader * nr, uint32_t nbits)
+{
+  /* Leave out enough bits in the cache once we are finished */
+  const uint32_t skip_size = 4 * sizeof (nr->cache);
+  uint32_t remaining = nbits;
+
+  nbits %= skip_size;
+  while (remaining > 0) {
+    if (!nal_reader_skip (nr, nbits))
+      return FALSE;
+    remaining -= nbits;
+    nbits = skip_size;
+  }
+  return TRUE;
+}
+//  add end
+
+/*****  Utils ****/
+#define EXTENDED_SAR 255
+
+static H265VPS *
+h265_parser_get_vps (H265Parser * parser, uint8_t vps_id)
+{
+  H265VPS *vps;
+
+  vps = &parser->vps[vps_id];
+
+  if (vps->valid)
+    return vps;
+
+  return NULL;
+}
+
+static H265SPS *
+h265_parser_get_sps (H265Parser * parser, uint8_t sps_id)
+{
+  H265SPS *sps;
+
+  sps = &parser->sps[sps_id];
+
+  if (sps->valid)
+    return sps;
+
+  return NULL;
+}
+
+static H265PPS *
+h265_parser_get_pps (H265Parser * parser, uint8_t pps_id)
+{
+  H265PPS *pps;
+
+  pps = &parser->pps[pps_id];
+
+  if (pps->valid)
+    return pps;
+
+  return NULL;
+}
+
+static BOOL
+h265_parse_nalu_header (H265NalUnit * nalu)
+{
+  uint8_t *data = nalu->data + nalu->offset;
+  BitReader br;
+
+  if (nalu->size < 2)
+    return FALSE;
+
+  bit_reader_init (&br, data, nalu->size - nalu->offset);
+
+  /* skip the forbidden_zero_bit */
+  bit_reader_skip_unchecked (&br, 1);
+
+  nalu->type = bit_reader_get_bits_uint8_unchecked (&br, 6);
+  nalu->layer_id = bit_reader_get_bits_uint8_unchecked (&br, 6);
+  nalu->temporal_id_plus1 = bit_reader_get_bits_uint8_unchecked (&br, 3);
+  nalu->header_bytes = 2;
+
+  return TRUE;
+}
+
+/****** Parsing functions *****/
+
+static BOOL
+h265_parse_profile_tier_level (H265ProfileTierLevel * ptl,
+    NalReader * nr, uint8_t maxNumSubLayersMinus1)
+{
+  uint32_t i, j;
+  DEBUG ("parsing \"ProfileTierLevel parameters\"");
+
+  /* set default values for fields that might not be present in the
+   * bitstream and have valid defaults */
+  for (i = 0; i < maxNumSubLayersMinus1; i++)
+    ptl->sub_layer_tier_flag[i] = 0;
+
+  NAL_READ_UINT8 (nr, ptl->profile_space, 2);
+  NAL_READ_UINT8 (nr, ptl->tier_flag, 1);
+  NAL_READ_UINT8 (nr, ptl->profile_idc, 5);
+
+  for (j = 0; j < 32; j++)
+    NAL_READ_UINT8 (nr, ptl->profile_compatibility_flag[j], 1);
+
+  NAL_READ_UINT8 (nr, ptl->progressive_source_flag, 1);
+  NAL_READ_UINT8 (nr, ptl->interlaced_source_flag, 1);
+  NAL_READ_UINT8 (nr, ptl->non_packed_constraint_flag, 1);
+  NAL_READ_UINT8 (nr, ptl->frame_only_constraint_flag, 1);
+
+  /* skip the reserved zero bits */
+  if (!nal_reader_skip (nr, 44))
+    goto error;
+
+  NAL_READ_UINT8 (nr, ptl->level_idc, 8);
+  for (j = 0; j < maxNumSubLayersMinus1; j++) {
+    NAL_READ_UINT8 (nr, ptl->sub_layer_profile_present_flag[j], 1);
+    NAL_READ_UINT8 (nr, ptl->sub_layer_level_present_flag[j], 1);
+  }
+
+  if (maxNumSubLayersMinus1 > 0) {
+    for (i = maxNumSubLayersMinus1; i < 8; i++)
+      if (!nal_reader_skip (nr, 2))
+        goto error;
+  }
+
+  for (i = 0; i < maxNumSubLayersMinus1; i++) {
+    if (ptl->sub_layer_profile_present_flag[i]) {
+      NAL_READ_UINT8 (nr, ptl->sub_layer_profile_space[i], 2);
+      NAL_READ_UINT8 (nr, ptl->sub_layer_tier_flag[i], 1);
+      NAL_READ_UINT8 (nr, ptl->sub_layer_profile_idc[i], 5);
+
+      for (j = 0; j < 32; j++)
+        NAL_READ_UINT8 (nr, ptl->sub_layer_profile_compatibility_flag[i][j], 1);
+
+      NAL_READ_UINT8 (nr, ptl->sub_layer_progressive_source_flag[i], 1);
+      NAL_READ_UINT8 (nr, ptl->sub_layer_interlaced_source_flag[i], 1);
+      NAL_READ_UINT8 (nr, ptl->sub_layer_non_packed_constraint_flag[i], 1);
+      NAL_READ_UINT8 (nr, ptl->sub_layer_frame_only_constraint_flag[i], 1);
+
+      if (!nal_reader_skip (nr, 44))
+        goto error;
+    }
+
+    if (ptl->sub_layer_level_present_flag[i])
+      NAL_READ_UINT8 (nr, ptl->sub_layer_level_idc[i], 8);
+  }
+
+  return TRUE;
+
+error:
+  WARNING ("error parsing \"ProfileTierLevel Parameters\"");
+  return FALSE;
+}
+
+static BOOL
+h265_parse_sub_layer_hrd_parameters (H265SubLayerHRDParams * sub_hrd,
+    NalReader * nr, uint8_t CpbCnt, uint8_t sub_pic_hrd_params_present_flag)
+{
+  uint32_t i;
+
+  DEBUG ("parsing \"SubLayer HRD Parameters\"");
+
+  /* set default values for fields that might not be present in the bitstream
+     and have valid defaults */
+  for (i = 0; i <= CpbCnt; i++)
+    sub_hrd->cbr_flag[i] = 0;
+
+  for (i = 0; i <= CpbCnt; i++) {
+    NAL_READ_UE_ALLOWED (nr, sub_hrd->bit_rate_value_minus1[i], 0, G_MAXUINT32 - 1);
+    NAL_READ_UE_ALLOWED (nr, sub_hrd->cpb_size_value_minus1[i], 0, G_MAXUINT32 - 1);
+
+    if (sub_pic_hrd_params_present_flag) {
+      NAL_READ_UE_ALLOWED (nr, sub_hrd->cpb_size_du_value_minus1[i], 0, G_MAXUINT32 - 1);
+      NAL_READ_UE_ALLOWED (nr, sub_hrd->bit_rate_du_value_minus1[i], 0, G_MAXUINT32 - 1);
+    }
+
+    NAL_READ_UINT8 (nr, sub_hrd->cbr_flag[i], 1);
+  }
+
+  return TRUE;
+
+error:
+  WARNING ("error parsing \"SubLayerHRD Parameters \"");
+  return FALSE;
+}
+
+static BOOL
+h265_parse_hrd_parameters (H265HRDParams * hrd, NalReader * nr,
+    uint8_t commonInfPresentFlag, uint8_t maxNumSubLayersMinus1)
+{
+  uint32_t i;
+
+  DEBUG ("parsing \"HRD Parameters\"");
+
+  /* set default values for fields that might not be present in the bitstream
+     and have valid defaults */
+  hrd->sub_pic_hrd_params_present_flag = 0;
+  hrd->sub_pic_cpb_params_in_pic_timing_sei_flag = 0;
+  hrd->initial_cpb_removal_delay_length_minus1 = 23;
+  hrd->au_cpb_removal_delay_length_minus1 = 23;
+  hrd->dpb_output_delay_length_minus1 = 23;
+  for (i = 0; i <= maxNumSubLayersMinus1; i++) {
+    hrd->fixed_pic_rate_general_flag[i] = 0;
+    hrd->low_delay_hrd_flag[i] = 0;
+    hrd->cpb_cnt_minus1[i] = 0;
+  }
+
+  if (commonInfPresentFlag) {
+    NAL_READ_UINT8 (nr, hrd->nal_hrd_parameters_present_flag, 1);
+    NAL_READ_UINT8 (nr, hrd->vcl_hrd_parameters_present_flag, 1);
+
+    if (hrd->nal_hrd_parameters_present_flag
+        || hrd->vcl_hrd_parameters_present_flag) {
+
+      NAL_READ_UINT8 (nr, hrd->sub_pic_hrd_params_present_flag, 1);
+
+      if (hrd->sub_pic_hrd_params_present_flag) {
+        NAL_READ_UINT8 (nr, hrd->tick_divisor_minus2, 8);
+        NAL_READ_UINT8 (nr, hrd->du_cpb_removal_delay_increment_length_minus1, 5);
+        NAL_READ_UINT8 (nr, hrd->sub_pic_cpb_params_in_pic_timing_sei_flag, 1);
+        NAL_READ_UINT8 (nr, hrd->dpb_output_delay_du_length_minus1, 5);
+      }
+
+      NAL_READ_UINT8 (nr, hrd->bit_rate_scale, 4);
+      NAL_READ_UINT8 (nr, hrd->cpb_size_scale, 4);
+
+      if (hrd->sub_pic_hrd_params_present_flag)
+        NAL_READ_UINT8 (nr, hrd->cpb_size_du_scale, 4);
+
+      NAL_READ_UINT8 (nr, hrd->initial_cpb_removal_delay_length_minus1, 5);
+      NAL_READ_UINT8 (nr, hrd->au_cpb_removal_delay_length_minus1, 5);
+      NAL_READ_UINT8 (nr, hrd->dpb_output_delay_length_minus1, 5);
+    }
+  }
+
+  for (i = 0; i <= maxNumSubLayersMinus1; i++) {
+    NAL_READ_UINT8 (nr, hrd->fixed_pic_rate_general_flag[i], 1);
+
+    if (!hrd->fixed_pic_rate_general_flag[i]) {
+      NAL_READ_UINT8 (nr, hrd->fixed_pic_rate_within_cvs_flag[i], 1);
+    } else
+      hrd->fixed_pic_rate_within_cvs_flag[i] = 1;
+
+    if (hrd->fixed_pic_rate_within_cvs_flag[i]) {
+      NAL_READ_UE_ALLOWED (nr, hrd->elemental_duration_in_tc_minus1[i], 0, 2047);
+    } else
+      NAL_READ_UINT8 (nr, hrd->low_delay_hrd_flag[i], 1);
+
+    if (!hrd->low_delay_hrd_flag[i])
+      NAL_READ_UE_ALLOWED (nr, hrd->cpb_cnt_minus1[i], 0, 31);
+
+    if (hrd->nal_hrd_parameters_present_flag)
+      if (!h265_parse_sub_layer_hrd_parameters (&hrd->sublayer_hrd_params
+              [i], nr, hrd->cpb_cnt_minus1[i],
+              hrd->sub_pic_hrd_params_present_flag))
+        goto error;
+
+    if (hrd->vcl_hrd_parameters_present_flag)
+      if (!h265_parse_sub_layer_hrd_parameters (&hrd->sublayer_hrd_params
+              [i], nr, hrd->cpb_cnt_minus1[i],
+              hrd->sub_pic_hrd_params_present_flag))
+        goto error;
+  }
+
+  return TRUE;
+
+error:
+  WARNING ("error parsing \"HRD Parameters\"");
+  return FALSE;
+}
+
+static BOOL
+h265_parse_vui_parameters (H265SPS * sps, NalReader * nr)
+{
+  H265VUIParams *vui = &sps->vui_params;
+
+  DEBUG ("parsing \"VUI Parameters\"");
+
+  /* set default values for fields that might not be present in the bitstream
+     and have valid defaults */
+  vui->aspect_ratio_idc = 0;
+  vui->video_format = 5;
+  vui->video_full_range_flag = 0;
+  vui->colour_primaries = 2;
+  vui->transfer_characteristics = 2;
+  vui->matrix_coefficients = 2;
+  vui->chroma_sample_loc_type_top_field = 0;
+  vui->chroma_sample_loc_type_bottom_field = 0;
+  vui->neutral_chroma_indication_flag = 0;
+  vui->field_seq_flag = 0;
+  vui->def_disp_win_left_offset = 0;
+  vui->def_disp_win_right_offset = 0;
+  vui->def_disp_win_top_offset = 0;
+  vui->def_disp_win_bottom_offset = 0;
+  vui->tiles_fixed_structure_flag = 0;
+  vui->motion_vectors_over_pic_boundaries_flag = 1;
+  vui->min_spatial_segmentation_idc = 0;
+  vui->max_bytes_per_pic_denom = 2;
+  vui->max_bits_per_min_cu_denom = 1;
+  vui->log2_max_mv_length_horizontal = 15;
+  vui->log2_max_mv_length_vertical = 15;
+  vui->par_n = 0;
+  vui->par_d = 0;
+
+  if (sps && sps->profile_tier_level.progressive_source_flag
+      && sps->profile_tier_level.interlaced_source_flag)
+    vui->frame_field_info_present_flag = 1;
+  else
+    vui->frame_field_info_present_flag = 0;
+
+  NAL_READ_UINT8 (nr, vui->aspect_ratio_info_present_flag, 1);
+  if (vui->aspect_ratio_info_present_flag) {
+    NAL_READ_UINT8 (nr, vui->aspect_ratio_idc, 8);
+    if (vui->aspect_ratio_idc == EXTENDED_SAR) {
+      NAL_READ_UINT16 (nr, vui->sar_width, 16);
+      NAL_READ_UINT16 (nr, vui->sar_height, 16);
+      vui->par_n = vui->sar_width;
+      vui->par_d = vui->sar_height;
+    } else if (vui->aspect_ratio_idc <= 16) {
+      vui->par_n = aspect_ratios[vui->aspect_ratio_idc].par_n;
+      vui->par_d = aspect_ratios[vui->aspect_ratio_idc].par_d;
+    }
+  }
+
+  NAL_READ_UINT8 (nr, vui->overscan_info_present_flag, 1);
+  if (vui->overscan_info_present_flag)
+    NAL_READ_UINT8 (nr, vui->overscan_appropriate_flag, 1);
+
+  NAL_READ_UINT8 (nr, vui->video_signal_type_present_flag, 1);
+  if (vui->video_signal_type_present_flag) {
+
+    NAL_READ_UINT8 (nr, vui->video_format, 3);
+    NAL_READ_UINT8 (nr, vui->video_full_range_flag, 1);
+    NAL_READ_UINT8 (nr, vui->colour_description_present_flag, 1);
+    if (vui->colour_description_present_flag) {
+      NAL_READ_UINT8 (nr, vui->colour_primaries, 8);
+      NAL_READ_UINT8 (nr, vui->transfer_characteristics, 8);
+      NAL_READ_UINT8 (nr, vui->matrix_coefficients, 8);
+    }
+  }
+
+  NAL_READ_UINT8 (nr, vui->chroma_loc_info_present_flag, 1);
+  if (vui->chroma_loc_info_present_flag) {
+    NAL_READ_UE_ALLOWED (nr, vui->chroma_sample_loc_type_top_field, 0, 5);
+    NAL_READ_UE_ALLOWED (nr, vui->chroma_sample_loc_type_bottom_field, 0, 5);
+  }
+
+  NAL_READ_UINT8 (nr, vui->neutral_chroma_indication_flag, 1);
+  NAL_READ_UINT8 (nr, vui->field_seq_flag, 1);
+  NAL_READ_UINT8 (nr, vui->frame_field_info_present_flag, 1);
+
+  NAL_READ_UINT8 (nr, vui->default_display_window_flag, 1);
+  if (vui->default_display_window_flag) {
+    NAL_READ_UE (nr, vui->def_disp_win_left_offset);
+    NAL_READ_UE (nr, vui->def_disp_win_right_offset);
+    NAL_READ_UE (nr, vui->def_disp_win_top_offset);
+    NAL_READ_UE (nr, vui->def_disp_win_bottom_offset);
+  }
+
+  NAL_READ_UINT8 (nr, vui->timing_info_present_flag, 1);
+  if (vui->timing_info_present_flag) {
+    NAL_READ_UINT32 (nr, vui->num_units_in_tick, 32);
+    if (vui->num_units_in_tick == 0)
+      WARNING ("num_units_in_tick = 0 detected in stream "
+          "(incompliant to H.265 E.2.1).");
+
+    NAL_READ_UINT32 (nr, vui->time_scale, 32);
+    if (vui->time_scale == 0)
+      WARNING ("time_scale = 0 detected in stream "
+          "(incompliant to H.265 E.2.1).");
+
+    NAL_READ_UINT8 (nr, vui->poc_proportional_to_timing_flag, 1);
+    if (vui->poc_proportional_to_timing_flag)
+      NAL_READ_UE_ALLOWED (nr, vui->num_ticks_poc_diff_one_minus1, 0, G_MAXUINT32 - 1);
+
+    NAL_READ_UINT8 (nr, vui->hrd_parameters_present_flag, 1);
+    if (vui->hrd_parameters_present_flag)
+      if (!h265_parse_hrd_parameters (&vui->hrd_params, nr, 1,
+              sps->max_sub_layers_minus1))
+        goto error;
+  }
+
+  NAL_READ_UINT8 (nr, vui->bitstream_restriction_flag, 1);
+  if (vui->bitstream_restriction_flag) {
+    NAL_READ_UINT8 (nr, vui->tiles_fixed_structure_flag, 1);
+    NAL_READ_UINT8 (nr, vui->motion_vectors_over_pic_boundaries_flag, 1);
+    NAL_READ_UINT8 (nr, vui->restricted_ref_pic_lists_flag, 1);
+    NAL_READ_UE_ALLOWED (nr, vui->min_spatial_segmentation_idc, 0, 4096);
+    NAL_READ_UE_ALLOWED (nr, vui->max_bytes_per_pic_denom, 0, 16);
+    NAL_READ_UE_ALLOWED (nr, vui->max_bits_per_min_cu_denom, 0, 16);
+    NAL_READ_UE_ALLOWED (nr, vui->log2_max_mv_length_horizontal, 0, 16);
+    NAL_READ_UE_ALLOWED (nr, vui->log2_max_mv_length_vertical, 0, 15);
+  }
+
+  return TRUE;
+
+error:
+  WARNING ("error parsing \"VUI Parameters\"");
+  return FALSE;
+}
+
+static BOOL
+get_scaling_list_params (H265ScalingList * dest_scaling_list,
+    uint8_t sizeId, uint8_t matrixId, uint8_t ** sl, uint8_t * size,
+    int16_t ** scaling_list_dc_coef_minus8)
+{
+  switch (sizeId) {
+    case H265_QUANT_MATIX_4X4:
+      *sl = dest_scaling_list->scaling_lists_4x4[matrixId];
+      if (size)
+        *size = 16;
+      break;
+    case H265_QUANT_MATIX_8X8:
+      *sl = dest_scaling_list->scaling_lists_8x8[matrixId];
+      if (size)
+        *size = 64;
+      break;
+    case H265_QUANT_MATIX_16X16:
+      *sl = dest_scaling_list->scaling_lists_16x16[matrixId];
+      if (size)
+        *size = 64;
+      if (scaling_list_dc_coef_minus8)
+        *scaling_list_dc_coef_minus8 =
+            dest_scaling_list->scaling_list_dc_coef_minus8_16x16;
+      break;
+    case H265_QUANT_MATIX_32X32:
+      *sl = dest_scaling_list->scaling_lists_32x32[matrixId];
+      if (size)
+        *size = 64;
+      if (scaling_list_dc_coef_minus8)
+        *scaling_list_dc_coef_minus8 =
+            dest_scaling_list->scaling_list_dc_coef_minus8_32x32;
+      break;
+    default:
+      return FALSE;
+  }
+  return TRUE;
+}
+
+static BOOL
+get_default_scaling_lists (uint8_t ** sl, uint8_t sizeId, uint8_t matrixId)
+{
+  switch (sizeId) {
+    case H265_QUANT_MATIX_4X4:
+      memcpy (*sl, default_scaling_list0, 16);
+      break;
+
+    case H265_QUANT_MATIX_8X8:
+    case H265_QUANT_MATIX_16X16:
+      if (matrixId <= 2)
+        memcpy (*sl, default_scaling_list1, 64);
+      else
+        memcpy (*sl, default_scaling_list2, 64);
+      break;
+
+    case H265_QUANT_MATIX_32X32:
+      if (matrixId == 0)
+        memcpy (*sl, default_scaling_list1, 64);
+      else
+        memcpy (*sl, default_scaling_list2, 64);
+      break;
+
+    default:
+      return FALSE;
+      break;
+  }
+  return TRUE;
+}
+
+static BOOL
+h265_parser_parse_scaling_lists (NalReader * nr,
+    H265ScalingList * dest_scaling_list, BOOL use_default)
+{
+  uint8_t sizeId;
+  uint8_t matrixId;
+  uint8_t scaling_list_pred_mode_flag = 0;
+  uint8_t scaling_list_pred_matrix_id_delta = 0;
+  uint8_t size, i;
+
+  DEBUG ("parsing scaling lists");
+
+  for (sizeId = 0; sizeId < 4; sizeId++) {
+    for (matrixId = 0; matrixId < ((sizeId == 3) ? 2 : 6); matrixId++) {
+      int16_t *scaling_list_dc_coef_minus8 = NULL;
+      uint8_t *sl;
+
+      if (!get_scaling_list_params (dest_scaling_list, sizeId, matrixId, &sl,
+              &size, &scaling_list_dc_coef_minus8))
+        goto error;
+
+      /* use_default_scaling_matrices forcefully which means,
+       * sps_scaling_list_enabled_flag=TRUE,
+       * sps_scaling_list_data_present_flag=FALSE,
+       * pps_scaling_list_data_present_falg=FALSE */
+      if (use_default) {
+        if (!get_default_scaling_lists (&sl, sizeId, matrixId))
+          goto error;
+
+        /* Inferring the value of scaling_list_dc_coef_minus8 */
+        if (sizeId > 1)
+          scaling_list_dc_coef_minus8[matrixId] = 8;
+
+      } else {
+        NAL_READ_UINT8 (nr, scaling_list_pred_mode_flag, 1);
+
+        if (!scaling_list_pred_mode_flag) {
+          uint8_t refMatrixId;
+
+          NAL_READ_UE_ALLOWED (nr, scaling_list_pred_matrix_id_delta, 0, matrixId);
+
+          if (!scaling_list_pred_matrix_id_delta) {
+            if (!get_default_scaling_lists (&sl, sizeId, matrixId))
+              goto error;
+
+            /* Inferring the value of scaling_list_dc_coef_minus8 */
+            if (sizeId > 1)
+              scaling_list_dc_coef_minus8[matrixId] = 8;
+
+          } else {
+            uint8_t *temp_sl;
+
+            refMatrixId = matrixId - scaling_list_pred_matrix_id_delta; /* 7-30 */
+
+            if (!get_scaling_list_params (dest_scaling_list, sizeId,
+                    refMatrixId, &temp_sl, NULL, NULL))
+              goto error;
+
+            for (i = 0; i < size; i++)
+              sl[i] = temp_sl[i];       /* 7-31 */
+
+
+            /* Inferring the value of scaling_list_dc_coef_minus8 */
+            if (sizeId > 1)
+              scaling_list_dc_coef_minus8[matrixId] =
+                  scaling_list_dc_coef_minus8[refMatrixId];
+          }
+        } else {
+          uint8_t nextCoef = 8;
+          int8_t scaling_list_delta_coef;
+
+          if (sizeId > 1) {
+            NAL_READ_SE_ALLOWED (nr, scaling_list_dc_coef_minus8[matrixId], -7,
+                247);
+            nextCoef = scaling_list_dc_coef_minus8[matrixId] + 8;
+          }
+
+          for (i = 0; i < size; i++) {
+            NAL_READ_SE_ALLOWED (nr, scaling_list_delta_coef, -128, 127);
+            nextCoef = (nextCoef + scaling_list_delta_coef) & 0xff;
+            sl[i] = nextCoef;
+          }
+        }
+      }
+    }
+  }
+
+  return TRUE;
+
+error:
+  WARNING ("error parsing scaling lists");
+  return FALSE;
+}
+
+static BOOL
+h265_parser_parse_short_term_ref_pic_sets (H265ShortTermRefPicSet *
+    stRPS, NalReader * nr, uint8_t stRpsIdx, H265SPS * sps)
+{
+  uint8_t num_short_term_ref_pic_sets;
+  uint8_t RefRpsIdx = 0;
+  int16_t deltaRps = 0;
+  uint8_t use_delta_flag[16] = { 0 };
+  uint8_t used_by_curr_pic_flag[16] = { 0 };
+  uint32_t delta_poc_s0_minus1[16] = { 0 };
+  uint32_t delta_poc_s1_minus1[16] = { 0 };
+  int32_t j, i = 0;
+  int32_t dPoc;
+
+  DEBUG ("parsing \"ShortTermRefPicSetParameters\"");
+
+  /* set default values for fields that might not be present in the bitstream
+     and have valid defaults */
+  stRPS->inter_ref_pic_set_prediction_flag = 0;
+  stRPS->delta_idx_minus1 = 0;
+  for (j = 0; j < 16; j++)
+    use_delta_flag[j] = 1;
+
+  num_short_term_ref_pic_sets = sps->num_short_term_ref_pic_sets;
+
+  if (stRpsIdx != 0)
+    NAL_READ_UINT8 (nr, stRPS->inter_ref_pic_set_prediction_flag, 1);
+
+  if (stRPS->inter_ref_pic_set_prediction_flag) {
+    H265ShortTermRefPicSet *RefRPS;
+
+    if (stRpsIdx == num_short_term_ref_pic_sets)
+      NAL_READ_UE_ALLOWED (nr, stRPS->delta_idx_minus1, 0, stRpsIdx - 1);
+
+    NAL_READ_UINT8 (nr, stRPS->delta_rps_sign, 1);
+    NAL_READ_UE_ALLOWED (nr, stRPS->abs_delta_rps_minus1, 0, 32767);
+
+    RefRpsIdx = stRpsIdx - stRPS->delta_idx_minus1 - 1; /* 7-45 */
+    deltaRps = (1 - 2 * stRPS->delta_rps_sign) * (stRPS->abs_delta_rps_minus1 + 1);     /* 7-46 */
+
+    RefRPS = &sps->short_term_ref_pic_set[RefRpsIdx];
+
+    for (j = 0; j <= RefRPS->NumDeltaPocs; j++) {
+      NAL_READ_UINT8 (nr, used_by_curr_pic_flag[j], 1);
+      if (!used_by_curr_pic_flag[j])
+        NAL_READ_UINT8 (nr, use_delta_flag[j], 1);
+    }
+
+    /* 7-47: calcuate NumNegativePics, DeltaPocS0 and UsedByCurrPicS0 */
+    i = 0;
+    for (j = (RefRPS->NumPositivePics - 1); j >= 0; j--) {
+      dPoc = RefRPS->DeltaPocS1[j] + deltaRps;
+      if (dPoc < 0 && use_delta_flag[RefRPS->NumNegativePics + j]) {
+        stRPS->DeltaPocS0[i] = dPoc;
+        stRPS->UsedByCurrPicS0[i++] =
+            used_by_curr_pic_flag[RefRPS->NumNegativePics + j];
+      }
+    }
+    if (deltaRps < 0 && use_delta_flag[RefRPS->NumDeltaPocs]) {
+      stRPS->DeltaPocS0[i] = deltaRps;
+      stRPS->UsedByCurrPicS0[i++] = used_by_curr_pic_flag[RefRPS->NumDeltaPocs];
+    }
+    for (j = 0; j < RefRPS->NumNegativePics; j++) {
+      dPoc = RefRPS->DeltaPocS0[j] + deltaRps;
+      if (dPoc < 0 && use_delta_flag[j]) {
+        stRPS->DeltaPocS0[i] = dPoc;
+        stRPS->UsedByCurrPicS0[i++] = used_by_curr_pic_flag[j];
+      }
+    }
+    stRPS->NumNegativePics = i;
+
+    /* 7-48: calcuate NumPositivePics, DeltaPocS1 and UsedByCurrPicS1 */
+    i = 0;
+    for (j = (RefRPS->NumNegativePics - 1); j >= 0; j--) {
+      dPoc = RefRPS->DeltaPocS0[j] + deltaRps;
+      if (dPoc > 0 && use_delta_flag[j]) {
+        stRPS->DeltaPocS1[i] = dPoc;
+        stRPS->UsedByCurrPicS1[i++] = used_by_curr_pic_flag[j];
+      }
+    }
+    if (deltaRps > 0 && use_delta_flag[RefRPS->NumDeltaPocs]) {
+      stRPS->DeltaPocS1[i] = deltaRps;
+      stRPS->UsedByCurrPicS1[i++] = used_by_curr_pic_flag[RefRPS->NumDeltaPocs];
+    }
+    for (j = 0; j < RefRPS->NumPositivePics; j++) {
+      dPoc = RefRPS->DeltaPocS1[j] + deltaRps;
+      if (dPoc > 0 && use_delta_flag[RefRPS->NumNegativePics + j]) {
+        stRPS->DeltaPocS1[i] = dPoc;
+        stRPS->UsedByCurrPicS1[i++] =
+            used_by_curr_pic_flag[RefRPS->NumNegativePics + j];
+      }
+    }
+    stRPS->NumPositivePics = i;
+
+  } else {
+    /* 7-49 */
+    NAL_READ_UE_ALLOWED (nr, stRPS->NumNegativePics, 0,
+        sps->max_dec_pic_buffering_minus1[sps->max_sub_layers_minus1]);
+
+    /* 7-50 */
+    NAL_READ_UE_ALLOWED (nr, stRPS->NumPositivePics, 0,
+        (sps->max_dec_pic_buffering_minus1[sps->max_sub_layers_minus1] -
+            stRPS->NumNegativePics));
+
+    for (i = 0; i < stRPS->NumNegativePics; i++) {
+      NAL_READ_UE_ALLOWED (nr, delta_poc_s0_minus1[i], 0, 32767);
+      /* 7-51 */
+      NAL_READ_UINT8 (nr, stRPS->UsedByCurrPicS0[i], 1);
+
+      if (i == 0) {
+        /* 7-53 */
+        stRPS->DeltaPocS0[i] = -(delta_poc_s0_minus1[i] + 1);
+      } else {
+        /* 7-55 */
+        stRPS->DeltaPocS0[i] =
+            stRPS->DeltaPocS0[i - 1] - (delta_poc_s0_minus1[i] + 1);
+      }
+    }
+
+    for (j = 0; j < stRPS->NumPositivePics; j++) {
+      NAL_READ_UE_ALLOWED (nr, delta_poc_s1_minus1[j], 0, 32767);
+
+      /* 7-52 */
+      NAL_READ_UINT8 (nr, stRPS->UsedByCurrPicS1[j], 1);
+
+      if (j == 0) {
+        /* 7-54 */
+        stRPS->DeltaPocS1[j] = delta_poc_s1_minus1[j] + 1;
+      } else {
+        /* 7-56 */
+        stRPS->DeltaPocS1[j] =
+            stRPS->DeltaPocS1[j - 1] + (delta_poc_s1_minus1[j] + 1);
+      }
+    }
+
+  }
+
+  /* 7-57 */
+  stRPS->NumDeltaPocs = stRPS->NumPositivePics + stRPS->NumNegativePics;
+
+  return TRUE;
+
+error:
+  WARNING ("error parsing \"ShortTermRefPicSet Parameters\"");
+  return FALSE;
+}
+
+static BOOL
+h265_slice_parse_ref_pic_list_modification (H265SliceHdr * slice,
+    NalReader * nr, int32_t NumPocTotalCurr)
+{
+  uint32_t i;
+  H265RefPicListModification *rpl_mod = &slice->ref_pic_list_modification;
+  const uint32_t n = ceil_log2 (NumPocTotalCurr);
+
+  /* set default values */
+  rpl_mod->ref_pic_list_modification_flag_l0 = 0;
+  rpl_mod->ref_pic_list_modification_flag_l1 = 0;
+  for (i = 0; i < slice->num_ref_idx_l0_active_minus1; i++)
+    rpl_mod->list_entry_l0[i] = 0;
+  for (i = 0; i <= slice->num_ref_idx_l1_active_minus1; i++)
+    rpl_mod->list_entry_l1[i] = 0;
+
+  NAL_READ_UINT8 (nr, rpl_mod->ref_pic_list_modification_flag_l0, 1);
+
+  if (rpl_mod->ref_pic_list_modification_flag_l0) {
+    for (i = 0; i < slice->num_ref_idx_l0_active_minus1; i++) {
+      NAL_READ_UINT32 (nr, rpl_mod->list_entry_l0[i], n);
+      CHECK_ALLOWED_MAX (rpl_mod->list_entry_l0[i], (NumPocTotalCurr - 1));
+    }
+  }
+  if (H265_IS_B_SLICE (slice)) {
+    NAL_READ_UINT8 (nr, rpl_mod->ref_pic_list_modification_flag_l1, 1);
+    if (rpl_mod->ref_pic_list_modification_flag_l1)
+      for (i = 0; i <= slice->num_ref_idx_l1_active_minus1; i++) {
+        NAL_READ_UINT32 (nr, rpl_mod->list_entry_l1[i], n);
+        CHECK_ALLOWED_MAX (rpl_mod->list_entry_l1[i], (NumPocTotalCurr - 1));
+      }
+  }
+
+  return TRUE;
+
+error:
+  WARNING ("error parsing \"Prediction weight table\"");
+  return FALSE;
+}
+
+static BOOL
+h265_slice_parse_pred_weight_table (H265SliceHdr * slice, NalReader * nr)
+{
+  H265PredWeightTable *p;
+  int32_t i, j;
+  H265PPS *pps = slice->pps;
+  H265SPS *sps = pps->sps;
+
+  DEBUG ("parsing \"Prediction weight table\"");
+
+  p = &slice->pred_weight_table;
+
+  NAL_READ_UE_ALLOWED (nr, p->luma_log2_weight_denom, 0, 7);
+
+  /* set default values */
+  for (i = 0; i < ARRAY_N_ELEMENT (p->chroma_weight_l0_flag); i++) {
+    p->chroma_weight_l0_flag[i] = 0;
+    p->luma_offset_l0[i] = 0;
+  }
+
+  if (H265_IS_B_SLICE (slice)) {
+    for (i = 0; i < ARRAY_N_ELEMENT (p->luma_weight_l1_flag); i++) {
+      p->chroma_weight_l1_flag[i] = 0;
+      p->luma_offset_l1[i] = 0;
+    }
+  }
+
+  if (sps->chroma_format_idc != 0)
+    NAL_READ_SE_ALLOWED (nr, p->delta_chroma_log2_weight_denom, 0, 7);
+
+  for (i = 0; i <= slice->num_ref_idx_l0_active_minus1; i++)
+    NAL_READ_UINT8 (nr, p->luma_weight_l0_flag[i], 1);
+
+  if (sps->chroma_format_idc != 0)
+    for (i = 0; i <= slice->num_ref_idx_l0_active_minus1; i++)
+      NAL_READ_UINT8 (nr, p->chroma_weight_l0_flag[i], 1);
+
+  for (i = 0; i <= slice->num_ref_idx_l0_active_minus1; i++) {
+    if (p->luma_weight_l0_flag[i]) {
+      NAL_READ_SE_ALLOWED (nr, p->delta_luma_weight_l0[i], -128, 127);
+      NAL_READ_SE_ALLOWED (nr, p->luma_offset_l0[i], -128, 127);
+    }
+    if (p->chroma_weight_l0_flag[i])
+      for (j = 0; j < 2; j++) {
+        NAL_READ_SE_ALLOWED (nr, p->delta_chroma_weight_l0[i][j], -128, 127);
+        NAL_READ_SE_ALLOWED (nr, p->delta_chroma_offset_l0[i][j], -512, 511);
+      }
+  }
+
+  if (H265_IS_B_SLICE (slice)) {
+    for (i = 0; i <= slice->num_ref_idx_l1_active_minus1; i++)
+      NAL_READ_UINT8 (nr, p->luma_weight_l1_flag[i], 1);
+    if (sps->chroma_format_idc != 0)
+      for (i = 0; i <= slice->num_ref_idx_l1_active_minus1; i++)
+        NAL_READ_UINT8 (nr, p->chroma_weight_l1_flag[i], 1);
+
+    for (i = 0; i <= slice->num_ref_idx_l1_active_minus1; i++) {
+      if (p->luma_weight_l1_flag[i]) {
+        NAL_READ_SE_ALLOWED (nr, p->delta_luma_weight_l1[i], -128, 127);
+        NAL_READ_SE_ALLOWED (nr, p->luma_offset_l1[i], -128, 127);
+      }
+      if (p->chroma_weight_l1_flag[i])
+        for (j = 0; j < 2; j++) {
+          NAL_READ_SE_ALLOWED (nr, p->delta_chroma_weight_l1[i][j], -128, 127);
+          NAL_READ_SE_ALLOWED (nr, p->delta_chroma_offset_l1[i][j], -512, 511);
+        }
+    }
+  }
+
+  return TRUE;
+
+error:
+  WARNING ("error parsing \"Prediction weight table\"");
+  return FALSE;
+}
+
+static H265ParserResult
+h265_parser_parse_buffering_period (H265Parser * parser,
+    H265BufferingPeriod * per, NalReader * nr)
+{
+  H265SPS *sps;
+  uint8_t sps_id;
+  uint32_t i;
+  uint32_t n;
+
+  DEBUG ("parsing \"Buffering period\"");
+
+  NAL_READ_UE_ALLOWED (nr, sps_id, 0, H265_MAX_SPS_COUNT - 1);
+  sps = h265_parser_get_sps (parser, sps_id);
+  if (!sps) {
+    WARNING ("couldn't find associated sequence parameter set with id: %d",
+        sps_id);
+    return H265_PARSER_BROKEN_LINK;
+  }
+  per->sps = sps;
+
+  /* set default values if not present */
+  per->irap_cpb_params_present_flag = 0;
+  per->cpb_delay_offset = 0;
+  per->dpb_delay_offset = 0;
+
+  if (sps->vui_parameters_present_flag) {
+    H265VUIParams *vui = &sps->vui_params;
+    H265HRDParams *hrd = &vui->hrd_params;
+
+    if (!hrd->sub_pic_hrd_params_present_flag)
+      NAL_READ_UINT8 (nr, per->irap_cpb_params_present_flag, 1);
+
+    if (per->irap_cpb_params_present_flag) {
+      NAL_READ_UINT8 (nr, per->cpb_delay_offset,
+          (hrd->au_cpb_removal_delay_length_minus1 + 1));
+      NAL_READ_UINT8 (nr, per->dpb_delay_offset,
+          (hrd->dpb_output_delay_length_minus1 + 1));
+    }
+
+    n = hrd->initial_cpb_removal_delay_length_minus1 + 1;
+
+    NAL_READ_UINT8 (nr, per->concatenation_flag, 1);
+    NAL_READ_UINT8 (nr, per->au_cpb_removal_delay_delta_minus1,
+        (hrd->au_cpb_removal_delay_length_minus1 + 1));
+
+    if (hrd->nal_hrd_parameters_present_flag) {
+      for (i = 0; i <= hrd->cpb_cnt_minus1[i]; i++) {
+        NAL_READ_UINT8 (nr, per->nal_initial_cpb_removal_delay[i], n);
+        NAL_READ_UINT8 (nr, per->nal_initial_cpb_removal_offset[i], n);
+        if (hrd->sub_pic_hrd_params_present_flag
+            || per->irap_cpb_params_present_flag) {
+          NAL_READ_UINT8 (nr, per->nal_initial_alt_cpb_removal_delay[i], n);
+          NAL_READ_UINT8 (nr, per->nal_initial_alt_cpb_removal_offset[i], n);
+        }
+      }
+    }
+
+    if (hrd->vcl_hrd_parameters_present_flag) {
+      for (i = 0; i <= hrd->cpb_cnt_minus1[i]; i++) {
+        NAL_READ_UINT8 (nr, per->vcl_initial_cpb_removal_delay[i], n);
+        NAL_READ_UINT8 (nr, per->vcl_initial_cpb_removal_offset[i], n);
+        if (hrd->sub_pic_hrd_params_present_flag
+            || per->irap_cpb_params_present_flag) {
+          NAL_READ_UINT8 (nr, per->vcl_initial_alt_cpb_removal_delay[i], n);
+          NAL_READ_UINT8 (nr, per->vcl_initial_alt_cpb_removal_offset[i], n);
+        }
+      }
+    }
+
+  }
+  return H265_PARSER_OK;
+
+error:
+  WARNING ("error parsing \"Buffering period\"");
+  return H265_PARSER_ERROR;
+}
+
+static H265ParserResult
+h265_parser_parse_pic_timing (H265Parser * parser,
+    H265PicTiming * tim, NalReader * nr)
+{
+  H265ProfileTierLevel *profile_tier_level;
+  uint32_t i;
+
+  DEBUG ("parsing \"Picture timing\"");
+  if (!parser->last_sps || !parser->last_sps->valid) {
+    WARNING ("didn't get the associated sequence paramater set for the "
+        "current access unit");
+    goto error;
+  }
+
+  profile_tier_level = &parser->last_sps->profile_tier_level;
+
+  /* set default values */
+  tim->pic_struct = 0;
+  if (!profile_tier_level->progressive_source_flag
+      && profile_tier_level->interlaced_source_flag)
+    tim->source_scan_type = 0;
+  else if (profile_tier_level->progressive_source_flag
+      && !profile_tier_level->interlaced_source_flag)
+    tim->source_scan_type = 1;
+  else
+    tim->source_scan_type = 2;
+
+  if (parser->last_sps->vui_parameters_present_flag) {
+    H265VUIParams *vui = &parser->last_sps->vui_params;
+
+    if (vui->frame_field_info_present_flag) {
+      NAL_READ_UINT8 (nr, tim->pic_struct, 4);
+      NAL_READ_UINT8 (nr, tim->source_scan_type, 2);
+      NAL_READ_UINT8 (nr, tim->duplicate_flag, 1);
+    } else {
+      /* set default values */
+      tim->pic_struct = 0;
+    }
+
+    if (vui->hrd_parameters_present_flag) {
+      H265HRDParams *hrd = &vui->hrd_params;
+
+      NAL_READ_UINT8 (nr, tim->au_cpb_removal_delay_minus1,
+          (hrd->au_cpb_removal_delay_length_minus1 + 1));
+      NAL_READ_UINT8 (nr, tim->pic_dpb_output_delay,
+          (hrd->dpb_output_delay_length_minus1 + 1));
+
+      if (hrd->sub_pic_hrd_params_present_flag)
+        NAL_READ_UINT8 (nr, tim->pic_dpb_output_du_delay,
+            (hrd->dpb_output_delay_du_length_minus1 + 1));
+
+      if (hrd->sub_pic_hrd_params_present_flag
+          && hrd->sub_pic_cpb_params_in_pic_timing_sei_flag) {
+        NAL_READ_UE (nr, tim->num_decoding_units_minus1);
+
+        NAL_READ_UINT8 (nr, tim->du_common_cpb_removal_delay_flag, 1);
+        if (tim->du_common_cpb_removal_delay_flag)
+          NAL_READ_UINT8 (nr, tim->du_common_cpb_removal_delay_increment_minus1,
+              (hrd->du_cpb_removal_delay_increment_length_minus1 + 1));
+
+        tim->num_nalus_in_du_minus1 =
+            (uint32_t*)malloc(sizeof(uint32_t)*(tim->num_decoding_units_minus1 + 1));
+        tim->du_cpb_removal_delay_increment_minus1 =
+            (uint8_t*)malloc(sizeof(uint8_t)*(tim->num_decoding_units_minus1 + 1));
+
+        for (i = 0; i <= (tim->num_decoding_units_minus1 + 1); i++) {
+          NAL_READ_UE (nr, tim->num_nalus_in_du_minus1[i]);
+
+          if (!tim->du_common_cpb_removal_delay_flag
+              && (i < tim->num_decoding_units_minus1))
+            NAL_READ_UINT8 (nr, tim->du_cpb_removal_delay_increment_minus1[i],
+                (hrd->du_cpb_removal_delay_increment_length_minus1 + 1));
+        }
+      }
+    }
+  }
+  return H265_PARSER_OK;
+
+error:
+  WARNING ("error parsing \"Picture timing\"");
+  return H265_PARSER_ERROR;
+}
+
+/******** API *************/
+
+/**
+ * h265_parser_new:
+ *
+ * Creates a new #H265Parser. It should be freed with
+ * h265_parser_free after use.
+ *
+ * Returns: a new #H265Parser
+ */
+H265Parser *
+h265_parser_new (void)
+{
+  H265Parser *parser;
+
+  parser = (H265Parser*)malloc(sizeof(H265Parser));
+
+  return parser;
+}
+
+/**
+ * h265_parser_free:
+ * @parser: the #H265Parser to free
+ *
+ * Frees @parser and sets it to %NULL
+ */
+void
+h265_parser_free (H265Parser * parser)
+{
+  free(parser);
+  parser = NULL;
+}
+
+/**
+ * h265_parser_identify_nalu_unchecked:
+ * @parser: a #H265Parser
+ * @data: The data to parse
+ * @offset: the offset from which to parse @data
+ * @size: the size of @data
+ * @nalu: The #H265NalUnit where to store parsed nal headers
+ *
+ * Parses @data and fills @nalu from the next nalu data from @data.
+ *
+ * This differs from @h265_parser_identify_nalu in that it doesn't
+ * check whether the packet is complete or not.
+ *
+ * Note: Only use this function if you already know the provided @data
+ * is a complete NALU, else use @h265_parser_identify_nalu.
+ *
+ * Returns: a #H265ParserResult
+ */
+H265ParserResult
+h265_parser_identify_nalu_unchecked (H265Parser * parser,
+    const uint8_t * data, uint32_t offset, size_t size, H265NalUnit * nalu)
+{
+  int32_t off1;
+
+  if (size < offset + 4) {
+    DEBUG ("Can't parse, buffer has too small size %d, offset %d", size, offset);
+    return H265_PARSER_ERROR;
+  }
+
+  off1 = scan_for_start_codes (data + offset, size - offset);
+
+  if (off1 < 0) {
+    DEBUG ("No start code prefix in this buffer");
+    return H265_PARSER_NO_NAL;
+  }
+
+  if (offset + off1 == size - 1) {
+    DEBUG ("Missing data to identify nal unit");
+
+    return H265_PARSER_ERROR;
+  }
+
+  nalu->sc_offset = offset + off1;
+
+  /* sc might have 2 or 3 0-bytes */
+  if (nalu->sc_offset > 0 && data[nalu->sc_offset - 1] == 00)
+    nalu->sc_offset--;
+
+  nalu->offset = offset + off1 + 3;
+  nalu->data = (uint8_t *) data;
+  nalu->size = size - nalu->offset;
+
+  if (!h265_parse_nalu_header (nalu)) {
+    WARNING ("error parsing \"NAL unit header\"");
+    nalu->size = 0;
+    return H265_PARSER_BROKEN_DATA;
+  }
+
+  nalu->valid = TRUE;
+
+  if (nalu->type == H265_NAL_EOS || nalu->type == H265_NAL_EOB) {
+    DEBUG ("end-of-seq or end-of-stream nal found");
+    nalu->size = 2;
+    return H265_PARSER_OK;
+  }
+
+  return H265_PARSER_OK;
+}
+
+/**
+ * h265_parser_identify_nalu:
+ * @parser: a #H265Parser
+ * @data: The data to parse
+ * @offset: the offset from which to parse @data
+ * @size: the size of @data
+ * @nalu: The #H265NalUnit where to store parsed nal headers
+ *
+ * Parses @data and fills @nalu from the next nalu data from @data
+ *
+ * Returns: a #H265ParserResult
+ */
+H265ParserResult
+h265_parser_identify_nalu (H265Parser * parser,
+    const uint8_t * data, uint32_t offset, size_t size, H265NalUnit * nalu)
+{
+  H265ParserResult res;
+  int32_t off2;
+
+  res =
+      h265_parser_identify_nalu_unchecked (parser, data, offset, size,
+      nalu);
+
+  if (res != H265_PARSER_OK || nalu->size == 2)
+    goto beach;
+
+  off2 = scan_for_start_codes (data + nalu->offset, size - nalu->offset);
+  if (off2 < 0) {
+    DEBUG ("Nal start %d, No end found", nalu->offset);
+
+    return H265_PARSER_NO_NAL_END;
+  }
+
+  /* Mini performance improvement:
+   * We could have a way to store how many 0s were skipped to avoid
+   * parsing them again on the next NAL */
+  while (off2 > 0 && data[nalu->offset + off2 - 1] == 00)
+    off2--;
+
+  nalu->size = off2;
+  if (nalu->size < 3)
+    return H265_PARSER_BROKEN_DATA;
+
+  DEBUG ("Complete nal found. Off: %d, Size: %d", nalu->offset, nalu->size);
+
+beach:
+  return res;
+}
+
+/**
+ * h265_parser_identify_nalu_hevc:
+ * @parser: a #H265Parser
+ * @data: The data to parse, must be the beging of the Nal unit
+ * @offset: the offset from which to parse @data
+ * @size: the size of @data
+ * @nal_length_size: the size in bytes of the HEVC nal length prefix.
+ * @nalu: The #H265NalUnit where to store parsed nal headers
+ *
+ * Parses @data and sets @nalu.
+ *
+ * Returns: a #H265ParserResult
+ */
+H265ParserResult
+h265_parser_identify_nalu_hevc (H265Parser * parser,
+    const uint8_t * data, uint32_t offset, size_t size, uint8_t nal_length_size,
+    H265NalUnit * nalu)
+{
+  BitReader br;
+
+  if (size < offset + nal_length_size) {
+    DEBUG ("Can't parse, buffer has too small size %d, offset %u", size, offset);
+    return H265_PARSER_ERROR;
+  }
+
+  size = size - offset;
+  bit_reader_init (&br, data + offset, size);
+
+  nalu->size = bit_reader_get_bits_uint32_unchecked (&br,
+      nal_length_size * 8);
+  nalu->sc_offset = offset;
+  nalu->offset = offset + nal_length_size;
+
+  if (size < nalu->size + nal_length_size) {
+    nalu->size = 0;
+
+    return H265_PARSER_NO_NAL_END;
+  }
+
+  nalu->data = (uint8_t *) data;
+
+  if (!h265_parse_nalu_header (nalu)) {
+    WARNING ("error parsing \"NAL unit header\"");
+    nalu->size = 0;
+    return H265_PARSER_BROKEN_DATA;
+  }
+
+  if (nalu->size < 2)
+    return H265_PARSER_BROKEN_DATA;
+
+  nalu->valid = TRUE;
+
+  return H265_PARSER_OK;
+}
+
+/**
+ * h265_parser_parse_nal:
+ * @parser: a #H265Parser
+ * @nalu: The #H265NalUnit to parse
+ *
+ * This function should be called in the case one doesn't need to
+ * parse a specific structure. It is necessary to do so to make
+ * sure @parser is up to date.
+ *
+ * Returns: a #H265ParserResult
+ */
+H265ParserResult
+h265_parser_parse_nal (H265Parser * parser, H265NalUnit * nalu)
+{
+  H265VPS vps;
+  H265SPS sps;
+  H265PPS pps;
+
+  switch (nalu->type) {
+    case H265_NAL_VPS:
+      return h265_parser_parse_vps (parser, nalu, &vps);
+      break;
+    case H265_NAL_SPS:
+      return h265_parser_parse_sps (parser, nalu, &sps, FALSE);
+      break;
+    case H265_NAL_PPS:
+      return h265_parser_parse_pps (parser, nalu, &pps);
+  }
+
+  return H265_PARSER_OK;
+}
+
+/**
+ * h265_parser_parse_vps:
+ * @parser: a #H265Parser
+ * @nalu: The #H265_NAL_VPS #H265NalUnit to parse
+ * @vps: The #H265VPS to fill.
+ *
+ * Parses @data, and fills the @vps structure.
+ *
+ * Returns: a #H265ParserResult
+ */
+H265ParserResult
+h265_parser_parse_vps (H265Parser * parser, H265NalUnit * nalu,
+    H265VPS * vps)
+{
+  H265ParserResult res = h265_parse_vps (nalu, vps);
+
+  if (res == H265_PARSER_OK) {
+    DEBUG ("adding video parameter set with id: %d to array", vps->id);
+
+    parser->vps[vps->id] = *vps;
+    parser->last_vps = &parser->vps[vps->id];
+  }
+
+  return res;
+}
+
+/**
+ * h265_parse_vps:
+ * @nalu: The #H265_NAL_VPS #H265NalUnit to parse
+ * @sps: The #H265VPS to fill.
+ *
+ * Parses @data, and fills the @vps structure.
+ *
+ * Returns: a #H265ParserResult
+ */
+H265ParserResult
+h265_parse_vps (H265NalUnit * nalu, H265VPS * vps)
+{
+  NalReader nr;
+  uint32_t i, j;
+
+  DEBUG ("parsing VPS");
+
+  nal_reader_init (&nr, nalu->data + nalu->offset + nalu->header_bytes,
+      nalu->size - nalu->header_bytes);
+
+  memset (&vps->profile_tier_level, 0, sizeof (vps->profile_tier_level));
+  memset (&vps->hrd_params, 0, sizeof (vps->hrd_params));
+  vps->cprms_present_flag = 1;
+
+  NAL_READ_UINT8 (&nr, vps->id, 4);
+
+  /* skip reserved_three_2bits */
+  if (!nal_reader_skip (&nr, 2))
+    goto error;
+
+  NAL_READ_UINT8 (&nr, vps->max_layers_minus1, 6);
+  NAL_READ_UINT8 (&nr, vps->max_sub_layers_minus1, 3);
+  NAL_READ_UINT8 (&nr, vps->temporal_id_nesting_flag, 1);
+
+  /* skip reserved_0xffff_16bits */
+  if (!nal_reader_skip (&nr, 16))
+    goto error;
+
+  if (!h265_parse_profile_tier_level (&vps->profile_tier_level, &nr,
+          vps->max_sub_layers_minus1))
+    goto error;
+
+  NAL_READ_UINT8 (&nr, vps->sub_layer_ordering_info_present_flag, 1);
+
+  for (i =
+      (vps->sub_layer_ordering_info_present_flag ? 0 :
+          vps->max_sub_layers_minus1); i <= vps->max_sub_layers_minus1; i++) {
+    NAL_READ_UE_ALLOWED (&nr, vps->max_dec_pic_buffering_minus1[i], 0, G_MAXUINT32 - 1);
+    NAL_READ_UE_ALLOWED (&nr, vps->max_num_reorder_pics[i], 0, vps->max_dec_pic_buffering_minus1[i]);
+    NAL_READ_UE_ALLOWED (&nr, vps->max_latency_increase_plus1[i], 0, G_MAXUINT32 - 1);
+  }
+  /* setting default values if vps->sub_layer_ordering_info_present_flag is zero */
+  if (!vps->sub_layer_ordering_info_present_flag && vps->max_sub_layers_minus1) {
+    for (i = 0; i <= (vps->max_sub_layers_minus1 - 1); i++) {
+      vps->max_dec_pic_buffering_minus1[i] =
+          vps->max_dec_pic_buffering_minus1[vps->max_sub_layers_minus1];
+      vps->max_num_reorder_pics[i] =
+          vps->max_num_reorder_pics[vps->max_sub_layers_minus1];
+      vps->max_latency_increase_plus1[i] =
+          vps->max_latency_increase_plus1[vps->max_sub_layers_minus1];
+    }
+  }
+
+  NAL_READ_UINT8 (&nr, vps->max_layer_id, 6);
+  CHECK_ALLOWED_MAX (vps->max_layer_id, 0);
+
+  NAL_READ_UE_ALLOWED (&nr, vps->num_layer_sets_minus1, 0, 1023);
+  CHECK_ALLOWED_MAX (vps->num_layer_sets_minus1, 0);
+
+  for (i = 1; i <= vps->num_layer_sets_minus1; i++)
+    for (j = 0; j <= vps->max_layer_id; j++)
+      nal_reader_skip (&nr, 1);
+
+  NAL_READ_UINT8 (&nr, vps->timing_info_present_flag, 1);
+
+  if (vps->timing_info_present_flag) {
+    NAL_READ_UINT32 (&nr, vps->num_units_in_tick, 32);
+    NAL_READ_UINT32 (&nr, vps->time_scale, 32);
+    NAL_READ_UINT8 (&nr, vps->poc_proportional_to_timing_flag, 1);
+
+    if (vps->poc_proportional_to_timing_flag)
+      NAL_READ_UE_ALLOWED (&nr, vps->num_ticks_poc_diff_one_minus1, 0, G_MAXUINT32 - 1);
+
+    NAL_READ_UE_ALLOWED (&nr, vps->num_hrd_parameters, 0, 1024);
+    CHECK_ALLOWED_MAX (vps->num_hrd_parameters, 1);
+
+    if (vps->num_hrd_parameters) {
+      NAL_READ_UE_ALLOWED (&nr, vps->hrd_layer_set_idx, 0, 1023);
+      CHECK_ALLOWED_MAX (vps->hrd_layer_set_idx, 0);
+
+      if (!h265_parse_hrd_parameters (&vps->hrd_params, &nr,
+              vps->cprms_present_flag, vps->max_sub_layers_minus1))
+        goto error;
+    }
+  }
+  NAL_READ_UINT8 (&nr, vps->vps_extension, 1);
+  vps->valid = TRUE;
+
+  return H265_PARSER_OK;
+
+error:
+  WARNING ("error parsing \"Video parameter set\"");
+  vps->valid = FALSE;
+  return H265_PARSER_ERROR;
+}
+
+/**
+ * h265_parser_parse_sps:
+ * @parser: a #H265Parser
+ * @nalu: The #H265_NAL_SPS #H265NalUnit to parse
+ * @sps: The #H265SPS to fill.
+ * @parse_vui_params: Whether to parse the vui_params or not
+ *
+ * Parses @data, and fills the @sps structure.
+ *
+ * Returns: a #H265ParserResult
+ */
+H265ParserResult
+h265_parser_parse_sps (H265Parser * parser, H265NalUnit * nalu,
+    H265SPS * sps, BOOL parse_vui_params)
+{
+  H265ParserResult res =
+      h265_parse_sps (parser, nalu, sps, parse_vui_params);
+
+  if (res == H265_PARSER_OK) {
+    DEBUG ("adding sequence parameter set with id: %d to array", sps->id);
+
+    parser->sps[sps->id] = *sps;
+    parser->last_sps = &parser->sps[sps->id];
+  }
+
+  return res;
+}
+
+/**
+ * h265_parse_sps:
+ * parser: The #H265Parser
+ * @nalu: The #H265_NAL_SPS #H265NalUnit to parse
+ * @sps: The #H265SPS to fill.
+ * @parse_vui_params: Whether to parse the vui_params or not
+ *
+ * Parses @data, and fills the @sps structure.
+ *
+ * Returns: a #H265ParserResult
+ */
+H265ParserResult
+h265_parse_sps (H265Parser * parser, H265NalUnit * nalu,
+    H265SPS * sps, BOOL parse_vui_params)
+{
+  NalReader nr;
+  H265VPS *vps;
+  uint8_t vps_id;
+  uint32_t i;
+  uint32_t subwc[] = { 1, 2, 2, 1, 1 };
+  uint32_t subhc[] = { 1, 2, 1, 1, 1 };
+  H265VUIParams *vui = NULL;
+
+  DEBUG ("parsing SPS");
+
+  nal_reader_init (&nr, nalu->data + nalu->offset + nalu->header_bytes,
+      nalu->size - nalu->header_bytes);
+
+  /* set default values for fields that might not be present in the bitstream
+     and have valid defaults */
+  memset (&sps->profile_tier_level, 0, sizeof (sps->profile_tier_level));
+  memset (sps->short_term_ref_pic_set, 0, sizeof (sps->short_term_ref_pic_set));
+  sps->scaling_list_data_present_flag = 0;
+  sps->separate_colour_plane_flag = 0;
+  sps->conf_win_left_offset = 0;
+  sps->conf_win_right_offset = 0;
+  sps->conf_win_top_offset = 0;
+  sps->conf_win_bottom_offset = 0;
+  sps->pcm_loop_filter_disabled_flag = 0;
+
+  NAL_READ_UINT8 (&nr, vps_id, 4);
+  vps = h265_parser_get_vps (parser, vps_id);
+  if (!vps) {
+    DEBUG ("couldn't find associated video parameter set with id: %d",
+        vps_id);
+  }
+  sps->vps = vps;
+
+  NAL_READ_UINT8 (&nr, sps->max_sub_layers_minus1, 3);
+  NAL_READ_UINT8 (&nr, sps->temporal_id_nesting_flag, 1);
+
+  if (!h265_parse_profile_tier_level (&sps->profile_tier_level, &nr,
+          sps->max_sub_layers_minus1))
+    goto error;
+
+  NAL_READ_UE_ALLOWED (&nr, sps->id, 0, H265_MAX_SPS_COUNT - 1);
+
+  NAL_READ_UE_ALLOWED (&nr, sps->chroma_format_idc, 0, 3);
+  if (sps->chroma_format_idc == 3)
+    NAL_READ_UINT8 (&nr, sps->separate_colour_plane_flag, 1);
+
+  READ_UE_ALLOWED (&nr, sps->pic_width_in_luma_samples, 1, 16888);
+  READ_UE_ALLOWED (&nr, sps->pic_height_in_luma_samples, 1, 16888);
+
+  NAL_READ_UINT8 (&nr, sps->conformance_window_flag, 1);
+  if (sps->conformance_window_flag) {
+    NAL_READ_UE (&nr, sps->conf_win_left_offset);
+    NAL_READ_UE (&nr, sps->conf_win_right_offset);
+    NAL_READ_UE (&nr, sps->conf_win_top_offset);
+    NAL_READ_UE (&nr, sps->conf_win_bottom_offset);
+  }
+
+  NAL_READ_UE_ALLOWED (&nr, sps->bit_depth_luma_minus8, 0, 6);
+  NAL_READ_UE_ALLOWED (&nr, sps->bit_depth_chroma_minus8, 0, 6);
+  NAL_READ_UE_ALLOWED (&nr, sps->log2_max_pic_order_cnt_lsb_minus4, 0, 12);
+
+  NAL_READ_UINT8 (&nr, sps->sub_layer_ordering_info_present_flag, 1);
+  for (i =
+      (sps->sub_layer_ordering_info_present_flag ? 0 :
+          sps->max_sub_layers_minus1); i <= sps->max_sub_layers_minus1; i++) {
+    NAL_READ_UE_ALLOWED (&nr, sps->max_dec_pic_buffering_minus1[i], 0, 16);
+    NAL_READ_UE_ALLOWED (&nr, sps->max_num_reorder_pics[i], 0,
+        sps->max_dec_pic_buffering_minus1[i]);
+    NAL_READ_UE_ALLOWED (&nr, sps->max_latency_increase_plus1[i], 0, G_MAXUINT32 - 1);
+  }
+  /* setting default values if sps->sub_layer_ordering_info_present_flag is zero */
+  if (!sps->sub_layer_ordering_info_present_flag && sps->max_sub_layers_minus1) {
+    for (i = 0; i <= (sps->max_sub_layers_minus1 - 1); i++) {
+      sps->max_dec_pic_buffering_minus1[i] =
+          sps->max_dec_pic_buffering_minus1[sps->max_sub_layers_minus1];
+      sps->max_num_reorder_pics[i] =
+          sps->max_num_reorder_pics[sps->max_sub_layers_minus1];
+      sps->max_latency_increase_plus1[i] =
+          sps->max_latency_increase_plus1[sps->max_sub_layers_minus1];
+    }
+  }
+
+  /* The limits are calculted based on the profile_tier_level constraint
+   * in Annex-A: CtbLog2SizeY = 4 to 6 */
+  NAL_READ_UE_ALLOWED (&nr, sps->log2_min_luma_coding_block_size_minus3, 0, 3);
+  NAL_READ_UE_ALLOWED (&nr, sps->log2_diff_max_min_luma_coding_block_size, 0, 6);
+  NAL_READ_UE_ALLOWED (&nr, sps->log2_min_transform_block_size_minus2, 0, 3);
+  NAL_READ_UE_ALLOWED (&nr, sps->log2_diff_max_min_transform_block_size, 0, 3);
+  NAL_READ_UE_ALLOWED (&nr, sps->max_transform_hierarchy_depth_inter, 0, 4);
+  NAL_READ_UE_ALLOWED (&nr, sps->max_transform_hierarchy_depth_intra, 0, 4);
+
+  NAL_READ_UINT8 (&nr, sps->scaling_list_enabled_flag, 1);
+  if (sps->scaling_list_enabled_flag) {
+    NAL_READ_UINT8 (&nr, sps->scaling_list_data_present_flag, 1);
+
+    if (sps->scaling_list_data_present_flag)
+      if (!h265_parser_parse_scaling_lists (&nr, &sps->scaling_list, FALSE))
+        goto error;
+  }
+
+  NAL_READ_UINT8 (&nr, sps->amp_enabled_flag, 1);
+  NAL_READ_UINT8 (&nr, sps->sample_adaptive_offset_enabled_flag, 1);
+  NAL_READ_UINT8 (&nr, sps->pcm_enabled_flag, 1);
+
+  if (sps->pcm_enabled_flag) {
+    NAL_READ_UINT8 (&nr, sps->pcm_sample_bit_depth_luma_minus1, 4);
+    NAL_READ_UINT8 (&nr, sps->pcm_sample_bit_depth_chroma_minus1, 4);
+    NAL_READ_UE_ALLOWED (&nr, sps->log2_min_pcm_luma_coding_block_size_minus3, 0, 2);
+    NAL_READ_UE_ALLOWED (&nr, sps->log2_diff_max_min_pcm_luma_coding_block_size, 0, 2);
+    NAL_READ_UINT8 (&nr, sps->pcm_loop_filter_disabled_flag, 1);
+  }
+
+  NAL_READ_UE_ALLOWED (&nr, sps->num_short_term_ref_pic_sets, 0, 64);
+  for (i = 0; i < sps->num_short_term_ref_pic_sets; i++)
+    if (!h265_parser_parse_short_term_ref_pic_sets
+        (&sps->short_term_ref_pic_set[i], &nr, i, sps))
+      goto error;
+
+  NAL_READ_UINT8 (&nr, sps->long_term_ref_pics_present_flag, 1);
+  if (sps->long_term_ref_pics_present_flag) {
+    NAL_READ_UE_ALLOWED (&nr, sps->num_long_term_ref_pics_sps, 0, 32);
+    for (i = 0; i < sps->num_long_term_ref_pics_sps; i++) {
+      NAL_READ_UINT16 (&nr, sps->lt_ref_pic_poc_lsb_sps[i],
+          sps->log2_max_pic_order_cnt_lsb_minus4 + 4);
+      NAL_READ_UINT8 (&nr, sps->used_by_curr_pic_lt_sps_flag[i], 1);
+    }
+  }
+
+  NAL_READ_UINT8 (&nr, sps->temporal_mvp_enabled_flag, 1);
+  NAL_READ_UINT8 (&nr, sps->strong_intra_smoothing_enabled_flag, 1);
+  NAL_READ_UINT8 (&nr, sps->vui_parameters_present_flag, 1);
+
+  if (sps->vui_parameters_present_flag && parse_vui_params) {
+    if (!h265_parse_vui_parameters (sps, &nr))
+      goto error;
+    vui = &sps->vui_params;
+  }
+
+  NAL_READ_UINT8 (&nr, sps->sps_extension_flag, 1);
+
+  /* calculate ChromaArrayType */
+  if (sps->separate_colour_plane_flag)
+    sps->chroma_array_type = 0;
+  else
+    sps->chroma_array_type = sps->chroma_format_idc;
+
+  /* Calculate  width and height */
+  sps->width = sps->pic_width_in_luma_samples;
+  sps->height = sps->pic_height_in_luma_samples;
+  if (sps->width < 0 || sps->height < 0) {
+    WARNING ("invalid width/height in SPS");
+    goto error;
+  }
+
+  if (sps->conformance_window_flag) {
+    const uint32_t crop_unit_x = subwc[sps->chroma_format_idc];
+    const uint32_t crop_unit_y = subhc[sps->chroma_format_idc];
+
+    sps->crop_rect_width = sps->width -
+        (sps->conf_win_left_offset + sps->conf_win_right_offset) * crop_unit_x;
+    sps->crop_rect_height = sps->height -
+        (sps->conf_win_top_offset + sps->conf_win_bottom_offset) * crop_unit_y;
+    sps->crop_rect_x = sps->conf_win_left_offset * crop_unit_x;
+    sps->crop_rect_y = sps->conf_win_top_offset * crop_unit_y;
+
+    INFO ("crop_rectangle x=%u y=%u width=%u, height=%u", sps->crop_rect_x,
+        sps->crop_rect_y, sps->crop_rect_width, sps->crop_rect_height);
+  }
+
+  sps->fps_num = 0;
+  sps->fps_den = 1;
+
+  if (vui && vui->timing_info_present_flag) {
+    /* derive framerate for progressive stream if the pic_struct
+     * syntax element is not present in picture timing SEI messages */
+    /* Fixme: handle other cases also */
+    if (parse_vui_params && vui->timing_info_present_flag
+        && !vui->field_seq_flag && !vui->frame_field_info_present_flag) {
+      sps->fps_num = vui->time_scale;
+      sps->fps_den = vui->num_units_in_tick;
+      INFO ("framerate %d/%d", sps->fps_num, sps->fps_den);
+    }
+  } else {
+    INFO ("No VUI, unknown framerate");
+  }
+
+  sps->valid = TRUE;
+
+  return H265_PARSER_OK;
+
+error:
+  WARNING ("error parsing \"Sequence parameter set\"");
+  sps->valid = FALSE;
+  return H265_PARSER_ERROR;
+}
+
+/**
+ * h265_parse_pps:
+ * @parser: a #H265Parser
+ * @nalu: The #H265_NAL_PPS #H265NalUnit to parse
+ * @pps: The #H265PPS to fill.
+ *
+ * Parses @data, and fills the @pps structure.
+ *
+ * Returns: a #H265ParserResult
+ */
+H265ParserResult
+h265_parse_pps (H265Parser * parser, H265NalUnit * nalu,
+    H265PPS * pps)
+{
+  NalReader nr;
+  H265SPS *sps;
+  int32_t sps_id;
+  int32_t qp_bd_offset;
+  uint8_t i;
+
+  DEBUG ("parsing PPS");
+
+  nal_reader_init (&nr, nalu->data + nalu->offset + nalu->header_bytes,
+      nalu->size - nalu->header_bytes);
+
+  NAL_READ_UE_ALLOWED (&nr, pps->id, 0, H265_MAX_PPS_COUNT - 1);
+  NAL_READ_UE_ALLOWED (&nr, sps_id, 0, H265_MAX_SPS_COUNT - 1);
+
+  sps = h265_parser_get_sps (parser, sps_id);
+  if (!sps) {
+    WARNING ("couldn't find associated sequence parameter set with id: %d",
+        sps_id);
+    return H265_PARSER_BROKEN_LINK;
+  }
+  pps->sps = sps;
+  qp_bd_offset = 6 * sps->bit_depth_luma_minus8;
+
+  /* set default values for fields that might not be present in the bitstream
+     and have valid defaults */
+  pps->diff_cu_qp_delta_depth = 0;
+  pps->num_tile_columns_minus1 = 0;
+  pps->num_tile_rows_minus1 = 0;
+  pps->uniform_spacing_flag = 1;
+  pps->loop_filter_across_tiles_enabled_flag = 1;
+  pps->deblocking_filter_override_enabled_flag = 0;
+  pps->deblocking_filter_disabled_flag = 0;
+  pps->beta_offset_div2 = 0;
+  pps->tc_offset_div2 = 0;
+
+  NAL_READ_UINT8 (&nr, pps->dependent_slice_segments_enabled_flag, 1);
+  NAL_READ_UINT8 (&nr, pps->output_flag_present_flag, 1);
+  NAL_READ_UINT8 (&nr, pps->num_extra_slice_header_bits, 3);
+  NAL_READ_UINT8 (&nr, pps->sign_data_hiding_enabled_flag, 1);
+  NAL_READ_UINT8 (&nr, pps->cabac_init_present_flag, 1);
+
+  NAL_READ_UE_ALLOWED (&nr, pps->num_ref_idx_l0_default_active_minus1, 0, 14);
+  NAL_READ_UE_ALLOWED (&nr, pps->num_ref_idx_l1_default_active_minus1, 0, 14);
+  NAL_READ_SE_ALLOWED (&nr, pps->init_qp_minus26, -(26 + qp_bd_offset), 25);
+
+  NAL_READ_UINT8 (&nr, pps->constrained_intra_pred_flag, 1);
+  NAL_READ_UINT8 (&nr, pps->transform_skip_enabled_flag, 1);
+
+  NAL_READ_UINT8 (&nr, pps->cu_qp_delta_enabled_flag, 1);
+  if (pps->cu_qp_delta_enabled_flag)
+    NAL_READ_UE_ALLOWED (&nr, pps->diff_cu_qp_delta_depth, 0,
+        sps->log2_diff_max_min_luma_coding_block_size);
+
+  NAL_READ_SE_ALLOWED (&nr, pps->cb_qp_offset, -12, 12);
+  NAL_READ_SE_ALLOWED (&nr, pps->cr_qp_offset, -12, 12);
+
+  NAL_READ_UINT8 (&nr, pps->slice_chroma_qp_offsets_present_flag, 1);
+  NAL_READ_UINT8 (&nr, pps->weighted_pred_flag, 1);
+  NAL_READ_UINT8 (&nr, pps->weighted_bipred_flag, 1);
+  NAL_READ_UINT8 (&nr, pps->transquant_bypass_enabled_flag, 1);
+  NAL_READ_UINT8 (&nr, pps->tiles_enabled_flag, 1);
+  NAL_READ_UINT8 (&nr, pps->entropy_coding_sync_enabled_flag, 1);
+
+  if (pps->tiles_enabled_flag) {
+    READ_UE_ALLOWED (&nr, pps->num_tile_columns_minus1, 1, 19);
+    READ_UE_ALLOWED (&nr, pps->num_tile_rows_minus1, 1, 21);
+
+    NAL_READ_UINT8 (&nr, pps->uniform_spacing_flag, 1);
+    if (!pps->uniform_spacing_flag) {
+      for (i = 0; i < pps->num_tile_columns_minus1; i++)
+        NAL_READ_UE (&nr, pps->column_width_minus1[i]);
+
+      for (i = 0; i < pps->num_tile_rows_minus1; i++)
+        NAL_READ_UE (&nr, pps->row_height_minus1[i]);
+    }
+    NAL_READ_UINT8 (&nr, pps->loop_filter_across_tiles_enabled_flag, 1);
+  }
+
+  NAL_READ_UINT8 (&nr, pps->loop_filter_across_slices_enabled_flag, 1);
+
+  NAL_READ_UINT8 (&nr, pps->deblocking_filter_control_present_flag, 1);
+  if (pps->deblocking_filter_control_present_flag) {
+    NAL_READ_UINT8 (&nr, pps->deblocking_filter_override_enabled_flag, 1);
+
+    NAL_READ_UINT8 (&nr, pps->deblocking_filter_disabled_flag, 1);
+    if (!pps->deblocking_filter_disabled_flag) {
+      NAL_READ_SE_ALLOWED (&nr, pps->beta_offset_div2, -6, 6);
+      NAL_READ_SE_ALLOWED (&nr, pps->tc_offset_div2, -6, +6);
+    }
+  }
+
+  NAL_READ_UINT8 (&nr, pps->scaling_list_data_present_flag, 1);
+  if (pps->scaling_list_data_present_flag)
+    if (!h265_parser_parse_scaling_lists (&nr, &pps->scaling_list, FALSE))
+      goto error;
+  if (sps->scaling_list_enabled_flag && !sps->scaling_list_data_present_flag
+      && !pps->scaling_list_data_present_flag)
+    if (!h265_parser_parse_scaling_lists (&nr, &pps->scaling_list, TRUE))
+      goto error;
+
+  NAL_READ_UINT8 (&nr, pps->lists_modification_present_flag, 1);
+  NAL_READ_UE_ALLOWED (&nr, pps->log2_parallel_merge_level_minus2, 0, 4);
+  NAL_READ_UINT8 (&nr, pps->slice_segment_header_extension_present_flag, 1);
+  NAL_READ_UINT8 (&nr, pps->pps_extension_flag, 1);
+
+  pps->valid = TRUE;
+  return H265_PARSER_OK;
+
+error:
+  WARNING ("error parsing \"Picture parameter set\"");
+  pps->valid = FALSE;
+  return H265_PARSER_ERROR;
+}
+
+/**
+ * h265_parser_parse_pps:
+ * @parser: a #H265Parser
+ * @nalu: The #H265_NAL_PPS #H265NalUnit to parse
+ * @pps: The #H265PPS to fill.
+ *
+ * Parses @data, and fills the @pps structure.
+ *
+ * Returns: a #H265ParserResult
+ */
+H265ParserResult
+h265_parser_parse_pps (H265Parser * parser,
+    H265NalUnit * nalu, H265PPS * pps)
+{
+  H265ParserResult res = h265_parse_pps (parser, nalu, pps);
+  if (res == H265_PARSER_OK) {
+    DEBUG ("adding picture parameter set with id: %d to array", pps->id);
+
+    parser->pps[pps->id] = *pps;
+    parser->last_pps = &parser->pps[pps->id];
+  }
+
+  return res;
+}
+
+/**
+ * h265_parser_parse_slice_hdr:
+ * @parser: a #H265Parser
+ * @nalu: The #H265_NAL_SLICE #H265NalUnit to parse
+ * @slice: The #H265SliceHdr to fill.
+ *
+ * Parses @data, and fills the @slice structure.
+ * The resulting @slice_hdr structure shall be deallocated with
+ * h265_slice_hdr_free() when it is no longer needed
+ *
+ * Returns: a #H265ParserResult
+ */
+H265ParserResult
+h265_parser_parse_slice_hdr (H265Parser * parser,
+    H265NalUnit * nalu, H265SliceHdr * slice)
+{
+  NalReader nr;
+  int32_t pps_id;
+  H265PPS *pps;
+  H265SPS *sps;
+  uint32_t i;
+  uint32_t CurrRpsIdx = 0;
+  H265ShortTermRefPicSet *stRPS = NULL;
+  uint32_t UsedByCurrPicLt[16];
+  uint32_t PicSizeInCtbsY;
+  uint32_t PicWidthInCtbsY;
+  uint32_t PicHeightInCtbsY;
+  uint32_t CtbSizeY;
+  uint32_t MinCbLog2SizeY;
+  uint32_t CtbLog2SizeY;
+  int32_t NumPocTotalCurr = 0;
+
+  if (!nalu->size) {
+    DEBUG ("Invalid Nal Unit");
+    return H265_PARSER_ERROR;
+  }
+
+  nal_reader_init (&nr, nalu->data + nalu->offset + nalu->header_bytes,
+      nalu->size - nalu->header_bytes);
+
+  DEBUG ("parsing \"Slice header\", slice type");
+
+  NAL_READ_UINT8 (&nr, slice->first_slice_segment_in_pic_flag, 1);
+
+  if (nalu->type >= H265_NAL_SLICE_BLA_W_LP
+      && nalu->type <= RESERVED_IRAP_NAL_TYPE_MAX)
+    NAL_READ_UINT8 (&nr, slice->no_output_of_prior_pics_flag, 1);
+
+  NAL_READ_UE_ALLOWED (&nr, pps_id, 0, H265_MAX_PPS_COUNT - 1);
+  pps = h265_parser_get_pps (parser, pps_id);
+  if (!pps) {
+    WARNING
+        ("couldn't find associated picture parameter set with id: %d", pps_id);
+    return H265_PARSER_BROKEN_LINK;
+  }
+
+  slice->pps = pps;
+  sps = pps->sps;
+  if (!sps) {
+    WARNING
+        ("couldn't find associated sequence parameter set with id: %d",
+        pps->id);
+    return H265_PARSER_BROKEN_LINK;
+  }
+
+  MinCbLog2SizeY = sps->log2_min_luma_coding_block_size_minus3 + 3;
+  CtbLog2SizeY = MinCbLog2SizeY + sps->log2_diff_max_min_luma_coding_block_size;
+  CtbSizeY = 1 << CtbLog2SizeY;
+  PicHeightInCtbsY =
+      ceil ((double) sps->pic_height_in_luma_samples / (double) CtbSizeY);
+  PicWidthInCtbsY =
+      ceil ((double) sps->pic_width_in_luma_samples / (double) CtbSizeY);
+  PicSizeInCtbsY = PicWidthInCtbsY * PicHeightInCtbsY;
+  /* set default values for fields that might not be present in the bitstream
+   * and have valid defaults */
+  slice->dependent_slice_segment_flag = 0;
+  slice->segment_address = 0;
+  slice->pic_output_flag = 1;
+  slice->pic_order_cnt_lsb = 0;
+  slice->short_term_ref_pic_set_idx = 0;
+  slice->num_long_term_sps = 0;
+  slice->num_long_term_pics = 0;
+  for (i = 0; i < 16; i++) {
+    slice->lt_idx_sps[i] = 0;
+    slice->delta_poc_msb_cycle_lt[i] = 0;
+  }
+  slice->temporal_mvp_enabled_flag = 0;
+  slice->sao_luma_flag = 0;
+  slice->sao_chroma_flag = 0;
+  slice->cabac_init_flag = 0;
+  slice->collocated_from_l0_flag = 1;
+  slice->cb_qp_offset = 0;
+  slice->cr_qp_offset = 0;
+  slice->deblocking_filter_override_flag = 0;
+  slice->deblocking_filter_disabled_flag = 0;
+  slice->beta_offset_div2 = pps->beta_offset_div2;
+  slice->tc_offset_div2 = pps->tc_offset_div2;
+  slice->loop_filter_across_slices_enabled_flag =
+      pps->loop_filter_across_slices_enabled_flag;
+  slice->num_entry_point_offsets = 0;
+  slice->entry_point_offset_minus1 = NULL;
+
+  if (!slice->first_slice_segment_in_pic_flag) {
+    const uint32_t n = ceil_log2 (PicSizeInCtbsY);
+
+    if (pps->dependent_slice_segments_enabled_flag)
+      NAL_READ_UINT8 (&nr, slice->dependent_slice_segment_flag, 1);
+    /* sice_segment_address parsing */
+    NAL_READ_UINT32 (&nr, slice->segment_address, n);
+  }
+
+  if (!slice->dependent_slice_segment_flag) {
+    for (i = 0; i < pps->num_extra_slice_header_bits; i++)
+      nal_reader_skip (&nr, 1);
+    NAL_READ_UE_ALLOWED (&nr, slice->type, 0, 63);
+
+
+    if (pps->output_flag_present_flag)
+      NAL_READ_UINT8 (&nr, slice->pic_output_flag, 1);
+    if (sps->separate_colour_plane_flag == 1)
+      NAL_READ_UINT8 (&nr, slice->colour_plane_id, 2);
+
+    if ((nalu->type != H265_NAL_SLICE_IDR_W_RADL)
+        && (nalu->type != H265_NAL_SLICE_IDR_N_LP)) {
+      NAL_READ_UINT16 (&nr, slice->pic_order_cnt_lsb,
+          (sps->log2_max_pic_order_cnt_lsb_minus4 + 4));
+
+      NAL_READ_UINT8 (&nr, slice->short_term_ref_pic_set_sps_flag, 1);
+      if (!slice->short_term_ref_pic_set_sps_flag) {
+        if (!h265_parser_parse_short_term_ref_pic_sets
+            (&slice->short_term_ref_pic_sets, &nr,
+                sps->num_short_term_ref_pic_sets, sps))
+          goto error;
+      } else if (sps->num_short_term_ref_pic_sets > 1) {
+        const uint32_t n = ceil_log2 (sps->num_short_term_ref_pic_sets);
+        NAL_READ_UINT8 (&nr, slice->short_term_ref_pic_set_idx, n);
+        CHECK_ALLOWED_MAX (slice->short_term_ref_pic_set_idx,
+            sps->num_short_term_ref_pic_sets - 1);
+      }
+
+      if (sps->long_term_ref_pics_present_flag) {
+        uint32_t limit;
+
+        if (sps->num_long_term_ref_pics_sps > 0)
+          NAL_READ_UE_ALLOWED (&nr, slice->num_long_term_sps, 0,
+              sps->num_long_term_ref_pics_sps);
+
+        NAL_READ_UE_ALLOWED (&nr, slice->num_long_term_pics, 0, 16);
+        limit = slice->num_long_term_sps + slice->num_long_term_pics;
+        for (i = 0; i < limit; i++) {
+          if (i < slice->num_long_term_sps) {
+            if (sps->num_long_term_ref_pics_sps > 1) {
+              const uint32_t n = ceil_log2 (sps->num_long_term_ref_pics_sps);
+              NAL_READ_UINT8 (&nr, slice->lt_idx_sps[i], n);
+            }
+          } else {
+            NAL_READ_UINT32 (&nr, slice->poc_lsb_lt[i],
+                (sps->log2_max_pic_order_cnt_lsb_minus4 + 4));
+            NAL_READ_UINT8 (&nr, slice->used_by_curr_pic_lt_flag[i], 1);
+          }
+
+          /* calculate UsedByCurrPicLt */
+          if (i < slice->num_long_term_sps)
+            UsedByCurrPicLt[i] =
+                sps->used_by_curr_pic_lt_sps_flag[slice->lt_idx_sps[i]];
+          else
+            UsedByCurrPicLt[i] = slice->used_by_curr_pic_lt_flag[i];
+          NAL_READ_UINT8 (&nr, slice->delta_poc_msb_present_flag[i], 1);
+          if (slice->delta_poc_msb_present_flag[i])
+            NAL_READ_UE (&nr, slice->delta_poc_msb_cycle_lt[i]);
+        }
+      }
+      if (sps->temporal_mvp_enabled_flag)
+        NAL_READ_UINT8 (&nr, slice->temporal_mvp_enabled_flag, 1);
+    }
+
+    if (sps->sample_adaptive_offset_enabled_flag) {
+      NAL_READ_UINT8 (&nr, slice->sao_luma_flag, 1);
+      NAL_READ_UINT8 (&nr, slice->sao_chroma_flag, 1);
+    }
+
+    if (H265_IS_B_SLICE (slice) || H265_IS_P_SLICE (slice)) {
+      NAL_READ_UINT8 (&nr, slice->num_ref_idx_active_override_flag, 1);
+
+      if (slice->num_ref_idx_active_override_flag) {
+        NAL_READ_UE_ALLOWED (&nr, slice->num_ref_idx_l0_active_minus1, 0, 14);
+        if (H265_IS_B_SLICE (slice))
+          NAL_READ_UE_ALLOWED (&nr, slice->num_ref_idx_l1_active_minus1, 0, 14);
+      } else {
+        /*set default values */
+        slice->num_ref_idx_l0_active_minus1 =
+            pps->num_ref_idx_l0_default_active_minus1;
+        slice->num_ref_idx_l1_active_minus1 =
+            pps->num_ref_idx_l1_default_active_minus1;
+      }
+
+      /* calculate NumPocTotalCurr */
+      if (slice->short_term_ref_pic_set_sps_flag)
+        CurrRpsIdx = slice->short_term_ref_pic_set_idx;
+      else
+        CurrRpsIdx = sps->num_short_term_ref_pic_sets;
+      stRPS = &sps->short_term_ref_pic_set[CurrRpsIdx];
+      for (i = 0; i < stRPS->NumNegativePics; i++)
+        if (stRPS->UsedByCurrPicS0[i])
+          NumPocTotalCurr++;
+      for (i = 0; i < stRPS->NumPositivePics; i++)
+        if (stRPS->UsedByCurrPicS1[i])
+          NumPocTotalCurr++;
+      for (i = 0;
+          i < (slice->num_long_term_sps + slice->num_long_term_pics); i++)
+        if (UsedByCurrPicLt[i])
+          NumPocTotalCurr++;
+      slice->NumPocTotalCurr = NumPocTotalCurr;
+
+      if (pps->lists_modification_present_flag) {
+        if (NumPocTotalCurr > 1)
+          if (!h265_slice_parse_ref_pic_list_modification (slice, &nr,
+                  NumPocTotalCurr))
+            goto error;
+      }
+
+      if (H265_IS_B_SLICE (slice))
+        NAL_READ_UINT8 (&nr, slice->mvd_l1_zero_flag, 1);
+      if (pps->cabac_init_present_flag)
+        NAL_READ_UINT8 (&nr, slice->cabac_init_flag, 1);
+      if (slice->temporal_mvp_enabled_flag) {
+        if (H265_IS_B_SLICE (slice))
+          NAL_READ_UINT8 (&nr, slice->collocated_from_l0_flag, 1);
+
+        if ((slice->collocated_from_l0_flag
+                && slice->num_ref_idx_l0_active_minus1 > 0)
+            || (!slice->collocated_from_l0_flag
+                && slice->num_ref_idx_l1_active_minus1 > 0)) {
+
+          /*fixme: add optimization */
+          if ((H265_IS_P_SLICE (slice))
+              || ((H265_IS_B_SLICE (slice))
+                  && (slice->collocated_from_l0_flag))) {
+            NAL_READ_UE_ALLOWED (&nr, slice->collocated_ref_idx, 0,
+                slice->num_ref_idx_l0_active_minus1);
+          } else if ((H265_IS_B_SLICE (slice))
+              && (!slice->collocated_from_l0_flag)) {
+            NAL_READ_UE_ALLOWED (&nr, slice->collocated_ref_idx, 0,
+                slice->num_ref_idx_l1_active_minus1);
+          }
+        }
+      }
+      if ((pps->weighted_pred_flag && H265_IS_P_SLICE (slice)) ||
+          (pps->weighted_bipred_flag && H265_IS_B_SLICE (slice)))
+        if (!h265_slice_parse_pred_weight_table (slice, &nr))
+          goto error;
+      NAL_READ_UE_ALLOWED (&nr, slice->five_minus_max_num_merge_cand, 0, 4);
+    }
+
+    NAL_READ_SE_ALLOWED (&nr, slice->qp_delta, -87, 77);
+    if (pps->slice_chroma_qp_offsets_present_flag) {
+      NAL_READ_SE_ALLOWED (&nr, slice->cb_qp_offset, -12, 12);
+      NAL_READ_SE_ALLOWED (&nr, slice->cr_qp_offset, -12, 12);
+    }
+
+    if (pps->deblocking_filter_override_enabled_flag)
+      NAL_READ_UINT8 (&nr, slice->deblocking_filter_override_flag, 1);
+    if (slice->deblocking_filter_override_flag) {
+      NAL_READ_UINT8 (&nr, slice->deblocking_filter_disabled_flag, 1);
+      if (!slice->deblocking_filter_disabled_flag) {
+        NAL_READ_SE_ALLOWED (&nr, slice->beta_offset_div2, -6, 6);
+        NAL_READ_SE_ALLOWED (&nr, slice->tc_offset_div2, -6, 6);
+      }
+    }
+
+    if (pps->loop_filter_across_slices_enabled_flag &&
+        (slice->sao_luma_flag || slice->sao_chroma_flag ||
+            !slice->deblocking_filter_disabled_flag))
+      NAL_READ_UINT8 (&nr, slice->loop_filter_across_slices_enabled_flag, 1);
+  }
+
+  if (pps->tiles_enabled_flag || pps->entropy_coding_sync_enabled_flag) {
+    uint32_t offset_max;
+
+    if (!pps->tiles_enabled_flag && pps->entropy_coding_sync_enabled_flag)
+      offset_max = PicHeightInCtbsY - 1;
+    else if (pps->tiles_enabled_flag && !pps->entropy_coding_sync_enabled_flag)
+      offset_max =
+          (pps->num_tile_columns_minus1 + 1) * (pps->num_tile_rows_minus1 + 1) -
+          1;
+    else
+      offset_max = (pps->num_tile_columns_minus1 + 1) * PicHeightInCtbsY - 1;
+
+    NAL_READ_UE_ALLOWED (&nr, slice->num_entry_point_offsets, 0, offset_max);
+    if (slice->num_entry_point_offsets > 0) {
+      NAL_READ_UE_ALLOWED (&nr, slice->offset_len_minus1, 0, 31);
+      slice->entry_point_offset_minus1 =
+          (uint32_t*)malloc(sizeof(uint32_t)*(slice->num_entry_point_offsets));
+      for (i = 0; i < slice->num_entry_point_offsets; i++)
+        NAL_READ_UINT32 (&nr, slice->entry_point_offset_minus1[i],
+            (slice->offset_len_minus1 + 1));
+    }
+  }
+
+  if (pps->slice_segment_header_extension_present_flag) {
+    uint16_t slice_segment_header_extension_length;
+    NAL_READ_UE_ALLOWED (&nr, slice_segment_header_extension_length, 0, 256);
+    for (i = 0; i < slice_segment_header_extension_length; i++)
+      if (!nal_reader_skip (&nr, 8))
+        goto error;
+  }
+
+  /* Skip the byte alignment bits */
+  if (!nal_reader_skip (&nr, 1))
+    goto error;
+  while (!nal_reader_is_byte_aligned (&nr)) {
+    if (!nal_reader_skip (&nr, 1))
+      goto error;
+  }
+
+  slice->header_size = nal_reader_get_pos (&nr);
+  slice->n_emulation_prevention_bytes = nal_reader_get_epb_count (&nr);
+
+  return H265_PARSER_OK;
+
+error:
+  WARNING ("error parsing \"Slice header\"");
+
+  h265_slice_hdr_free (slice);
+
+  return H265_PARSER_ERROR;
+}
+
+static BOOL
+nal_reader_has_more_data_in_payload (NalReader * nr,
+    uint32_t payload_start_pos_bit, uint32_t payloadSize)
+{
+  if (nal_reader_is_byte_aligned (nr) &&
+      (nal_reader_get_pos (nr) == (payload_start_pos_bit + 8 * payloadSize)))
+    return FALSE;
+
+  return TRUE;
+}
+
+static H265ParserResult
+h265_parser_parse_sei_message (H265Parser * parser,
+    uint8_t nal_type, NalReader * nr, H265SEIMessage * sei)
+{
+  uint32_t payloadSize;
+  uint8_t payload_type_byte, payload_size_byte;
+  uint32_t remaining, payload_size;
+  uint32_t payload_start_pos_bit;
+  H265ParserResult res = H265_PARSER_OK;
+
+  DEBUG ("parsing \"Sei message\"");
+
+  sei->payloadType = 0;
+  do {
+    NAL_READ_UINT8 (nr, payload_type_byte, 8);
+    sei->payloadType += payload_type_byte;
+  } while (payload_type_byte == 0xff);
+  payloadSize = 0;
+  do {
+    NAL_READ_UINT8 (nr, payload_size_byte, 8);
+    payloadSize += payload_size_byte;
+  }
+  while (payload_size_byte == 0xff);
+
+  remaining = nal_reader_get_remaining (nr);
+  payload_size = payloadSize * 8 < remaining ? payloadSize * 8 : remaining;
+
+  payload_start_pos_bit = nal_reader_get_pos (nr);
+  DEBUG
+      ("SEI message received: payloadType  %u, payloadSize = %u bytes",
+      sei->payloadType, payload_size);
+
+  if (nal_type == H265_NAL_PREFIX_SEI) {
+    switch (sei->payloadType) {
+      case H265_SEI_BUF_PERIOD:
+        /* size not set; might depend on emulation_prevention_three_byte */
+        res = h265_parser_parse_buffering_period (parser,
+            &sei->payload.buffering_period, nr);
+        break;
+      case H265_SEI_PIC_TIMING:
+        /* size not set; might depend on emulation_prevention_three_byte */
+        res = h265_parser_parse_pic_timing (parser,
+            &sei->payload.pic_timing, nr);
+        break;
+      default:
+        /* Just consume payloadSize bytes, which does not account for
+           emulation prevention bytes */
+        if (!nal_reader_skip_long (nr, payload_size))
+          goto error;
+        res = H265_PARSER_OK;
+        break;
+    }
+  } else if (nal_type == H265_NAL_SUFFIX_SEI) {
+    switch (sei->payloadType) {
+      default:
+        /* Just consume payloadSize bytes, which does not account for
+           emulation prevention bytes */
+        if (!nal_reader_skip_long (nr, payload_size))
+          goto error;
+        res = H265_PARSER_OK;
+        break;
+    }
+  }
+
+  /* Not parsing the reserved_payload_extension, but it shouldn't be
+   * an issue because of 1: There shall not be any reserved_payload_extension
+   * present in bitstreams conforming to the specification.2. Even though
+   * it is present, the size will be less than total PayloadSize since the
+   * size of reserved_payload_extension is supposed to be
+   * 8 * payloadSize - nEarlierBits - nPayloadZeroBits -1 which means the
+   * the current implementation will still skip all unnecessary bits correctly.
+   * In theory, we can have a more optimized implementation by skipping the
+   * data left in PayLoadSize without out individually checking for each bits,
+   * since the totoal size will be always less than payloadSize*/
+  if (nal_reader_has_more_data_in_payload (nr, payload_start_pos_bit,
+          payloadSize)) {
+    /* Skip the byte alignment bits */
+    if (!nal_reader_skip (nr, 1))
+      goto error;
+    while (!nal_reader_is_byte_aligned (nr)) {
+      if (!nal_reader_skip (nr, 1))
+        goto error;
+    }
+  }
+
+  return res;
+
+error:
+  WARNING ("error parsing \"Sei message\"");
+  return H265_PARSER_ERROR;
+}
+
+/**
+ * h265_slice_hdr_copy:
+ * @dst_slice: The destination #H265SliceHdr to copy into
+ * @src_slice: The source #H265SliceHdr to copy from
+ *
+ * Copies @src_slice into @dst_slice
+ *
+ * Returns: %TRUE if everything went fine, %FALSE otherwise
+ */
+BOOL
+h265_slice_hdr_copy (H265SliceHdr * dst_slice,
+    const H265SliceHdr * src_slice)
+{
+  uint32_t i;
+
+  if(!dst_slice || !src_slice)
+    return FALSE;
+
+  h265_slice_hdr_free (dst_slice);
+
+  *dst_slice = *src_slice;
+
+  if (dst_slice->num_entry_point_offsets > 0) {
+    dst_slice->entry_point_offset_minus1 =
+        (uint32_t*)malloc(sizeof(uint32_t)*(dst_slice->num_entry_point_offsets));
+    for (i = 0; i < dst_slice->num_entry_point_offsets; i++)
+      dst_slice->entry_point_offset_minus1[i] =
+          src_slice->entry_point_offset_minus1[i];
+  }
+
+  return TRUE;
+}
+
+/**
+ * h265_slice_hdr_free:
+ * slice_hdr: The #H265SliceHdr to free
+ *
+ * Frees @slice_hdr fields.
+ */
+void
+h265_slice_hdr_free (H265SliceHdr * slice_hdr)
+{
+  if(!slice_hdr)
+    return;
+
+  if (slice_hdr->num_entry_point_offsets > 0)
+    free (slice_hdr->entry_point_offset_minus1);
+  slice_hdr->entry_point_offset_minus1 = 0;
+}
+
+/**
+ * h265_sei_copy:
+ * @dst_sei: The destination #H265SEIMessage to copy into
+ * @src_sei: The source #H265SEIMessage to copy from
+ *
+ * Copies @src_sei into @dst_sei
+ *
+ * Returns: %TRUE if everything went fine, %FALSE otherwise
+ */
+BOOL
+h265_sei_copy (H265SEIMessage * dst_sei,
+    const H265SEIMessage * src_sei)
+{
+  uint32_t i;
+
+  if(!dst_sei || !src_sei)
+    return FALSE;
+
+  h265_sei_free (dst_sei);
+
+  *dst_sei = *src_sei;
+
+  if (dst_sei->payloadType == H265_SEI_PIC_TIMING) {
+    H265PicTiming *dst_pic_timing = &dst_sei->payload.pic_timing;
+    const H265PicTiming *src_pic_timing = &src_sei->payload.pic_timing;
+
+    if (dst_pic_timing->num_decoding_units_minus1 > 0) {
+      dst_pic_timing->num_nalus_in_du_minus1 =
+          (uint32_t*)malloc(sizeof(uint32_t)*(dst_pic_timing->num_decoding_units_minus1 + 1));
+      dst_pic_timing->du_cpb_removal_delay_increment_minus1 =
+          (uint8_t*)malloc(sizeof(uint8_t)*(dst_pic_timing->num_decoding_units_minus1 + 1));
+
+      for (i = 0; i <= dst_pic_timing->num_decoding_units_minus1; i++) {
+        dst_pic_timing->num_nalus_in_du_minus1[i] =
+            src_pic_timing->num_nalus_in_du_minus1[i];
+        dst_pic_timing->du_cpb_removal_delay_increment_minus1[i] =
+            src_pic_timing->du_cpb_removal_delay_increment_minus1[i];
+      }
+    }
+  }
+
+  return TRUE;
+}
+
+/**
+ * h265_sei_free:
+ * sei: The #H265SEIMessage to free
+ *
+ * Frees @sei fields.
+ */
+void
+h265_sei_free (H265SEIMessage * sei)
+{
+  if(!sei)
+    return;
+
+  if (sei->payloadType == H265_SEI_PIC_TIMING) {
+    H265PicTiming *pic_timing = &sei->payload.pic_timing;
+    if (pic_timing->num_decoding_units_minus1 > 0) {
+      free (pic_timing->num_nalus_in_du_minus1);
+      free (pic_timing->du_cpb_removal_delay_increment_minus1);
+    }
+    pic_timing->num_nalus_in_du_minus1 = 0;
+    pic_timing->du_cpb_removal_delay_increment_minus1 = 0;
+  }
+}
+
+#if 0
+/**
+ * h265_parser_parse_sei:
+ * @nalparser: a #H265Parser
+ * @nalu: The #H265_NAL_SEI #H265NalUnit to parse
+ * @messages: The GArray of #H265SEIMessage to fill. The caller must free it when done.
+ *
+ * Parses @data, create and fills the @messages array.
+ *
+ * Returns: a #H265ParserResult
+ */
+H265ParserResult
+h265_parser_parse_sei (H265Parser * nalparser, H265NalUnit * nalu,
+    GArray ** messages)
+{
+  NalReader nr;
+  H265SEIMessage sei;
+  H265ParserResult res;
+
+  DEBUG ("parsing SEI nal");
+  nal_reader_init (&nr, nalu->data + nalu->offset + nalu->header_bytes,
+      nalu->size - nalu->header_bytes);
+  *messages = g_array_new (FALSE, FALSE, sizeof (H265SEIMessage));
+  g_array_set_clear_func (*messages, (GDestroyNotify) h265_sei_free);
+
+  do {
+    res = h265_parser_parse_sei_message (nalparser, nalu->type, &nr, &sei);
+    if (res == H265_PARSER_OK)
+      g_array_append_val (*messages, sei);
+    else
+      break;
+  } while (nal_reader_has_more_data (&nr));
+
+  return res;
+}
+#endif
+
+/**
+ * h265_quant_matrix_4x4_get_zigzag_from_raster:
+ * @out_quant: (out): The resulting quantization matrix
+ * @quant: The source quantization matrix
+ *
+ * Converts quantization matrix @quant from raster scan order to
+ * zigzag scan order and store the resulting factors into @out_quant.
+ *
+ * Note: it is an error to pass the same table in both @quant and
+ * @out_quant arguments.
+ *
+ * Since: 1.6
+ */
+void
+h265_quant_matrix_4x4_get_zigzag_from_raster (uint8_t out_quant[16],
+    const uint8_t quant[16])
+{
+  uint32_t i;
+
+  if(out_quant == quant)
+    return;
+
+  for (i = 0; i < 16; i++)
+    out_quant[i] = quant[zigzag_4x4[i]];
+}
+
+/**
+ * h265_quant_matrix_4x4_get_raster_from_zigzag:
+ * @out_quant: (out): The resulting quantization matrix
+ * @quant: The source quantization matrix
+ *
+ * Converts quantization matrix @quant from zigzag scan order to
+ * raster scan order and store the resulting factors into @out_quant.
+ *
+ * Note: it is an error to pass the same table in both @quant and
+ * @out_quant arguments.
+ *
+ * Since: 1.6
+ */
+void
+h265_quant_matrix_4x4_get_raster_from_zigzag (uint8_t out_quant[16],
+    const uint8_t quant[16])
+{
+  uint32_t i;
+
+  if(out_quant == quant)
+    return;
+
+  for (i = 0; i < 16; i++)
+    out_quant[zigzag_4x4[i]] = quant[i];
+}
+
+/**
+ * h265_quant_matrix_8x8_get_zigzag_from_raster:
+ * @out_quant: (out): The resulting quantization matrix
+ * @quant: The source quantization matrix
+ *
+ * Converts quantization matrix @quant from raster scan order to
+ * zigzag scan order and store the resulting factors into @out_quant.
+ *
+ * Note: it is an error to pass the same table in both @quant and
+ * @out_quant arguments.
+ *
+ * Since: 1.6
+ */
+void
+h265_quant_matrix_8x8_get_zigzag_from_raster (uint8_t out_quant[64],
+    const uint8_t quant[64])
+{
+  uint32_t i;
+
+  if(out_quant == quant)
+    return;
+
+  for (i = 0; i < 64; i++)
+    out_quant[i] = quant[zigzag_8x8[i]];
+}
+
+/**
+ * h265_quant_matrix_8x8_get_raster_from_zigzag:
+ * @out_quant: (out): The resulting quantization matrix
+ * @quant: The source quantization matrix
+ *
+ * Converts quantization matrix @quant from zigzag scan order to
+ * raster scan order and store the resulting factors into @out_quant.
+ *
+ * Note: it is an error to pass the same table in both @quant and
+ * @out_quant arguments.
+ *
+ * Since: 1.6
+ */
+void
+h265_quant_matrix_8x8_get_raster_from_zigzag (uint8_t out_quant[64],
+    const uint8_t quant[64])
+{
+  uint32_t i;
+
+  if(out_quant == quant)
+    return;
+
+  for (i = 0; i < 64; i++)
+    out_quant[zigzag_8x8[i]] = quant[i];
+}

--- a/codecparsers/h265parser.h
+++ b/codecparsers/h265parser.h
@@ -1,0 +1,1095 @@
+/* H.265 bitstream parser
+ * Copyright (C) 2013 Intel Corporation
+ * Copyright (C) 2013 Sreerenj Balachandran <sreerenj.balachandran@intel.com>
+ *
+ * Contact: Sreerenj Balachandran <sreerenj.balachandran@intel.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __H265_PARSER_H__
+#define __H265_PARSER_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#include <stdint.h>
+#include <string.h>
+#include "common/common_def.h"
+
+#define H265_MAX_SUB_LAYERS   8
+#define H265_MAX_VPS_COUNT   16
+#define H265_MAX_SPS_COUNT   16
+#define H265_MAX_PPS_COUNT   64
+
+#define H265_IS_B_SLICE(slice)  ((slice)->type == H265_B_SLICE)
+#define H265_IS_P_SLICE(slice)  ((slice)->type == H265_P_SLICE)
+#define H265_IS_I_SLICE(slice)  ((slice)->type == H265_I_SLICE)
+
+#ifndef G_MAXUINT32 //lyb add ------
+    typedef unsigned int guint32;
+    #define G_MAXUINT32	((guint32)0xffffffff)
+#endif //add end
+
+/**
+ * H265Profile:
+ * @H265_PROFILE_MAIN: Main profile (A.3.2)
+ * @H265_PROFILE_MAIN_10: Main 10 profile (A.3.3)
+ * @H265_PROFILE_MAIN_STILL_PICTURE: Main Still Picture profile (A.3.4)
+ *
+ * H.265 Profiles.
+ *
+ */
+typedef enum {
+  H265_PROFILE_MAIN                 = 1,
+  H265_PROFILE_MAIN_10              = 2,
+  H265_PROFILE_MAIN_STILL_PICTURE   = 3
+} H265Profile;
+
+/**
+ * H265NalUnitType:
+ * @H265_NAL_SLICE_TRAIL_N: Slice nal of a non-TSA, non-STSA trailing picture
+ * @H265_NAL_SLICE_TRAIL_R: Slice nal of a non-TSA, non-STSA trailing picture
+ * @H265_NAL_SLICE_TSA_N: Slice nal of a TSA picture
+ * @H265_NAL_SLICE_TSA_R: Slice nal of a TSA picture
+ * @H265_NAL_SLICE_STSA_N: Slice nal of a STSA picture
+ * @H265_NAL_SLICE_STSA_R: Slice nal of a STSA picture
+ * @H265_NAL_SLICE_RADL_N: Slice nal of a RADL picture
+ * @H265_NAL_SLICE_RADL_R: Slice nal of a RADL piicture
+ * @H265_NAL_SLICE_RASL_N: Slice nal of a RASL picture
+ * @H265_NAL_SLICE_RASL_R: Slice nal of a RASL picture
+ * @H265_NAL_SLICE_BLA_W_LP: Slice nal of a BLA picture
+ * @H265_NAL_SLICE_BLA_W_RADL: Slice nal of a BLA picture
+ * @H265_NAL_SLICE_BLA_N_LP: Slice nal of a BLA picture
+ * @H265_NAL_SLICE_IDR_W_RADL: Slice nal of an IDR picture
+ * @H265_NAL_SLICE_IDR_N_LP: Slice nal of an IDR picture
+ * @H265_NAL_SLICE_CRA_NUT: Slice nal of a CRA picture
+ * @H265_NAL_VPS: Video parameter set(VPS) nal unit
+ * @H265_NAL_SPS: Sequence parameter set (SPS) nal unit
+ * @H265_NAL_PPS: Picture parameter set (PPS) nal unit
+ * @H265_NAL_AUD: Access unit (AU) delimiter nal unit
+ * @H265_NAL_EOS: End of sequence (EOS) nal unit
+ * @H265_NAL_EOB: End of bitstream (EOB) nal unit
+ * @H265_NAL_FD: Filler data (FD) nal lunit
+ * @H265_NAL_PREFIX_SEI: Supplemental enhancement information prefix nal unit
+ * @H265_NAL_SUFFIX_SEI: Suppliemental enhancement information suffix nal unit
+ *
+ * Indicates the type of H265 Nal Units
+ */
+typedef enum
+{
+  H265_NAL_SLICE_TRAIL_N    = 0,
+  H265_NAL_SLICE_TRAIL_R    = 1,
+  H265_NAL_SLICE_TSA_N      = 2,
+  H265_NAL_SLICE_TSA_R      = 3,
+  H265_NAL_SLICE_STSA_N     = 4,
+  H265_NAL_SLICE_STSA_R     = 5,
+  H265_NAL_SLICE_RADL_N     = 6,
+  H265_NAL_SLICE_RADL_R     = 7,
+  H265_NAL_SLICE_RASL_N     = 8,
+  H265_NAL_SLICE_RASL_R     = 9,
+  H265_NAL_SLICE_BLA_W_LP   = 16,
+  H265_NAL_SLICE_BLA_W_RADL = 17,
+  H265_NAL_SLICE_BLA_N_LP   = 18,
+  H265_NAL_SLICE_IDR_W_RADL = 19,
+  H265_NAL_SLICE_IDR_N_LP   = 20,
+  H265_NAL_SLICE_CRA_NUT    = 21,
+  H265_NAL_VPS              = 32,
+  H265_NAL_SPS              = 33,
+  H265_NAL_PPS              = 34,
+  H265_NAL_AUD              = 35,
+  H265_NAL_EOS              = 36,
+  H265_NAL_EOB              = 37,
+  H265_NAL_FD               = 38,
+  H265_NAL_PREFIX_SEI       = 39,
+  H265_NAL_SUFFIX_SEI       = 40
+} H265NalUnitType;
+
+#define RESERVED_NON_IRAP_SUBLAYER_NAL_TYPE_MIN 10
+#define RESERVED_NON_IRAP_SUBLAYER_NAL_TYPE_MAX 15
+
+#define RESERVED_IRAP_NAL_TYPE_MIN 22
+#define RESERVED_IRAP_NAL_TYPE_MAX 23
+
+#define RESERVED_NON_IRAP_NAL_TYPE_MIN 24
+#define RESERVED_NON_IRAP_NAL_TYPE_MAX 31
+
+#define RESERVED_NON_VCL_NAL_TYPE_MIN 41
+#define RESERVED_NON_VCL_NAL_TYPE_MAX 47
+
+#define UNSPECIFIED_NON_VCL_NAL_TYPE_MIN 48
+#define UNSPECIFIED_NON_VCL_NAL_TYPE_MAX 63
+
+/**
+ * H265ParserResult:
+ * @H265_PARSER_OK: The parsing succeded
+ * @H265_PARSER_BROKEN_DATA: The data to parse is broken
+ * @H265_PARSER_BROKEN_LINK: The link to structure needed for the parsing couldn't be found
+ * @H265_PARSER_ERROR: An error accured when parsing
+ * @H265_PARSER_NO_NAL: No nal found during the parsing
+ * @H265_PARSER_NO_NAL_END: Start of the nal found, but not the end.
+ *
+ * The result of parsing H265 data.
+ */
+typedef enum
+{
+  H265_PARSER_OK,
+  H265_PARSER_BROKEN_DATA,
+  H265_PARSER_BROKEN_LINK,
+  H265_PARSER_ERROR,
+  H265_PARSER_NO_NAL,
+  H265_PARSER_NO_NAL_END
+} H265ParserResult;
+
+/**
+ * H265SEIPayloadType:
+ * @H265_SEI_BUF_PERIOD: Buffering Period SEI Message
+ * @H265_SEI_PIC_TIMING: Picture Timing SEI Message
+ * ...
+ *
+ * The type of SEI message.
+ */
+typedef enum
+{
+  H265_SEI_BUF_PERIOD = 0,
+  H265_SEI_PIC_TIMING = 1
+      /* and more...  */
+} H265SEIPayloadType;
+
+/**
+ * H265SEIPicStructType:
+ * @H265_SEI_PIC_STRUCT_FRAME: Picture is a frame
+ * @H265_SEI_PIC_STRUCT_TOP_FIELD: Top field of frame
+ * @H265_SEI_PIC_STRUCT_BOTTOM_FIELD: Botom field of frame
+ * @H265_SEI_PIC_STRUCT_TOP_BOTTOM: Top bottom field of frame
+ * @H265_SEI_PIC_STRUCT_BOTTOM_TOP: bottom top field of frame
+ * @H265_SEI_PIC_STRUCT_TOP_BOTTOM_TOP: top bottom top field of frame
+ * @H265_SEI_PIC_STRUCT_BOTTOM_TOP_BOTTOM: bottom top bottom field of frame
+ * @H265_SEI_PIC_STRUCT_FRAME_DOUBLING: indicates that the frame should
+ *  be displayed two times consecutively
+ * @H265_SEI_PIC_STRUCT_FRAME_TRIPLING: indicates that the frame should be
+ *  displayed three times consecutively
+ * @H265_SEI_PIC_STRUCT_TOP_PAIRED_PREVIOUS_BOTTOM: top field paired with
+ *  previous bottom field in output order
+ * @H265_SEI_PIC_STRUCT_BOTTOM_PAIRED_PREVIOUS_TOP: bottom field paried with
+ *  previous top field in output order
+ * @H265_SEI_PIC_STRUCT_TOP_PAIRED_NEXT_BOTTOM: top field paired with next
+ *  bottom field in output order
+ * @H265_SEI_PIC_STRUCT_BOTTOM_PAIRED_NEXT_TOP: bottom field paired with
+ *  next top field in output order
+ *
+ * SEI pic_struct type
+ */
+typedef enum
+{
+  H265_SEI_PIC_STRUCT_FRAME                         = 0,
+  H265_SEI_PIC_STRUCT_TOP_FIELD                     = 1,
+  H265_SEI_PIC_STRUCT_BOTTOM_FIELD                  = 2,
+  H265_SEI_PIC_STRUCT_TOP_BOTTOM                    = 3,
+  H265_SEI_PIC_STRUCT_BOTTOM_TOP                    = 4,
+  H265_SEI_PIC_STRUCT_TOP_BOTTOM_TOP                = 5,
+  H265_SEI_PIC_STRUCT_BOTTOM_TOP_BOTTOM             = 6,
+  H265_SEI_PIC_STRUCT_FRAME_DOUBLING                = 7,
+  H265_SEI_PIC_STRUCT_FRAME_TRIPLING                = 8,
+  H265_SEI_PIC_STRUCT_TOP_PAIRED_PREVIOUS_BOTTOM    = 9,
+  H265_SEI_PIC_STRUCT_BOTTOM_PAIRED_PREVIOUS_TOP    = 10,
+  H265_SEI_PIC_STRUCT_TOP_PAIRED_NEXT_BOTTOM        = 11,
+  H265_SEI_PIC_STRUCT_BOTTOM_PAIRED_NEXT_TOP        = 12
+} H265SEIPicStructType;
+
+/**
+ * H265SliceType:
+ *
+ * Type of Picture slice
+ */
+
+typedef enum
+{
+  H265_B_SLICE    = 0,
+  H265_P_SLICE    = 1,
+  H265_I_SLICE    = 2
+} H265SliceType;
+
+typedef enum
+{
+  H265_QUANT_MATIX_4X4   = 0,
+  H265_QUANT_MATIX_8X8   = 1,
+  H265_QUANT_MATIX_16X16 = 2,
+  H265_QUANT_MATIX_32X32 = 3
+} H265QuantMatrixSize;
+
+typedef struct _H265Parser                   H265Parser;
+
+typedef struct _H265NalUnit                  H265NalUnit;
+
+typedef struct _H265VPS                      H265VPS;
+typedef struct _H265SPS                      H265SPS;
+typedef struct _H265PPS                      H265PPS;
+typedef struct _H265ProfileTierLevel         H265ProfileTierLevel;
+typedef struct _H265SubLayerHRDParams        H265SubLayerHRDParams;
+typedef struct _H265HRDParams                H265HRDParams;
+typedef struct _H265VUIParams                H265VUIParams;
+
+typedef struct _H265ScalingList              H265ScalingList;
+typedef struct _H265RefPicListModification   H265RefPicListModification;
+typedef struct _H265PredWeightTable          H265PredWeightTable;
+typedef struct _H265ShortTermRefPicSet       H265ShortTermRefPicSet;
+typedef struct _H265SliceHdr                 H265SliceHdr;
+
+typedef struct _H265PicTiming                H265PicTiming;
+typedef struct _H265BufferingPeriod          H265BufferingPeriod;
+typedef struct _H265SEIMessage               H265SEIMessage;
+
+/**
+ * H265NalUnit:
+ * @type: A #H265NalUnitType
+ * @layer_id: A nal unit layer id
+ * @temporal_id_plus1: A nal unit temporal identifier
+ * @size: The size of the nal unit starting from @offset
+ * @offset: The offset of the actual start of the nal unit
+ * @sc_offset:The offset of the start code of the nal unit
+ * @valid: If the nal unit is valid, which mean it has
+ * already been parsed
+ * @data: The data from which the Nalu has been parsed
+ *
+ * Structure defining the Nal unit headers
+ */
+struct _H265NalUnit
+{
+  uint8_t type;
+  uint8_t layer_id;
+  uint8_t temporal_id_plus1;
+
+  /* calculated values */
+  uint32_t size;
+  uint32_t offset;
+  uint32_t sc_offset;
+  BOOL valid;
+
+  uint8_t *data;
+  uint8_t header_bytes;
+};
+
+/**
+ * H265ProfileTierLevel:
+ * @profile_space: specifies the context for the interpretation of
+ *   general_profile_idc and general_profile_combatibility_flag
+ * @tier_flag: the tier context for the interpretation of general_level_idc
+ * @profile_idc: profile id
+ * @profile_compatibility_flag: compatibility flags
+ * @progressive_source_flag: flag to indicate the type of stream
+ * @interlaced_source_flag: flag to indicate the type of stream
+ * @non_packed_constraint_flag: indicate the presence of frame packing
+ *   arragement sei message
+ * @frame_only_constraint_flag: recognize the field_seq_flag
+ * @level idc: indicate the level which the CVS confirms
+ * @sub_layer_profile_present_flag: sublayer profile presence ind
+ * @sub_layer_level_present_flag:sublayer level presence indicator.
+ * @sub_layer_profile_space: profile space for sublayers
+ * @sub_layer_tier_flag: tier flags for sublayers.
+ * @sub_layer_profile_idc: conformant profile indicator for sublayers.
+ * @sub_layer_profile_compatibility_flag[6][32]: compatibility flags for sublayers
+ * @sub_layer_progressive_source_flag:progressive stream indicator for sublayer
+ * @sub_layer_interlaced_source_flag: interlaced stream indicator for sublayer
+ * @sub_layer_non_packed_constraint_flag: indicate the presence of
+ *   frame packing arrangement sei message with in sublayers
+ * @sub_layer_frame_only_constraint_flag:recognize the sublayer
+ *   specific field_seq_flag
+ * @sub_layer_level_idc:indicate the sublayer specific level
+ *
+ * Define ProfileTierLevel parameters
+ */
+struct _H265ProfileTierLevel {
+  uint8_t profile_space;
+  uint8_t tier_flag;
+  uint8_t profile_idc;
+
+  uint8_t profile_compatibility_flag[32];
+
+  uint8_t progressive_source_flag;
+  uint8_t interlaced_source_flag;
+  uint8_t non_packed_constraint_flag;
+  uint8_t frame_only_constraint_flag;
+  uint8_t level_idc;
+
+  uint8_t sub_layer_profile_present_flag[6];
+  uint8_t sub_layer_level_present_flag[6];
+
+  uint8_t sub_layer_profile_space[6];
+  uint8_t sub_layer_tier_flag[6];
+  uint8_t sub_layer_profile_idc[6];
+  uint8_t sub_layer_profile_compatibility_flag[6][32];
+  uint8_t sub_layer_progressive_source_flag[6];
+  uint8_t sub_layer_interlaced_source_flag[6];
+  uint8_t sub_layer_non_packed_constraint_flag[6];
+  uint8_t sub_layer_frame_only_constraint_flag[6];
+  uint8_t sub_layer_level_idc[6];
+};
+
+/**
+ * H265SubLayerHRDParams:
+ * @bit_rate_value_minus1:togeter with bit_rate_scale, it specifies
+ *   the maximum input bitrate when the CPB operates at the access
+ *   unit level
+ * @cpb_size_value_minus1: is used together with cpb_size_scale to
+ *   specify the CPB size when the CPB operates at the access unit
+ *   level
+ * @cpb_size_du_value_minus1: is used together with cpb_size_du_scale
+ *   to specify the CPB size when the CPB operates at sub-picture
+ *   level
+ * @bit_rate_du_value_minus1: together with bit_rate_scale, it
+ *   specifies the maximum input bit rate when the CPB operates at the
+ *   sub-picture level
+ * @cbr_flag: indicate whether HSS operates in intermittent bit rate
+ *   mode or constant bit rate mode.
+ *
+ * Defines the Sublayer HRD parameters
+ */
+struct _H265SubLayerHRDParams
+{
+  uint32_t bit_rate_value_minus1[32];
+  uint32_t cpb_size_value_minus1[32];
+
+  uint32_t cpb_size_du_value_minus1[32];
+  uint32_t bit_rate_du_value_minus1[32];
+
+  uint8_t cbr_flag[32];
+};
+
+/**
+ * H265HRDParams:
+ * @nal_hrd_parameters_present_flag: indicate the presence of NAL HRD parameters
+ * @vcl_hrd_parameters_present_flag: indicate the presence of VCL HRD parameters
+ * @sub_pic_hrd_params_present_flag: indicate the presence of sub_pic_hrd_params
+ * @tick_divisor_minus2: is used to specify the clock sub-tick
+ * @du_cpb_removal_delay_increment_length_minus1: specifies the length,
+ *   in bits, of the nal_initial_cpb_removal_delay
+ * @sub_pic_cpb_params_in_pic_timing_sei_flag: specifies the length, in bits, of
+ *   the cpb_delay_offset and the au_cpb_removal_delay_minus1 syntax elements.
+ * @dpb_output_delay_du_length_minu1: specifies the length, in bits, of the
+ *   dpb_delay_offset and the pic_dpb_output_delay syntax elements
+ * @bit_rate_scale: maximum input bitrate
+ * @cpb_size_scale: CPB size when operates in access unit level
+ * @cpb_size_du_scale: CPB size when operates in sub-picture level
+ * @initial_cpb_removal_delay_length_minus1: specifies the length, in bits, of the
+ *   nal_initial_cpb_removal_delay, nal_initial_cpb_removal_offset,
+ *   vcl_initial_cpb_removal_delay and vcl_initial_cpb_removal_offset.
+ * @au_cpb_removal_delay_length_minus1: specifies the length, in bits, of the
+ *   cpb_delay_offset and the au_cpb_removal_delay_minus1 syntax elements
+ * @dpb_output_delay_length_minus1: specifies the length, in bits, of the
+ *   dpb_delay_offset and the pic_dpb_output_delay syntax elements
+ * @fixed_pic_rate_general_flag: flag to indicate the presence of constraint
+ *   on the temporal distance between the HRD output times of consecutive
+ *   pictures in output order
+ * @fixed_pic_rate_within_cvs_flag: same as fixed_pic_rate_general_flag
+ * @elemental_duration_in_tc_minus1: temporal distance in clock ticks
+ * @low_delay_hrd_flag: specifies the HRD operational mode
+ * @cpb_cnt_minus1:specifies the number of alternative CPS specifications.
+ * @sublayer_hrd_params: Sublayer HRD parameters.
+ *
+ * Defines the HRD parameters
+ */
+struct _H265HRDParams
+{
+  uint8_t nal_hrd_parameters_present_flag;
+  uint8_t vcl_hrd_parameters_present_flag;
+  uint8_t sub_pic_hrd_params_present_flag;
+
+  uint8_t tick_divisor_minus2;
+  uint8_t du_cpb_removal_delay_increment_length_minus1;
+  uint8_t sub_pic_cpb_params_in_pic_timing_sei_flag;
+  uint8_t dpb_output_delay_du_length_minus1;
+
+  uint8_t bit_rate_scale;
+  uint8_t cpb_size_scale;
+  uint8_t cpb_size_du_scale;
+
+  uint8_t initial_cpb_removal_delay_length_minus1;
+  uint8_t au_cpb_removal_delay_length_minus1;
+  uint8_t dpb_output_delay_length_minus1;
+
+  uint8_t fixed_pic_rate_general_flag [7];
+  uint8_t fixed_pic_rate_within_cvs_flag [7];
+  uint16_t elemental_duration_in_tc_minus1 [7];
+  uint8_t low_delay_hrd_flag [7];
+  uint8_t cpb_cnt_minus1[7];
+
+  H265SubLayerHRDParams sublayer_hrd_params[7];
+};
+
+/**
+ * H265VPS:
+ * @id: vps id
+ * @max_layers_minus1: should be zero, but can be other values in future
+ * @max_sub_layers_minus1:specifies the maximum number of temporal sub-layers
+ * @temporal_id_nesting_flag: specifies whether inter prediction is
+ *   additionally restricted
+ * @profile_tier_level: ProfileTierLevel info
+ * @sub_layer_ordering_info_present_flag: indicates the presense of
+ *   vps_max_dec_pic_buffering_minus1, vps_max_num_reorder_pics and
+ *   vps_max_latency_increase_plus1
+ * @max_dec_pic_buffering_minus1: specifies the maximum required size
+ *   of the decoded picture buffer
+ * @max_num_reorder_pics: indicates the maximum allowed number of
+ *   pictures that can precede any picture in the CVS in decoding
+ *   order
+ * @max_latency_increase_plus1: is used to compute the value of
+ *   VpsMaxLatencyPictures
+ * @max_layer_id: specifies the maximum allowed value of nuh_layer_id
+ * @num_layer_sets_minus1: specifies the number of layer sets
+ * @layer_id_included_flag: specifies whether a nuh_layer_id included
+ *   in the layer identifier list
+ * @timing_info_present_flag: indicate the presence of
+ *   num_units_in_tick, time_scale, poc_proportional_to_timing_flag
+ *   and num_hrd_parameters
+ * @num_units_in_tick: number of time units in a tick
+ * @time_scale: number of time units that pass in one second
+ * @poc_proportional_to_timing_flag: indicate whether the picture
+ *   order count is proportional to output timin
+ * @num_ticks_poc_diff_one_minus1: specifies the number of clock ticks
+ *   corresponding to a difference of picture order count values equal
+ *   to 1
+ * @num_hrd_parameters: number of hrd_parameters present
+ * @hrd_layer_set_idx: index to the list of layer hrd params.
+ * @hrd_params: the H265HRDParams list
+ *
+ * Defines the VPS parameters
+ */
+struct _H265VPS {
+  uint8_t id;
+
+  uint8_t max_layers_minus1;
+  uint8_t max_sub_layers_minus1;
+  uint8_t temporal_id_nesting_flag;
+
+  H265ProfileTierLevel profile_tier_level;
+
+  uint8_t sub_layer_ordering_info_present_flag;
+  uint8_t max_dec_pic_buffering_minus1[H265_MAX_SUB_LAYERS];
+  uint8_t max_num_reorder_pics[H265_MAX_SUB_LAYERS];
+  uint32_t max_latency_increase_plus1[H265_MAX_SUB_LAYERS];
+
+  uint8_t max_layer_id;
+  uint16_t num_layer_sets_minus1;
+
+  uint8_t timing_info_present_flag;
+  uint32_t num_units_in_tick;
+  uint32_t time_scale;
+  uint8_t poc_proportional_to_timing_flag;
+  uint32_t num_ticks_poc_diff_one_minus1;
+
+  uint16_t num_hrd_parameters;
+  uint16_t hrd_layer_set_idx;
+  uint8_t cprms_present_flag;
+
+  H265HRDParams hrd_params;
+
+  uint8_t vps_extension;
+
+  BOOL valid;
+};
+/**
+ * H265ShortTermRefPicSet:
+ * @inter_ref_pic_set_prediction_flag: %TRUE specifies that the stRpsIdx-th candidate
+ *  short-term RPS is predicted from another candidate short-term RPS
+ * @delta_idx_minus1: plus 1 specifies the difference between the value of source and
+ *  candidate short term RPS.
+ * @delta_rps_sign: delta_rps_sign and abs_delta_rps_minus1 together specify
+ *  the value of the variable deltaRps.
+ * @abs_delta_rps_minus1: delta_rps_sign and abs_delta_rps_minus1 together specify
+ *  the value of the variable deltaRps
+ *
+ * Defines the #H265ShortTermRefPicSet params
+ */
+struct _H265ShortTermRefPicSet
+{
+  uint8_t inter_ref_pic_set_prediction_flag;
+  uint8_t delta_idx_minus1;
+  uint8_t delta_rps_sign;
+  uint16_t abs_delta_rps_minus1;
+
+  /* calculated values */
+  uint8_t NumDeltaPocs;
+  uint8_t NumNegativePics;
+  uint8_t NumPositivePics;
+  uint8_t UsedByCurrPicS0[16];
+  uint8_t UsedByCurrPicS1[16];
+  int32_t DeltaPocS0[16];
+  int32_t DeltaPocS1[16];
+};
+
+/**
+ * H265VUIParams:
+ * @aspect_ratio_info_present_flag: %TRUE specifies that aspect_ratio_idc is present.
+ *  %FALSE specifies that aspect_ratio_idc is not present
+ * @aspect_ratio_idc specifies the value of the sample aspect ratio of the luma samples
+ * @sar_width indicates the horizontal size of the sample aspect ratio
+ * @sar_height indicates the vertical size of the sample aspect ratio
+ * @overscan_info_present_flag: %TRUE overscan_appropriate_flag is present %FALSE otherwize
+ * @overscan_appropriate_flag: %TRUE indicates that the cropped decoded pictures
+ *  output are suitable for display using overscan. %FALSE the cropped decoded pictures
+ *  output contain visually important information
+ * @video_signal_type_present_flag: %TRUE specifies that video_format, video_full_range_flag and
+ *  colour_description_present_flag are present.
+ * @video_format: indicates the representation of the picture
+ * @video_full_range_flag: indicates the black level and range of the luma and chroma signals
+ * @colour_description_present_flag: %TRUE specifies that colour_primaries,
+ *  transfer_characteristics and matrix_coefficients are present
+ * @colour_primaries: indicates the chromaticity coordinates of the source primaries
+ * @transfer_characteristics: indicates the opto-electronic transfer characteristic
+ * @matrix_coefficients: describes the matrix coefficients used in deriving luma and chroma signals
+ * @chroma_loc_info_present_flag: %TRUE specifies that chroma_sample_loc_type_top_field and
+ *  chroma_sample_loc_type_bottom_field are present, %FALSE otherwize
+ * @chroma_sample_loc_type_top_field: specify the location of chroma for top field
+ * @chroma_sample_loc_type_bottom_field specify the location of chroma for bottom field
+ * @neutral_chroma_indication_flag: %TRUE indicate that the value of chroma samples is equla
+ *  to 1<<(BitDepthchrom-1).
+ * @field_seq_flag: %TRUE indicate field and %FALSE indicate frame
+ * @frame_field_info_present_flag: %TRUE indicate picture timing SEI messages are present for every
+ *   picture and include the pic_struct, source_scan_type, and duplicate_flag syntax elements.
+ * @default_display_window_flag: %TRUE indicate that the default display window parameters present
+ * def_disp_win_left_offset:left offset of display rect
+ * def_disp_win_right_offset: right offset of display rect
+ * def_disp_win_top_offset: top offset of display rect
+ * def_disp_win_bottom_offset: bottom offset of display rect
+ * @timing_info_present_flag: %TRUE specifies that num_units_in_tick,
+ *  time_scale and fixed_frame_rate_flag are present in the bitstream
+ * @num_units_in_tick: is the number of time units of a clock operating at the frequency time_scale Hz
+ * @time_scale: is the number of time units that pass in one second
+ * @poc_proportional_to_timing_flag: %TRUE indicates that the picture order count value for each picture
+ *  in the CVS that is not the first picture in the CVS, in decoding order, is proportional to the output
+ *  time of the picture relative to the output time of the first picture in the CVS.
+ * @num_ticks_poc_diff_one_minus1: plus 1 specifies the number of clock ticks corresponding to a
+ *  difference of picture order count values equal to 1
+ * @hrd_parameters_present_flag: %TRUE if hrd parameters present in the bitstream
+ * @bitstream_restriction_flag: %TRUE specifies that the following coded video sequence bitstream restriction
+ * parameters are present
+ * @tiles_fixed_structure_flag: %TRUE indicates that each PPS that is active in the CVS has the same value
+ *   of the syntax elements num_tile_columns_minus1, num_tile_rows_minus1, uniform_spacing_flag,
+ *   column_width_minus1, row_height_minus1 and loop_filter_across_tiles_enabled_flag, when present
+ * @motion_vectors_over_pic_boundaries_flag: %FALSE indicates that no sample outside the
+ *  picture boundaries and no sample at a fractional sample position, %TRUE indicates that one or more
+ *  samples outside picture boundaries may be used in inter prediction
+ * @restricted_ref_pic_list_flag: %TRUE indicates that all P and B slices (when present) that belong to
+ *  the same picture have an identical reference picture list 0, and that all B slices (when present)
+ *   that belong to the same picture have an identical reference picture list 1
+ * @min_spatial_segmentation_idc: when not equal to 0, establishes a bound on the maximum possible size
+ *  of distinct coded spatial segmentation regions in the pictures of the CVS
+ * @max_bytes_per_pic_denom: indicates a number of bytes not exceeded by the sum of the sizes of
+ *  the VCL NAL units associated with any coded picture in the coded video sequence.
+ * @max_bits_per_min_cu_denom: indicates an upper bound for the number of coded bits of coding_unit
+ *  data for any coding block in any picture of the CVS
+ * @log2_max_mv_length_horizontal: indicate the maximum absolute value of a decoded horizontal
+ * motion vector component
+ * @log2_max_mv_length_vertical: indicate the maximum absolute value of a decoded vertical
+ *  motion vector component
+ *
+ * The structure representing the VUI parameters.
+ */
+struct _H265VUIParams
+{
+  uint8_t aspect_ratio_info_present_flag;
+  uint8_t aspect_ratio_idc;
+  /* if aspect_ratio_idc == 255 */
+  uint16_t sar_width;
+  uint16_t sar_height;
+
+  uint8_t overscan_info_present_flag;
+  /* if overscan_info_present_flag */
+  uint8_t overscan_appropriate_flag;
+
+  uint8_t video_signal_type_present_flag;
+  uint8_t video_format;
+  uint8_t video_full_range_flag;
+  uint8_t colour_description_present_flag;
+  uint8_t colour_primaries;
+  uint8_t transfer_characteristics;
+  uint8_t matrix_coefficients;
+
+  uint8_t chroma_loc_info_present_flag;
+  uint8_t chroma_sample_loc_type_top_field;
+  uint8_t chroma_sample_loc_type_bottom_field;
+
+  uint8_t neutral_chroma_indication_flag;
+  uint8_t field_seq_flag;
+  uint8_t frame_field_info_present_flag;
+  uint8_t default_display_window_flag;
+  uint32_t def_disp_win_left_offset;
+  uint32_t def_disp_win_right_offset;
+  uint32_t def_disp_win_top_offset;
+  uint32_t def_disp_win_bottom_offset;
+
+  uint8_t timing_info_present_flag;
+  /* if timing_info_present_flag */
+  uint32_t num_units_in_tick;
+  uint32_t time_scale;
+  uint8_t poc_proportional_to_timing_flag;
+  /* if poc_proportional_to_timing_flag */
+  uint32_t num_ticks_poc_diff_one_minus1;
+  uint8_t hrd_parameters_present_flag;
+  /*if hrd_parameters_present_flat */
+  H265HRDParams hrd_params;
+
+  uint8_t bitstream_restriction_flag;
+  /*  if bitstream_restriction_flag */
+  uint8_t tiles_fixed_structure_flag;
+  uint8_t motion_vectors_over_pic_boundaries_flag;
+  uint8_t restricted_ref_pic_lists_flag;
+  uint16_t min_spatial_segmentation_idc;
+  uint8_t max_bytes_per_pic_denom;
+  uint8_t max_bits_per_min_cu_denom;
+  uint8_t log2_max_mv_length_horizontal;
+  uint8_t log2_max_mv_length_vertical;
+
+  /* calculated values */
+  uint32_t par_n;
+  uint32_t par_d;
+};
+
+/**
+ * H265ScalingList:
+ * @scaling_list_dc_coef_minus8_16x16: this plus 8 specifies the DC
+ *   Coefficient values for 16x16 scaling list
+ * @scaling_list_dc_coef_minus8_32x32: this plus 8 specifies the DC
+ *   Coefficient values for 32x32 scaling list
+ * @scaling_lists_4x4: 4x4 scaling list
+ * @scaling_lists_8x8: 8x8 scaling list
+ * @scaling_lists_16x16: 16x16 scaling list
+ * @uint8_t scaling_lists_32x32: 32x32 scaling list
+ *
+ * Defines the H265ScalingList
+ */
+struct _H265ScalingList {
+
+  int16_t scaling_list_dc_coef_minus8_16x16[6];
+  int16_t scaling_list_dc_coef_minus8_32x32[2];
+
+  uint8_t scaling_lists_4x4 [6][16];
+  uint8_t scaling_lists_8x8 [6][64];
+  uint8_t scaling_lists_16x16 [6][64];
+  uint8_t scaling_lists_32x32 [2][64];
+};
+
+/**
+ * H265SPS:
+ * @id: The ID of the sequence parameter set
+ * @profile_idc: indicate the profile to which the coded video sequence conforms
+ *
+ * H265 Sequence Parameter Set (SPS)
+ */
+struct _H265SPS
+{
+  uint8_t id;
+
+  H265VPS *vps;
+
+  uint8_t max_sub_layers_minus1;
+  uint8_t temporal_id_nesting_flag;
+
+  H265ProfileTierLevel profile_tier_level;
+
+  uint8_t chroma_format_idc;
+  uint8_t separate_colour_plane_flag;
+  uint16_t pic_width_in_luma_samples;
+  uint16_t pic_height_in_luma_samples;
+
+  uint8_t conformance_window_flag;
+  /* if conformance_window_flag */
+  uint32_t conf_win_left_offset;
+  uint32_t conf_win_right_offset;
+  uint32_t conf_win_top_offset;
+  uint32_t conf_win_bottom_offset;
+
+  uint8_t bit_depth_luma_minus8;
+  uint8_t bit_depth_chroma_minus8;
+  uint8_t log2_max_pic_order_cnt_lsb_minus4;
+
+  uint8_t sub_layer_ordering_info_present_flag;
+  uint8_t max_dec_pic_buffering_minus1[H265_MAX_SUB_LAYERS];
+  uint8_t max_num_reorder_pics[H265_MAX_SUB_LAYERS];
+  uint8_t max_latency_increase_plus1[H265_MAX_SUB_LAYERS];
+
+  uint8_t log2_min_luma_coding_block_size_minus3;
+  uint8_t log2_diff_max_min_luma_coding_block_size;
+  uint8_t log2_min_transform_block_size_minus2;
+  uint8_t log2_diff_max_min_transform_block_size;
+  uint8_t max_transform_hierarchy_depth_inter;
+  uint8_t max_transform_hierarchy_depth_intra;
+
+  uint8_t scaling_list_enabled_flag;
+  /* if scaling_list_enabled_flag */
+  uint8_t scaling_list_data_present_flag;
+
+  H265ScalingList scaling_list;
+
+  uint8_t amp_enabled_flag;
+  uint8_t sample_adaptive_offset_enabled_flag;
+  uint8_t pcm_enabled_flag;
+  /* if pcm_enabled_flag */
+  uint8_t pcm_sample_bit_depth_luma_minus1;
+  uint8_t pcm_sample_bit_depth_chroma_minus1;
+  uint8_t log2_min_pcm_luma_coding_block_size_minus3;
+  uint8_t log2_diff_max_min_pcm_luma_coding_block_size;
+  uint8_t pcm_loop_filter_disabled_flag;
+
+  uint8_t num_short_term_ref_pic_sets;
+  H265ShortTermRefPicSet short_term_ref_pic_set[65];
+
+  uint8_t long_term_ref_pics_present_flag;
+  /* if long_term_ref_pics_present_flag */
+  uint8_t num_long_term_ref_pics_sps;
+  uint16_t lt_ref_pic_poc_lsb_sps[32];
+  uint8_t used_by_curr_pic_lt_sps_flag[32];
+
+  uint8_t temporal_mvp_enabled_flag;
+  uint8_t strong_intra_smoothing_enabled_flag;
+  uint8_t vui_parameters_present_flag;
+
+  /* if vui_parameters_present_flat */
+  H265VUIParams vui_params;
+
+  uint8_t sps_extension_flag;
+
+  /* calculated values */
+  uint8_t chroma_array_type;
+  int32_t width, height;
+  int32_t crop_rect_width, crop_rect_height;
+  int32_t crop_rect_x, crop_rect_y;
+  int32_t fps_num, fps_den;
+  BOOL valid;
+};
+
+/**
+ * H265PPS:
+ *
+ * H265 Picture Parameter Set
+ */
+struct _H265PPS
+{
+  uint32_t id;
+
+  H265SPS *sps;
+
+  uint8_t dependent_slice_segments_enabled_flag;
+  uint8_t output_flag_present_flag;
+  uint8_t num_extra_slice_header_bits;
+  uint8_t sign_data_hiding_enabled_flag;
+  uint8_t cabac_init_present_flag;
+  uint8_t num_ref_idx_l0_default_active_minus1;
+  uint8_t num_ref_idx_l1_default_active_minus1;
+  int8_t init_qp_minus26;
+  uint8_t constrained_intra_pred_flag;
+  uint8_t transform_skip_enabled_flag;
+  uint8_t cu_qp_delta_enabled_flag;
+  /*if cu_qp_delta_enabled_flag */
+  uint8_t diff_cu_qp_delta_depth;
+
+  int8_t cb_qp_offset;
+  int8_t cr_qp_offset;
+  uint8_t slice_chroma_qp_offsets_present_flag;
+  uint8_t weighted_pred_flag;
+  uint8_t weighted_bipred_flag;
+  uint8_t transquant_bypass_enabled_flag;
+  uint8_t tiles_enabled_flag;
+  uint8_t entropy_coding_sync_enabled_flag;
+
+  uint8_t num_tile_columns_minus1;
+  uint8_t num_tile_rows_minus1;
+  uint8_t uniform_spacing_flag;
+  uint32_t column_width_minus1[19];
+  uint32_t row_height_minus1[21];
+  uint8_t loop_filter_across_tiles_enabled_flag;
+
+  uint8_t loop_filter_across_slices_enabled_flag;
+  uint8_t deblocking_filter_control_present_flag;
+  uint8_t deblocking_filter_override_enabled_flag;
+  uint8_t deblocking_filter_disabled_flag;
+  int8_t beta_offset_div2;
+  int8_t tc_offset_div2;
+
+  uint8_t scaling_list_data_present_flag;
+
+  H265ScalingList scaling_list;
+
+  uint8_t lists_modification_present_flag;
+  uint8_t log2_parallel_merge_level_minus2;
+  uint8_t slice_segment_header_extension_present_flag;
+
+  uint8_t pps_extension_flag;
+
+  BOOL valid;
+};
+
+struct _H265RefPicListModification
+{
+  uint8_t ref_pic_list_modification_flag_l0;
+  uint32_t list_entry_l0[15];
+  uint8_t ref_pic_list_modification_flag_l1;
+  uint32_t list_entry_l1[15];
+};
+
+struct _H265PredWeightTable
+{
+  uint8_t luma_log2_weight_denom;
+  int8_t delta_chroma_log2_weight_denom;
+
+  uint8_t luma_weight_l0_flag[15];
+  uint8_t  chroma_weight_l0_flag[15];
+  int8_t delta_luma_weight_l0[15];
+  int8_t luma_offset_l0[15];
+  int8_t delta_chroma_weight_l0 [15][2];
+  int16_t delta_chroma_offset_l0 [15][2];
+
+  uint8_t luma_weight_l1_flag[15];
+  uint8_t chroma_weight_l1_flag[15];
+  int8_t delta_luma_weight_l1[15];
+  int8_t luma_offset_l1[15];
+  int8_t delta_chroma_weight_l1[15][2];
+  int16_t delta_chroma_offset_l1[15][2];
+};
+
+struct _H265SliceHdr
+{
+  uint8_t first_slice_segment_in_pic_flag;
+  uint8_t no_output_of_prior_pics_flag;
+
+  H265PPS *pps;
+
+  uint8_t dependent_slice_segment_flag;
+  uint32_t segment_address;
+
+  uint8_t type;
+
+  uint8_t pic_output_flag;
+  uint8_t colour_plane_id;
+  uint16_t pic_order_cnt_lsb;
+
+  uint8_t  short_term_ref_pic_set_sps_flag;
+  H265ShortTermRefPicSet short_term_ref_pic_sets;
+  uint8_t short_term_ref_pic_set_idx;
+
+  uint8_t num_long_term_sps;
+  uint8_t num_long_term_pics;
+  uint8_t lt_idx_sps[16];
+  uint32_t poc_lsb_lt[16];
+  uint8_t used_by_curr_pic_lt_flag[16];
+  uint8_t delta_poc_msb_present_flag[16];
+  uint32_t delta_poc_msb_cycle_lt[16];
+
+  uint8_t temporal_mvp_enabled_flag;
+  uint8_t sao_luma_flag;
+  uint8_t sao_chroma_flag;
+  uint8_t num_ref_idx_active_override_flag;
+  uint8_t num_ref_idx_l0_active_minus1;
+  uint8_t num_ref_idx_l1_active_minus1;
+
+  H265RefPicListModification ref_pic_list_modification;
+
+  uint8_t mvd_l1_zero_flag;
+  uint8_t cabac_init_flag;
+  uint8_t collocated_from_l0_flag;
+  uint8_t collocated_ref_idx;
+
+  H265PredWeightTable pred_weight_table;
+
+  uint8_t five_minus_max_num_merge_cand;
+
+  int8_t qp_delta;
+  int8_t cb_qp_offset;
+  int8_t cr_qp_offset;
+
+  uint8_t deblocking_filter_override_flag;
+  uint8_t deblocking_filter_disabled_flag;
+  int8_t beta_offset_div2;
+  int8_t tc_offset_div2;
+
+  uint8_t loop_filter_across_slices_enabled_flag;
+
+  uint32_t num_entry_point_offsets;
+  uint8_t offset_len_minus1;
+  uint32_t *entry_point_offset_minus1;
+
+  /* calculated values */
+
+  int32_t NumPocTotalCurr;
+  /* Size of the slice_header() in bits */
+  uint32_t header_size;
+  /* Number of emulation prevention bytes (EPB) in this slice_header() */
+  uint32_t n_emulation_prevention_bytes;
+};
+
+struct _H265PicTiming
+{
+  uint8_t pic_struct;
+  uint8_t source_scan_type;
+  uint8_t duplicate_flag;
+
+  uint8_t au_cpb_removal_delay_minus1;
+  uint8_t pic_dpb_output_delay;
+  uint8_t pic_dpb_output_du_delay;
+  uint32_t num_decoding_units_minus1;
+  uint8_t du_common_cpb_removal_delay_flag;
+  uint8_t du_common_cpb_removal_delay_increment_minus1;
+  uint32_t *num_nalus_in_du_minus1;
+  uint8_t *du_cpb_removal_delay_increment_minus1;
+};
+
+struct _H265BufferingPeriod
+{
+  H265SPS *sps;
+
+  uint8_t irap_cpb_params_present_flag;
+  uint8_t cpb_delay_offset;
+  uint8_t dpb_delay_offset;
+  uint8_t concatenation_flag;
+  uint8_t au_cpb_removal_delay_delta_minus1;
+
+  /* seq->vui_parameters->nal_hrd_parameters_present_flag */
+  uint8_t nal_initial_cpb_removal_delay[32];
+  uint8_t nal_initial_cpb_removal_offset[32];
+  uint8_t nal_initial_alt_cpb_removal_delay[32];
+  uint8_t nal_initial_alt_cpb_removal_offset [32];
+
+  /* seq->vui_parameters->vcl_hrd_parameters_present_flag */
+  uint8_t vcl_initial_cpb_removal_delay[32];
+  uint8_t vcl_initial_cpb_removal_offset[32];
+  uint8_t vcl_initial_alt_cpb_removal_delay[32];
+  uint8_t vcl_initial_alt_cpb_removal_offset[32];
+};
+
+struct _H265SEIMessage
+{
+  H265SEIPayloadType payloadType;
+
+  union {
+    H265BufferingPeriod buffering_period;
+    H265PicTiming pic_timing;
+    /* ... could implement more */
+  } payload;
+};
+
+/**
+ * H265Parser:
+ *
+ * H265 NAL Parser (opaque structure).
+ */
+struct _H265Parser
+{
+  /*< private >*/
+  H265VPS vps[H265_MAX_VPS_COUNT];
+  H265SPS sps[H265_MAX_SPS_COUNT];
+  H265PPS pps[H265_MAX_PPS_COUNT];
+  H265VPS *last_vps;
+  H265SPS *last_sps;
+  H265PPS *last_pps;
+};
+
+H265Parser *     h265_parser_new               (void);
+
+H265ParserResult h265_parser_identify_nalu      (H265Parser  * parser,
+                                                        const uint8_t   * data,
+                                                        uint32_t            offset,
+                                                        size_t            size,
+                                                        H265NalUnit * nalu);
+
+H265ParserResult h265_parser_identify_nalu_unchecked (H265Parser * parser,
+                                                        const uint8_t   * data,
+                                                        uint32_t            offset,
+                                                        size_t            size,
+                                                        H265NalUnit * nalu);
+
+H265ParserResult h265_parser_identify_nalu_hevc (H265Parser  * parser,
+                                                        const uint8_t   * data,
+                                                        uint32_t            offset,
+                                                        size_t            size,
+                                                        uint8_t           nal_length_size,
+                                                        H265NalUnit * nalu);
+
+H265ParserResult h265_parser_parse_nal       (H265Parser   * parser,
+                                                     H265NalUnit  * nalu);
+
+H265ParserResult h265_parser_parse_slice_hdr (H265Parser   * parser,
+                                                     H265NalUnit  * nalu,
+                                                     H265SliceHdr * slice);
+
+H265ParserResult h265_parser_parse_vps       (H265Parser   * parser,
+                                                     H265NalUnit  * nalu,
+                                                     H265VPS      * vps);
+
+H265ParserResult h265_parser_parse_sps       (H265Parser   * parser,
+                                                     H265NalUnit  * nalu,
+                                                     H265SPS      * sps,
+                                                     BOOL          parse_vui_params);
+
+H265ParserResult h265_parser_parse_pps       (H265Parser   * parser,
+                                                     H265NalUnit  * nalu,
+                                                     H265PPS      * pps);
+/*
+H265ParserResult h265_parser_parse_sei       (H265Parser   * parser,
+                                                     H265NalUnit  * nalu,
+                                                     GArray **messages);
+*/
+
+void                h265_parser_free            (H265Parser  * parser);
+
+H265ParserResult h265_parse_vps              (H265NalUnit * nalu,
+                                                     H265VPS     * vps);
+
+H265ParserResult h265_parse_sps              (H265Parser  * parser,
+                                                     H265NalUnit * nalu,
+                                                     H265SPS     * sps,
+                                                     BOOL         parse_vui_params);
+
+H265ParserResult h265_parse_pps              (H265Parser  * parser,
+                                                     H265NalUnit * nalu,
+                                                     H265PPS     * pps);
+
+BOOL            h265_slice_hdr_copy (H265SliceHdr       * dst_slice,
+                                             const H265SliceHdr * src_slice);
+
+void                h265_slice_hdr_free (H265SliceHdr * slice_hdr);
+
+BOOL            h265_sei_copy       (H265SEIMessage       * dest_sei,
+                                             const H265SEIMessage * src_sei);
+
+void                h265_sei_free       (H265SEIMessage * sei);
+
+void    h265_quant_matrix_4x4_get_zigzag_from_raster (uint8_t out_quant[16],
+                                                          const uint8_t quant[16]);
+
+void    h265_quant_matrix_4x4_get_raster_from_zigzag (uint8_t out_quant[16],
+                                                          const uint8_t quant[16]);
+
+void    h265_quant_matrix_8x8_get_zigzag_from_raster (uint8_t out_quant[64],
+                                                          const uint8_t quant[64]);
+
+void    h265_quant_matrix_8x8_get_raster_from_zigzag (uint8_t out_quant[64],
+                                                          const uint8_t quant[64]);
+
+#define h265_quant_matrix_16x16_get_zigzag_from_raster \
+        h265_quant_matrix_8x8_get_zigzag_from_raster
+#define h265_quant_matrix_16x16_get_raster_from_zigzag \
+        h265_quant_matrix_8x8_get_raster_from_zigzag
+#define h265_quant_matrix_32x32_get_zigzag_from_raster \
+        h265_quant_matrix_8x8_get_zigzag_from_raster
+#define h265_quant_matrix_32x32_get_raster_from_zigzag \
+        h265_quant_matrix_8x8_get_raster_from_zigzag
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+#endif

--- a/encoder/vaapiencoder_vp8.cpp
+++ b/encoder/vaapiencoder_vp8.cpp
@@ -63,7 +63,7 @@ Encode_Status VaapiEncoderVP8::getMaxOutSize(uint32_t *maxSize)
 void VaapiEncoderVP8::resetParams()
 {
     //5 times compress ratio
-    m_maxCodedbufSize = width() * height() * 3 / 2 / 5;
+    m_maxCodedbufSize = width() * height() * 3 / 2;
 }
 
 Encode_Status VaapiEncoderVP8::start()

--- a/encoder/vaapiencoder_vp8.cpp
+++ b/encoder/vaapiencoder_vp8.cpp
@@ -198,6 +198,8 @@ bool VaapiEncoderVP8::fill(VAQMatrixBufferVP8* qMatrix) const
     for (int i = 0; i < 4; i++) {
         qMatrix->quantization_index[i] = 40;
     }
+
+    return true;
 }
 
 

--- a/tests/encodeinput.cpp
+++ b/tests/encodeinput.cpp
@@ -238,7 +238,7 @@ static void get_ivf_file_header(uint8_t *header, int width, int height,int count
     setUint32(header+8,  '08PV');               /* headersize */
     setUint16(header+12, width);                /* width */
     setUint16(header+14, height);               /* height */
-    setUint32(header+16, 1);                    /* rate */
+    setUint32(header+16, 30);                    /* rate */
     setUint32(header+20, 1);                    /* scale */
     setUint32(header+24, count);                /* length */
     setUint32(header+28, 0);                    /* unused */

--- a/tests/encodeinput.h
+++ b/tests/encodeinput.h
@@ -40,7 +40,7 @@ class EncodeInput {
 public:
     static EncodeInput* create(const char* inputFileName, uint32_t fourcc, int width, int height);
     EncodeInput() : m_width(0), m_height(0), m_frameSize(0) {};
-    ~EncodeInput() {};
+    virtual ~EncodeInput() {};
     virtual bool init(const char* inputFileName, uint32_t fourcc, int width, int height) = 0;
     virtual bool getOneFrameInput(VideoFrameRawData &inputBuffer) = 0;
     virtual bool recycleOneFrameInput(VideoFrameRawData &inputBuffer) {return true;};
@@ -107,7 +107,7 @@ private:
 class EncodeOutput {
 public:
     EncodeOutput();
-    ~EncodeOutput();
+    virtual ~EncodeOutput();
     static  EncodeOutput* create(const char* outputFileName, int width , int height);
     virtual bool write(void* data, int size);
     virtual const char* getMimeType() = 0;


### PR DESCRIPTION
 	1) vp8enc: add missed "return true" statement
 	2) vp8enc: add missed "return true" statement
 	3) tests: Write frame counts to VP8 file header
 	4) tests: set default fps to 30 for .vp8 container
 	5) codecparsers: add new files for h265 support.