### PR TITLE
Revert "yamidecode: compile tests with X when supported"

### DIFF
--- a/tests/egl/gles2_help.c
+++ b/tests/egl/gles2_help.c
@@ -304,7 +304,6 @@ EGLContextType *eglInit(Display *x11Display, XID x11Window, uint32_t fourcc, int
     glClearColor(0.0, 0.0, 0.5, 0.0);
     glEnable(GL_DEPTH_TEST);
     glClearDepthf(1.0f);
-#if __ENABLE_V4L2_GLX__
     {
         int width, height;
         Window root;
@@ -312,7 +311,6 @@ EGLContextType *eglInit(Display *x11Display, XID x11Window, uint32_t fourcc, int
         XGetGeometry(x11Display, x11Window, &root, &x, &y, &width, &height, &borderWidth, &depth);
         glViewport(0, 0, width, height);
     }
-#endif
     if (isExternalTexture)
         glProgram = createShaders(vertexShaderText_rgba, fragShaderText_rgba_ext, 1);
     else

--- a/tests/v4l2decode.cpp
+++ b/tests/v4l2decode.cpp
@@ -278,9 +278,7 @@ int main(int argc, char** argv)
     renderMode = 3; // set default render mode to 3
 
     yamiTraceInit();
-#if __ENABLE_V4L2_GLX__
     XInitThreads();
-#endif
 
     if (!process_cmdline(argc, argv))
         return -1;
@@ -323,9 +321,9 @@ int main(int argc, char** argv)
     fd = YamiV4L2_Open("decoder", 0);
     ASSERT(fd!=-1);
 
-#if __ENABLE_V4L2_GLX__
     x11Display = XOpenDisplay(NULL);
     ASSERT(x11Display);
+#if __ENABLE_V4L2_GLX__
     ioctlRet = YamiV4L2_SetXDisplay(fd, x11Display);
 #endif
     // set output frame memory type


### PR DESCRIPTION
QA will do 1 round regression test. this patch will break the v4l2decoder.So I revert it temporarily. hope we can find a better patch for this latter.

>commit 456207affc9ecfe17127bd24630a35a00727f500
>Author: Daniel Charles <daniel.charles@intel.com>
>Date:   Thu Apr 9 17:17:14 2015 -0700
>
>    yamidecode: compile tests with X when supported
>
>    test application use X only when available
>
>    Signed-off-by: Daniel Charles <daniel.charles@intel.com>

