### PR TITLE
h264dec: accpet annexb format codec data

### DIFF
--- a/decoder/vaapidecoder_h264.cpp
+++ b/decoder/vaapidecoder_h264.cpp
@@ -1277,13 +1277,17 @@ bool VaapiDecoderH264::decodeCodecData(uint8_t * buf, uint32_t bufSize)
     if (!buf || bufSize == 0)
         return false;
 
+    if (buf[0] != 1) {
+        VideoDecodeBuffer buffer;
+        memset(&buffer, 0, sizeof(buffer));
+        buffer.data = buf;
+        buffer.size = bufSize;
+        status = decode(&buffer);
+        return status == DECODE_SUCCESS;
+    }
+
     if (bufSize < 8)
         return false;
-
-    if (buf[0] != 1) {
-        ERROR("failed to decode codec-data, not in avcC format");
-        return false;
-    }
 
     m_nalLengthSize = (buf[4] & 0x03) + 1;
 

--- a/tests/decodeinputavformat.cpp
+++ b/tests/decodeinputavformat.cpp
@@ -112,7 +112,6 @@ bool DecodeInputAvFormat::getNextDecodeUnit(VideoDecodeBuffer &inputBuffer)
             memset(&inputBuffer, 0, sizeof(inputBuffer));
             inputBuffer.data = m_packet.data;
             inputBuffer.size = m_packet.size;
-            inputBuffer.flag = IS_AVCC;
             inputBuffer.timeStamp = m_packet.dts;
             return true;
         }


### PR DESCRIPTION
If you read a ts file using avformat, the codec data and frame data is
annexb format.So We'd better accpet annexb format in codec data