### PR TITLE
v4l2_encode: do not deref NULL m_encoder

### DIFF
--- a/v4l2/v4l2_encode.cpp
+++ b/v4l2/v4l2_encode.cpp
@@ -83,7 +83,8 @@ bool V4l2Encoder::start()
 bool V4l2Encoder::stop()
 {
     Encode_Status encodeStatus = ENCODE_SUCCESS;
-    encodeStatus = m_encoder->stop();
+    if (m_encoder)
+        encodeStatus = m_encoder->stop();
     return encodeStatus == ENCODE_SUCCESS;
 }
 
@@ -297,6 +298,10 @@ int32_t V4l2Encoder::ioctl(int command, void* arg)
             switch (format->fmt.pix_mp.pixelformat) {
                 case V4L2_PIX_FMT_H264: {
                     m_encoder.reset(createVideoEncoder(YAMI_MIME_H264), releaseVideoEncoder);
+                    if (!m_encoder) {
+                        ret = -1;
+                        break;
+                    }
                     m_videoParams.size = sizeof(m_videoParams);
                     encodeStatus = m_encoder->getParameters(VideoParamsTypeCommon, &m_videoParams);
                     ASSERT(encodeStatus == ENCODE_SUCCESS);


### PR DESCRIPTION
If createVideoEncoder fails (i.e. returns NULL), then we need
to avoid dereferencing it and return -1 to the client so it
can choose to proceed gracefully if needed.

This can happen if we compile without the h264 encoder (i.e.
--disable-h264enc) and the client still attempts to request
an h264 encode format.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>