### PR TITLE
fixed permissive warnings

### DIFF
--- a/codecparsers/bitwriter.h
+++ b/codecparsers/bitwriter.h
@@ -134,7 +134,7 @@ extern "C"
     assert (new_bit_size
         && ((new_bit_size & __BITS_WRITER_ALIGNMENT_MASK) == 0));
     clear_pos = ((bitwriter->bit_size + 7) >> 3);
-    bitwriter->data = realloc (bitwriter->data, (new_bit_size >> 3));
+    bitwriter->data = (uint8_t*)realloc (bitwriter->data, (new_bit_size >> 3));
     memset (bitwriter->data + clear_pos, 0, (new_bit_size >> 3) - clear_pos);
     bitwriter->bit_capacity = new_bit_size;
     return TRUE;

--- a/decoder/vaapidecoder_base.cpp
+++ b/decoder/vaapidecoder_base.cpp
@@ -435,7 +435,7 @@ Decode_Status VaapiDecoderBase::flagNativeBuffer(void *pBuffer)
     return DECODE_SUCCESS;
 }
 
-void VaapiDecoderBase::releaseLock(bool lockable=false)
+void VaapiDecoderBase::releaseLock(bool lockable)
 {
     if (!m_surfacePool)
         return;

--- a/vaapi/vaapiimage.cpp
+++ b/vaapi/vaapiimage.cpp
@@ -213,7 +213,7 @@ ImagePtr VaapiImage::create(const DisplayPtr& display,
 
     VAImagePtr vaImage(new VAImage);
 
-    status = vaCreateImage(display->getID(), vaFormat, width, height, vaImage.get());
+    status = vaCreateImage(display->getID(), const_cast<VAImageFormat*>(vaFormat), width, height, vaImage.get());
     if (status != VA_STATUS_SUCCESS ||
         vaImage->format.fourcc != vaFormat->fourcc) {
         ERROR("fourcc mismatch wated = 0x%x, got = 0x%x", vaFormat->fourcc, vaImage->format.fourcc);

--- a/vaapi/vaapisurface.cpp
+++ b/vaapi/vaapisurface.cpp
@@ -96,7 +96,7 @@ VaapiSurface::VaapiSurface(const DisplayPtr& display,
 }
 
 VaapiSurface::VaapiSurface(const DisplayPtr& display, VASurfaceID id)
-    : m_display(display), m_chromaType(0)
+    : m_display(display), m_chromaType(VAAPI_CHROMA_TYPE_YUV400)
     , m_allocWidth(0), m_allocHeight(0), m_width(0), m_height(0)
     , m_ID(id), m_owner(false)
 {


### PR DESCRIPTION
Compile passed when open the "-fpermissive" option, but errors must be occured if no this option. 
That is, these are incorrect cplusplus statements as following.