### PR TITLE
warningInfo: initialize local variables

### DIFF
--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -70,7 +70,7 @@ bool guessResolution(const char* filename, int& w, int& h)
     };
     int state = STATE_START;
     const char* p = filename;
-    const char* tokStart;
+    const char* tokStart = NULL;
     w = h = 0;
     while (*p != '\0') {
         switch (state) {

--- a/decoder/vaapidecoder_jpeg.cpp
+++ b/decoder/vaapidecoder_jpeg.cpp
@@ -146,7 +146,6 @@ Decode_Status
 Decode_Status VaapiDecoderJpeg::fillPictureParam()
 {
     VAPictureParameterBufferJPEGBaseline *vaPicParam = NULL;
-    VaapiBufObject *object;
     uint32_t i;
 
     if (!m_picture->editPicture(vaPicParam))
@@ -156,10 +155,8 @@ Decode_Status VaapiDecoderJpeg::fillPictureParam()
     vaPicParam->picture_height = m_frameHdr.height;
     vaPicParam->num_components = m_frameHdr.num_components;
 
-    if (m_frameHdr.num_components > 4) {
-        object->unmap();
+    if (m_frameHdr.num_components > 4)
         return DECODE_FAIL;
-    }
 
     for (i = 0; i < vaPicParam->num_components; i++) {
         vaPicParam->components[i].component_id =

--- a/encoder/vaapiencoder_base.cpp
+++ b/encoder/vaapiencoder_base.cpp
@@ -343,14 +343,14 @@ void VaapiEncoderBase::fill(VAEncMiscParameterRateControl* rateControl) const
 /* Generates additional control parameters */
 bool VaapiEncoderBase::ensureMiscParams (VaapiEncPicture* picture)
 {
-    VAEncMiscParameterHRD* hrd;
+    VAEncMiscParameterHRD* hrd = NULL;
     if (!picture->newMisc(VAEncMiscParameterTypeHRD, hrd))
         return false;
     fill(hrd);
     VideoRateControl mode = rateControlMode();
     if (mode == RATE_CONTROL_CBR ||
             mode == RATE_CONTROL_VBR) {
-        VAEncMiscParameterRateControl* rateControl;
+        VAEncMiscParameterRateControl* rateControl = NULL;
         if (!picture->newMisc(VAEncMiscParameterTypeRateControl, rateControl))
             return false;
         fill(rateControl);

--- a/tests/vpp.cpp
+++ b/tests/vpp.cpp
@@ -154,7 +154,7 @@ public:
 
         SharedPtr<VideoFrame> src, dest;
         YamiStatus  status;
-        int count;
+        int count = 0;
         while (m_input->read(src)) {
             dest = m_allocator->alloc();
             status = m_vpp->process(src, dest);


### PR DESCRIPTION
Init some local variables, otherwise it`ll run failed under some conditions.
As following:
    1) the local var "object" uninitialized, program will be aborted if m_frameHdr.num_components > 4.
    2) "count" uninitialized, mybe zero or random value. Depended on compiler. 
    3) And others will be assigned before use it, but output warning log still. So better init it.