### PR TITLE
warningInfo: fixed parentheses warnings

### DIFF
--- a/common/log.cpp
+++ b/common/log.cpp
@@ -59,7 +59,7 @@ void yamiTraceInit()
                     	curtime->tm_year + 1900, curtime->tm_mon + 1, curtime->tm_mday,
                     	curtime->tm_hour, curtime->tm_sec);
 
-            	if (tmp = fopen(filename, "w")){
+            	if ((tmp = fopen(filename, "w"))){
                 	yamiLogFn = tmp;
                 	yamiMessage(stdout, "Libyami_Trace is on, save log into %s.\n", filename);
             	} else {

--- a/decoder/vaapidecoder_jpeg.cpp
+++ b/decoder/vaapidecoder_jpeg.cpp
@@ -492,8 +492,8 @@ Decode_Status VaapiDecoderJpeg::decode(VideoDecodeBuffer * buffer)
             }
 
             /* Application segments */
-            if (seg.marker >= JPEG_MARKER_APP_MIN &&
-                seg.marker <= JPEG_MARKER_APP_MAX || seg.marker == JPEG_MARKER_COM) {
+            if ((seg.marker >= JPEG_MARKER_APP_MIN && seg.marker <= JPEG_MARKER_APP_MAX) ||
+                seg.marker == JPEG_MARKER_COM) {
                 status = DECODE_SUCCESS;
                 break;
             }

--- a/encoder/vaapiencoder_base.cpp
+++ b/encoder/vaapiencoder_base.cpp
@@ -112,7 +112,7 @@ Encode_Status VaapiEncoderBase::encode(VideoEncRawBuffer *inBuffer)
 {
     FUNC_ENTER();
 
-    if (!inBuffer || !inBuffer->data && !inBuffer->size) {
+    if (!inBuffer || (!inBuffer->data && !inBuffer->size)) {
         // XXX handle EOS when there is B frames
         inBuffer->bufAvailable = true;
         return ENCODE_SUCCESS;

--- a/encoder/vaapiencoder_h264.cpp
+++ b/encoder/vaapiencoder_h264.cpp
@@ -510,7 +510,7 @@ public:
 
     Encode_Status getCodecConfig(VideoEncOutputBuffer *outBuffer)
     {
-        ASSERT(outBuffer && outBuffer->format == OUTPUT_CODEC_DATA || outBuffer->format == OUTPUT_EVERYTHING);
+        ASSERT((outBuffer && outBuffer->format == OUTPUT_CODEC_DATA) || outBuffer->format == OUTPUT_EVERYTHING);
         if (outBuffer->bufferSize < m_headers.size())
             return ENCODE_BUFFER_TOO_SMALL;
         if (m_headers.empty())
@@ -998,7 +998,7 @@ Encode_Status VaapiEncoderH264::doEncode(const SurfacePtr& surface, uint64_t tim
 
 Encode_Status VaapiEncoderH264::getCodecConfig(VideoEncOutputBuffer * outBuffer)
 {
-    ASSERT(outBuffer && outBuffer->flag == OUTPUT_CODEC_DATA || outBuffer->flag == OUTPUT_EVERYTHING);
+    ASSERT((outBuffer && outBuffer->flag == OUTPUT_CODEC_DATA) || outBuffer->flag == OUTPUT_EVERYTHING);
     AutoLock locker(m_paramLock);
     if (!m_headers)
         return ENCODE_NO_REQUEST_DATA;

--- a/testscripts/psnr.cpp
+++ b/testscripts/psnr.cpp
@@ -151,7 +151,7 @@ psnr_calculate(char *filename1, char *filename2, char *eachpsnr, char *psnrresul
     fprintf(fpeachpsnr,"[%dx%d] frame = %d\n",width,height,framecount);
     fprintf(fpeachpsnr,"Average of psnr  %f  %f  %f\n",avgy,avgu,avgv);
     char *path = NULL ;
-    if (path = strrchr (filename2, '/'))
+    if ((path = strrchr (filename2, '/')))
         path++;
     strcpy(videofile,path);
     if(avgy<standardpsnr || avgu<standardpsnr || avgv<standardpsnr)
@@ -184,7 +184,7 @@ int main(int argc, char *argv[])
         switch (opt) {
             case 'h':
             case '?':
-                print_help (argv[0]);
+                print_help(argv[0]);
                 return false;
             case 'i':
                 strcpy(filename1,optarg);
@@ -193,7 +193,7 @@ int main(int argc, char *argv[])
                 strcpy(filename2,optarg);
                 strcat(eachpsnr,filename2);
                 strcat(eachpsnr,".txt");
-                if (path = strrchr (filename2, '/'))
+                if ((path = strrchr(filename2, '/')))
                     path++;
                 memcpy(psnrresult,filename2,path-filename2);
                 strcat(psnrresult,"jpg_psnr.txt");


### PR DESCRIPTION
The GNU compiler collection (GCC) 4.6.3 issues a warning when the logical AND operator (&&) and the logical OR operator (||) are used in a comparison statement without the use of parentheses to control the comparison order. And also suggest parentheses around assignment used as truth value.  For improving code quality