### PR TITLE
warningInfo: unused but set variables and lable

### DIFF
--- a/decoder/vaapidecoder_h264.cpp
+++ b/decoder/vaapidecoder_h264.cpp
@@ -1326,7 +1326,6 @@ bool VaapiDecoderH264::decodeCodecData(uint8_t * buf, uint32_t bufSize)
 void VaapiDecoderH264::updateFrameInfo()
 {
     INFO("H264: update frame info ");
-    bool sizeChanged = FALSE;
     H264SPS *sps = &m_lastSPS;
     uint32_t width = (sps->pic_width_in_mbs_minus1 + 1) * 16;
     uint32_t height = (sps->pic_height_in_map_units_minus1 + 1) *
@@ -1340,7 +1339,6 @@ void VaapiDecoderH264::updateFrameInfo()
 
     if (widthAlign != formatInfoWidthAlign ||
         heightAlign != formatInfoHeightAlign) {
-        sizeChanged = TRUE;
         m_videoFormatInfo.width = width;
         m_videoFormatInfo.height = height;
         m_configBuffer.width = width;

--- a/decoder/vaapidecoder_jpeg.cpp
+++ b/decoder/vaapidecoder_jpeg.cpp
@@ -509,7 +509,7 @@ Decode_Status VaapiDecoderJpeg::decode(VideoDecodeBuffer * buffer)
             break;
         }
     }
-  end:
+
     return status;
 }
 

--- a/encoder/vaapiencoder_h264.cpp
+++ b/encoder/vaapiencoder_h264.cpp
@@ -890,7 +890,7 @@ Encode_Status VaapiEncoderH264::getParameters(VideoParamConfigType type, Yami_PT
 
     FUNC_ENTER();
     if (!videoEncParams)
-        return ENCODE_INVALID_PARAMS;
+        return status;
     switch (type) {
     case VideoParamsTypeAVC: {
             VideoParamsAVC* avc = (VideoParamsAVC*)videoEncParams;
@@ -913,8 +913,7 @@ Encode_Status VaapiEncoderH264::getParameters(VideoParamConfigType type, Yami_PT
         break;
     }
 
-    // TODO, update video resolution basing on hw requirement
-    return VaapiEncoderBase::getParameters(type, videoEncParams);
+    return status;
 }
 
 Encode_Status VaapiEncoderH264::reorder(const SurfacePtr& surface, uint64_t timeStamp, bool forceKeyFrame)


### PR DESCRIPTION
1) vaapidecoder_h264.cpp: var "sizeChanged" unused but set
2) vaapidecoder_jpeg.cpp:lable "end" unused but set
3) vaapiencoder_h264.cpp: define a status-variable at the beginning of a function, and then should return this status-var at the end of function. Make the function structure  understand clearly.

