### PR TITLE
fix typo in code.

### DIFF
--- a/decoder/vaapidecoder_host.cpp
+++ b/decoder/vaapidecoder_host.cpp
@@ -90,9 +90,4 @@ void releaseVideoDecoder(IVideoDecoder * p)
     delete p;
 }
 
-bool preSandboxInitDecoder()
-{
-    // TODO, for hybrid Decoder uses mediasdk, does the prework here
-    return true;
-}
 } // extern "C"

--- a/encoder/vaapiencoder_host.cpp
+++ b/encoder/vaapiencoder_host.cpp
@@ -74,8 +74,4 @@ void releaseVideoEncoder(IVideoEncoder* p) {
     delete p;
 }
 
-bool preSandboxInitEncoder() {
-    // TODO, for hybrid VP8 encoder uses mediasdk, does the prework here
-    return true;
-}
 } // extern "C"

--- a/interface/VideoDecoderHost.h
+++ b/interface/VideoDecoderHost.h
@@ -36,18 +36,7 @@ YamiMediaCodec::IVideoDecoder *createVideoDecoder(const char *mimeType);
 /// \brief destroy the decoder
 void releaseVideoDecoder(YamiMediaCodec::IVideoDecoder * p);
 
-/** \fn void preSandboxInitEncoder()
- * \brief when yami runs inside sandbox, some necessary work goes here before enter sanbox
- * usually, nothing special is required  except when yami dlopen thirty party libraries.
- * the shared libraries linked by yami will be loaded automatically.
- * vaGetDisplay/vaInitialize should NOT run in this function. since:
- * 1)  it is ok to call vaGetDisplay()/vaInitialize() inside sandbox.
- * 2) Native display (X11 display) isn't available at this point
- */
-bool preSandboxInitDecoder();
-
 typedef YamiMediaCodec::IVideoDecoder *(*YamiCreateVideoDecoderFuncPtr) (const char *mimeType);
 typedef void (*YamiReleaseVideoDecoderFuncPtr)(YamiMediaCodec::IVideoDecoder * p);
-typedef bool (*YamiPreSandboxInitDecoder)();
 }
 #endif                          /* VIDEO_DECODER_HOST_H_ */

--- a/interface/VideoEncoderHost.h
+++ b/interface/VideoEncoderHost.h
@@ -37,18 +37,7 @@ YamiMediaCodec::IVideoEncoder *createVideoEncoder(const char *mimeType);
 */
 void releaseVideoEncoder(YamiMediaCodec::IVideoEncoder * p);
 
-/** \fn void preSandboxInitEncoder()
- * \brief when yami runs inside sandbox, some necessary work goes here before enter sanbox
- * usually, nothing special is required  except when yami dlopen thirty party libraries.
- * the shared libraries linked by yami will be loaded automatically.
- * vaGetDisplay/vaInitialize should NOT run in this function. since:
- * 1)  it is ok to call vaGetDisplay()/vaInitialize() inside sandbox.
- * 2) Native display (X11 display) isn't available at this point
- */
-bool preSandboxInitEncoder();
-
 typedef YamiMediaCodec::IVideoEncoder *(*YamiCreateVideoEncoderFuncPtr) (const char *mimeType);
 typedef void (*YamiReleaseVideoEncoderFuncPtr)(YamiMediaCodec::IVideoEncoder * p);
-typedef bool (*YamiPreSandboxInitEncoder)();
 }
 #endif                          /* VIDEO_ENCODER_HOST_H_ */

--- a/interface/VideoPostProcessHost.h
+++ b/interface/VideoPostProcessHost.h
@@ -37,18 +37,7 @@ YamiMediaCodec::IVideoPostProcess *createVideoPostProcess(const char *mimeType);
 */
 void releaseVideoPostProcess(YamiMediaCodec::IVideoPostProcess * p);
 
-/** \fn void preSandboxInitPostProcess()
- * \brief when yami runs inside sandbox, some necessary work goes here before enter sanbox
- * usually, nothing special is required  except when yami dlopen thirty party libraries.
- * the shared libraries linked by yami will be loaded automatically.
- * vaGetDisplay/vaInitialize should NOT run in this function. since:
- * 1)  it is ok to call vaGetDisplay()/vaInitialize() inside sandbox.
- * 2) Native display (X11 display) isn't available at this point
- */
-bool preSandboxInitPostProcess();
-
 typedef YamiMediaCodec::IVideoPostProcess *(*YamiCreateVideoPostProcessFuncPtr) (const char *mimeType);
 typedef void (*YamiReleaseVideoPostProcessFuncPtr)(YamiMediaCodec::IVideoPostProcess * p);
-typedef bool (*YamiPreSandboxInitPostProcess)();
 }
 #endif                          /* VIDEO_POST_PROCESS_HOST_H_ */

--- a/tests/decodeoutput.cpp
+++ b/tests/decodeoutput.cpp
@@ -198,7 +198,7 @@ DecodeOutputRaw::~DecodeOutputRaw()
 bool DecodeOutputFileDump::config(const char* source, const char* dest, uint32_t fourcc)
 {
     if (!fourcc && dest)
-        fourcc == guessFourcc(dest);
+        fourcc = guessFourcc(dest);
     setFourcc(fourcc);
     const char* baseFileName = source;
     const char* s = strrchr(source, '/');

--- a/vpp/vaapipostprocess_host.cpp
+++ b/vpp/vaapipostprocess_host.cpp
@@ -61,9 +61,4 @@ void releaseVideoPostProcess(IVideoPostProcess * p)
     delete p;
 }
 
-bool preSandboxInitDecoder()
-{
-    // TODO, for hybrid Decoder uses mediasdk, does the prework here
-    return true;
-}
 } // extern "C"


### PR DESCRIPTION
two commit here to fix typo:
1. preSandboxInitDecoder in vpp/vaapipostprocess_host.cpp will conflict with decoder/vaapidecoder_host.cpp. Halley assume preSandboxInitXXX will called by chrome, but actually it's not. Since nobody use it, we'd better remove it all.
2. fix == error in assignment 