### PR TITLE
vaapidisplay: use the libva api for driver name

### DIFF
--- a/decoder/vaapidecoder_base.cpp
+++ b/decoder/vaapidecoder_base.cpp
@@ -375,7 +375,7 @@ Decode_Status
         INFO("setting LIBVA_DRIVER_NAME to wrapper for chromeos");
     }
 #endif
-    m_display = VaapiDisplay::create(m_externalDisplay);
+    m_display = VaapiDisplay::create(m_externalDisplay, profile);
 
     if (!m_display) {
         ERROR("failed to create display");

--- a/vaapi/vaapidisplay.h
+++ b/vaapi/vaapidisplay.h
@@ -31,6 +31,7 @@
 #include <va/va_x11.h>
 #endif
 #include <va/va_drm.h>
+#include <string>
 #include <vector>
 #include "interface/VideoCommonDefs.h"
 #include "common/lock.h"
@@ -50,6 +51,7 @@ public:
     ~VaapiDisplay();
     //FIXME: add more create functions.
     static DisplayPtr create(const NativeDisplay& display);
+    static DisplayPtr create(const NativeDisplay& display, VAProfile profile);
     virtual bool setRotation(int degree);
     VADisplay getID() const { return m_vaDisplay; }
     const VAImageFormat* getVaFormat(uint32_t fourcc);


### PR DESCRIPTION
libva has introduced a new api to set the driver name, this is changed
when the default driver is not going to be used. Right now the driver
and supported profiles are handled by libyami

Signed-off-by: Daniel Charles <daniel.charles@intel.com>