### PR TITLE
vaapidisplay: fix NativeDisplayDrm::isCompatible bug

### DIFF
--- a/vaapi/vaapidisplay.cpp
+++ b/vaapi/vaapidisplay.cpp
@@ -138,7 +138,7 @@ class NativeDisplayDrm : public NativeDisplayBase{
             return false;
         if (display.handle == 0 || display.handle == -1 || display.handle == m_handle)
             return true;
-        return true;
+        return false;
     }
 };
 


### PR DESCRIPTION
NativeDisplayDrm::isCompatible() always returns true if
the display.type == NATIVE_DISPLAY_DRM, regardless of
whether the handles are compatible or not.  This causes
multiple instances of decoders to use the same VADisplay
regardless of whether they have different m_drmfd set by
the client.  As a result, this causes crashes and/or
playback artifacts/corruption.

This bug was introduced in commit:

commit 020542ed62981a690ec4b2d1eab9ce43befd8455
Author: Zhao, Halley <halley.zhao@intel.com>
Date:   Wed Aug 20 13:19:22 2014 +0800

    vaapidisplay: add drm backend support

To fix this, NativeDisplayDrm::isCompatible() now returns
false if the handles aren't compatible.

Kudos should also go out to Manasi for identifying that
bypassing the display cache in yami fixed the issue too.  That
datapoint along with additional debugging led to the discovery
of this underlying root-cause.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>