### PR TITLE
configure.ac fixups and formatting

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -353,3 +353,25 @@ AC_OUTPUT([
          pkgconfig/libyami_vpp.pc
 ])
 
+# Print a configuration summary
+DECODERS=""
+AS_IF([test x$enable_h264dec = xyes], [DECODERS="$DECODERS h264"])
+AS_IF([test x$enable_jpegdec = xyes], [DECODERS="$DECODERS jpeg"])
+AS_IF([test x$enable_vp8dec = xyes], [DECODERS="$DECODERS vp8"])
+AS_IF([test x$enable_vp9dec = xyes], [DECODERS="$DECODERS vp9"])
+AS_IF([test x$enable_fakedec = xyes], [DECODERS="$DECODERS fake"])
+
+ENCODERS=""
+AS_IF([test x$enable_h264enc = xyes], [ENCODERS="$ENCODERS h264"])
+AS_IF([test x$enable_jpegenc = xyes], [ENCODERS="$ENCODERS jpeg"])
+AS_IF([test x$enable_vp8enc = xyes], [ENCODERS="$ENCODERS vp8"])
+
+AC_MSG_RESULT([
+    libyami - libyami_version
+
+    Build decoders ................... :$DECODERS
+    Build encoders ....................:$ENCODERS
+    Build documentation .............. : $enable_docs
+    Enable debug ......................: $enable_debug
+    Installation prefix .............. : $prefix
+])

--- a/configure.ac
+++ b/configure.ac
@@ -38,166 +38,224 @@ AC_SUBST(LIBYAMI_LT_VERSION)
 AC_SUBST(LIBYAMI_LT_LDFLAGS)
 
 AC_ARG_ENABLE(debug,
-    [AC_HELP_STRING([--enable-debug],[build with extra debug @<:@default=no@:>@])],
+    [AC_HELP_STRING([--enable-debug],
+        [build with extra debug @<:@default=no@:>@])],
     [], [enable_debug="no"])
 
 if test "$enable_debug" = "yes"; then
-AC_DEFINE([__ENABLE_DEBUG__], [1], [Defined to 1 if --enable-debug="yes" ])
+    AC_DEFINE([__ENABLE_DEBUG__], [1],
+        [Defined to 1 if --enable-debug="yes"])
 fi
 
 AC_ARG_ENABLE(tests,
-    [AC_HELP_STRING([--enable-tests], [build tests @<:@default=no@:>@])],
+    [AC_HELP_STRING([--enable-tests],
+        [build tests @<:@default=no@:>@])],
     [], [enable_tests="no"])
 
 AC_ARG_ENABLE(tests-gles,
-    [AC_HELP_STRING([--enable-tests-gles], [build tests with opengles/texutre rendering@<:@default=no@:>@])],
+    [AC_HELP_STRING([--enable-tests-gles],
+        [build tests with opengles/texture rendering @<:@default=no@:>@])],
     [], [enable_tests_gles="no"])
 
 if test "$enable_tests" = "yes" -o "$enable_tests_gles" = "yes"; then
-AC_DEFINE([__ENABLE_TESTS__], [1], [Defined to 1 if --enable-tests="yes" ])
+    AC_DEFINE([__ENABLE_TESTS__], [1],
+        [Defined to 1 if --enable-tests="yes"])
 fi
-AM_CONDITIONAL(ENABLE_TESTS, test "x$enable_tests" = "xyes" -o "x$enable_tests_gles" = "xyes")
+AM_CONDITIONAL(ENABLE_TESTS,
+    [test "x$enable_tests" = "xyes" -o "x$enable_tests_gles" = "xyes"])
 
 if test "$enable_tests_gles" = "yes"; then
-AC_DEFINE([__ENABLE_TESTS_GLES__], [1], [Defined to 1 if --enable-tests-gles="yes" ])
+    AC_DEFINE([__ENABLE_TESTS_GLES__], [1],
+        [Defined to 1 if --enable-tests-gles="yes"])
 fi
-AM_CONDITIONAL(ENABLE_TESTS_GLES, test "x$enable_tests_gles" = "xyes")
+AM_CONDITIONAL(ENABLE_TESTS_GLES,
+    [test "x$enable_tests_gles" = "xyes"])
 
 AC_ARG_ENABLE(dmabuf,
-    [AC_HELP_STRING([--enable-dmabuf], [support dm_buf buffer sharing@<:@default=no@:>@])],
+    [AC_HELP_STRING([--enable-dmabuf],
+        [support dma_buf buffer sharing @<:@default=no@:>@])],
     [], [enable_dmabuf="no"])
 
 if test "$enable_dmabuf" = "yes"; then
-AC_DEFINE([__ENABLE_DMABUF__], [1], [Defined to 1 if --enable-dmabuf="yes" ])
+    AC_DEFINE([__ENABLE_DMABUF__], [1],
+        [Defined to 1 if --enable-dmabuf="yes"])
 fi
-AM_CONDITIONAL(ENABLE_DMABUF, test "x$enable_dmabuf" = "xyes")
+AM_CONDITIONAL(ENABLE_DMABUF,
+    [test "x$enable_dmabuf" = "xyes"])
 
 AC_ARG_ENABLE(v4l2,
-    [AC_HELP_STRING([--enable-v4l2], [wrapper of v4l2 interface@<:@default=no@:>@])],
+    [AC_HELP_STRING([--enable-v4l2],
+        [wrapper of v4l2 interface @<:@default=no@:>@])],
     [], [enable_v4l2="no"])
 
 AC_ARG_ENABLE(v4l2-glx,
-    [AC_HELP_STRING([--enable-v4l2-glx], [use glx/tfp in v4l2 wrapper@<:@default=no@:>@])],
+    [AC_HELP_STRING([--enable-v4l2-glx],
+        [use glx/tfp in v4l2 wrapper @<:@default=no@:>@])],
     [], [enable_v4l2_glx="no"])
 
 if test "$enable_v4l2" = "yes" -o "$enable_v4l2_glx" = "yes"; then
-AC_DEFINE([__ENABLE_V4L2__], [1], [Defined to 1 if --enable-v4l2="yes" or --enable-v4l2-glx="yes" ])
+    AC_DEFINE([__ENABLE_V4L2__], [1],
+        [Defined to 1 if --enable-v4l2="yes" or --enable-v4l2-glx="yes"])
 fi
-AM_CONDITIONAL(ENABLE_V4L2, test "x$enable_v4l2" = "xyes" -o "x$enable_v4l2_glx" = "xyes")
+AM_CONDITIONAL(ENABLE_V4L2,
+    [test "x$enable_v4l2" = "xyes" -o "x$enable_v4l2_glx" = "xyes"])
 
 if test "$enable_v4l2_glx" = "yes"; then
-AC_DEFINE([__ENABLE_V4L2_GLX__], [1], [Defined to 1 if --enable-v4l2-glx="yes" ])
+    AC_DEFINE([__ENABLE_V4L2_GLX__], [1],
+        [Defined to 1 if --enable-v4l2-glx="yes"])
 fi
-AM_CONDITIONAL(ENABLE_V4L2_GLX, test "x$enable_v4l2_glx" = "xyes")
+AM_CONDITIONAL(ENABLE_V4L2_GLX,
+    [test "x$enable_v4l2_glx" = "xyes"])
 
 AC_ARG_ENABLE(capi,
-    [AC_HELP_STRING([--enable-capi], [wrapper of c api interface@<:@default=no@:>@])],
+    [AC_HELP_STRING([--enable-capi],
+        [wrapper of c api interface @<:@default=no@:>@])],
     [], [enable_capi="no"])
 
 if test "$enable_capi" = "yes"; then
-AC_DEFINE([__ENABLE_CAPI__], [1], [Defined to 1 if --enable-capi="yes" ])
+    AC_DEFINE([__ENABLE_CAPI__], [1],
+        [Defined to 1 if --enable-capi="yes"])
 fi
-AM_CONDITIONAL(ENABLE_CAPI, test "x$enable_capi" = "xyes")
+AM_CONDITIONAL(ENABLE_CAPI,
+    [test "x$enable_capi" = "xyes"])
 
 AC_ARG_ENABLE(x11,
-    [AC_HELP_STRING([--enable-x11], [enable x11@<:@default=yes@:>@])],
-	[], [enable_x11="yes"])
+    [AC_HELP_STRING([--enable-x11],
+        [enable x11 @<:@default=yes@:>@])],
+    [], [enable_x11="yes"])
 
 if test "$enable_x11" = "yes"; then
     AC_DEFINE([__ENABLE_X11__], [1],
-        [Defined to 1 if --enable-x11="yes" ])
+        [Defined to 1 if --enable-x11="yes"])
 fi
-AM_CONDITIONAL(ENABLE_X11, test "x$enable_x11" = "xyes")
+AM_CONDITIONAL(ENABLE_X11,
+    [test "x$enable_x11" = "xyes"])
 
 AC_ARG_ENABLE(avformat,
-    [AC_HELP_STRING([--enable-avformat], [enable avformat@<:@default=no@:>@])],
+    [AC_HELP_STRING([--enable-avformat],
+        [enable avformat @<:@default=no@:>@])],
     [], [enable_avformat="no"])
 
 if test "$enable_avformat" = "yes"; then
     AC_DEFINE([__ENABLE_AVFORMAT__], [1],
-        [Defined to 1 if --enable-avformat="yes" ])
+        [Defined to 1 if --enable-avformat="yes"])
 fi
-AM_CONDITIONAL(ENABLE_AVFORMAT, test "x$enable_avformat" = "xyes")
+AM_CONDITIONAL(ENABLE_AVFORMAT,
+    [test "x$enable_avformat" = "xyes"])
 
 AC_ARG_ENABLE(baytrail,
-    [AC_HELP_STRING([--enable-baytrail], [build with baytrail/chromeos support @<:@default=no@:>@])],
+    [AC_HELP_STRING([--enable-baytrail],
+        [build with baytrail/chromeos support @<:@default=no@:>@])],
     [], [enable_baytrail="no"])
 
 if test "$enable_baytrail" = "yes"; then
-AC_DEFINE([__PLATFORM_BYT__], [1], [Defined to 1 if --enable-baytrail="yes" ])
+    AC_DEFINE([__PLATFORM_BYT__], [1],
+        [Defined to 1 if --enable-baytrail="yes"])
 fi
 
 dnl vp8 decoder
 AC_ARG_ENABLE(vp8dec,
-    [AC_HELP_STRING([--enable-vp8dec], [build with vp8 decoder support @<:@default=yes@:>@])],
+    [AC_HELP_STRING([--enable-vp8dec],
+        [build with vp8 decoder support @<:@default=yes@:>@])],
     [], [enable_vp8dec="yes"])
-AM_CONDITIONAL(BUILD_VP8_DECODER, test "x$enable_vp8dec" = "xyes")
+
+AM_CONDITIONAL(BUILD_VP8_DECODER,
+    [test "x$enable_vp8dec" = "xyes"])
 
 dnl vp9 decoder
 AC_ARG_ENABLE(vp9dec,
-    [AC_HELP_STRING([--enable-vp9dec], [build with vp9 decoder support @<:@default=no@:>@])],
+    [AC_HELP_STRING([--enable-vp9dec],
+        [build with vp9 decoder support @<:@default=no@:>@])],
     [], [enable_vp9dec="no"])
-AM_CONDITIONAL(BUILD_VP9_DECODER, test "x$enable_vp9dec" = "xyes")
+
+AM_CONDITIONAL(BUILD_VP9_DECODER,
+    [test "x$enable_vp9dec" = "xyes"])
 
 dnl jpeg decoder
 AC_ARG_ENABLE(jpegdec,
-    [AC_HELP_STRING([--enable-jpegdec], [build with jpeg decoder support @<:@default=yes@:>@])],
+    [AC_HELP_STRING([--enable-jpegdec],
+        [build with jpeg decoder support @<:@default=yes@:>@])],
     [], [enable_jpegdec="yes"])
-AM_CONDITIONAL(BUILD_JPEG_DECODER, test "x$enable_jpegdec" = "xyes")
+
+AM_CONDITIONAL(BUILD_JPEG_DECODER,
+    [test "x$enable_jpegdec" = "xyes"])
 
 dnl h264 decoder
 AC_ARG_ENABLE(h264dec,
-    [AC_HELP_STRING([--enable-h264dec], [build with h264 decoder support @<:@default=yes@:>@])],
+    [AC_HELP_STRING([--enable-h264dec],
+        [build with h264 decoder support @<:@default=yes@:>@])],
     [], [enable_h264dec="yes"])
-AM_CONDITIONAL(BUILD_H264_DECODER, test "x$enable_h264dec" = "xyes")
+
+AM_CONDITIONAL(BUILD_H264_DECODER,
+    [test "x$enable_h264dec" = "xyes"])
 
 dnl fake decoder
 AC_ARG_ENABLE(fakedec,
-    [AC_HELP_STRING([--enable-fakedec], [build with fake decoder support @<:@default=no@:>@])],
+    [AC_HELP_STRING([--enable-fakedec],
+        [build with fake decoder support @<:@default=no@:>@])],
     [], [enable_fakedec="no"])
+
 if test "$enable_fakedec" = "yes"; then
-AC_DEFINE([__BUILD_FAKE_DECODER__], [1], [Defined to 1 if --enable-fakedec="yes" ])
+    AC_DEFINE([__BUILD_FAKE_DECODER__], [1],
+        [Defined to 1 if --enable-fakedec="yes"])
 fi
-AM_CONDITIONAL(BUILD_FAKE_DECODER, test "x$enable_fakedec" = "xyes")
+AM_CONDITIONAL(BUILD_FAKE_DECODER,
+    [test "x$enable_fakedec" = "xyes"])
 
 dnl h264 encoder
 AC_ARG_ENABLE(h264enc,
-    [AC_HELP_STRING([--enable-h264enc], [build with h264 encoder support @<:@default=yes@:>@])],
+    [AC_HELP_STRING([--enable-h264enc],
+        [build with h264 encoder support @<:@default=yes@:>@])],
     [], [enable_h264enc="yes"])
-AM_CONDITIONAL(BUILD_H264_ENCODER, test "x$enable_h264enc" = "xyes")
+
+AM_CONDITIONAL(BUILD_H264_ENCODER,
+    [test "x$enable_h264enc" = "xyes"])
 
 dnl jpeg encoder
 AC_ARG_ENABLE(jpegenc,
-    [AC_HELP_STRING([--enable-jpegenc], [build with jpeg encoder support @<:@default=no@:>@])],
+    [AC_HELP_STRING([--enable-jpegenc],
+        [build with jpeg encoder support @<:@default=no@:>@])],
     [], [enable_jpegenc="no"])
-AM_CONDITIONAL(BUILD_JPEG_ENCODER, test "x$enable_jpegenc" = "xyes")
+
+AM_CONDITIONAL(BUILD_JPEG_ENCODER,
+    [test "x$enable_jpegenc" = "xyes"])
 
 dnl vp8 encoder
 AC_ARG_ENABLE(vp8enc,
-    [AC_HELP_STRING([--enable-vp8enc], [build with vp8 encoder support @<:@default=no@:>@])],
+    [AC_HELP_STRING([--enable-vp8enc],
+        [build with vp8 encoder support @<:@default=no@:>@])],
     [], [enable_vp8enc="no"])
-AM_CONDITIONAL(BUILD_VP8_ENCODER, test "x$enable_vp8enc" = "xyes")
+
+AM_CONDITIONAL(BUILD_VP8_ENCODER,
+    [test "x$enable_vp8enc" = "xyes"])
 
 dnl encoder getmv
 AC_ARG_ENABLE(getmv,
-    [AC_HELP_STRING([--enable-getmv], [build with get mv support @<:@default=no@:>@])],
+    [AC_HELP_STRING([--enable-getmv],
+        [build with get mv support @<:@default=no@:>@])],
     [], [enable_getmv="no"])
+
 if test "$enable_getmv" = "yes"; then
-AC_DEFINE([__BUILD_GET_MV__], [1], [Defined to 1 if --enable-getmv="yes" ])
+    AC_DEFINE([__BUILD_GET_MV__], [1],
+        [Defined to 1 if --enable-getmv="yes"])
 fi
-AM_CONDITIONAL(BUILD_GET_MV, test "x$enable_getmv" = "xyes")
+AM_CONDITIONAL(BUILD_GET_MV,
+    [test "x$enable_getmv" = "xyes"])
 
 # dnl Doxygen
 AC_ARG_ENABLE(docs,
-              [AC_HELP_STRING([--enable-docs], [build with doxygen support @<:@default=yes@:>@])],
+    [AC_HELP_STRING([--enable-docs],
+        [build Doxygen docs @<:@default=yes@:>@])],
     [], [enable_docs="yes"])
+
 if test "$enable_docs" = "yes"; then
     AC_CHECK_TOOL([DOXYGEN], [doxygen], [no])
     if test "$DOXYGEN" = "no"; then
        enable_docs="no"
     fi
 fi
-AM_CONDITIONAL(ENABLE_DOCS, test "$enable_docs" = "yes")
+AM_CONDITIONAL(ENABLE_DOCS,
+    [test "$enable_docs" = "yes"])
 
 # Checks for programs.
 AC_DISABLE_STATIC
@@ -237,13 +295,14 @@ AC_SUBST(LIBVA_VERSION)
 
 PKG_CHECK_MODULES(LIBVA_DRM, [libva-drm])
 if test "$enable_x11" = "yes" -o "$enable_v4l2_glx" = "yes"; then
-PKG_CHECK_MODULES(LIBVA_X11, [libva-x11],
-	         [AC_DEFINE([HAVE_VA_X11], [1], [Defined to 1 if VA/X11 API is enabled])])
-PKG_CHECK_MODULES(X11, [x11])
+    PKG_CHECK_MODULES(LIBVA_X11, [libva-x11],
+        [AC_DEFINE([HAVE_VA_X11], [1],
+            [Defined to 1 if VA/X11 API is enabled])])
+    PKG_CHECK_MODULES(X11, [x11])
 fi
 
 if test "$enable_v4l2" = "yes"; then
-PKG_CHECK_MODULES(LIBV4L2, [libv4l2])
+    PKG_CHECK_MODULES(LIBV4L2, [libv4l2])
 fi
 
 if test ["$enable_v4l2" = "yes" -a "$enable_v4l2_glx" = "no"] -o "$enable_tests_gles" = "yes"; then
@@ -256,15 +315,15 @@ fi
 
 # drm_fourcc.h for dma_buf support
 if test "$enable_dmabuf" = "yes"; then
-PKG_CHECK_MODULES(LIBDRM, [libdrm])
+    PKG_CHECK_MODULES(LIBDRM, [libdrm])
 fi
 
 if test "$enable_v4l2_glx" = "yes"; then
-PKG_CHECK_MODULES(LIBGL, [gl])
+    PKG_CHECK_MODULES(LIBGL, [gl])
 fi
 
 if test "$enable_avformat" = "yes"; then
-PKG_CHECK_MODULES(LIBAVFORMAT,  libavformat libavcodec libavutil)
+    PKG_CHECK_MODULES(LIBAVFORMAT,  [libavformat libavcodec libavutil])
 fi
 
 # Checks for library functions.

--- a/configure.ac
+++ b/configure.ac
@@ -103,22 +103,20 @@ AC_ARG_ENABLE(x11,
     [AC_HELP_STRING([--enable-x11], [enable x11@<:@default=yes@:>@])],
 	[], [enable_x11="yes"])
 
-AS_IF([test "x$enable_x11" = "xyes"],
-[AC_DEFINE([__ENABLE_X11__], [1], [Defined to 0 if --enable-x11="yes" ])],
-[TEST "X$enable_x11" = "xno"],
-[AC_DEFINE([__ENABLE_X11__], [1], [Defined to 1 if --disable-x11="yes" ])],
-[])
+if test "$enable_x11" = "yes"; then
+    AC_DEFINE([__ENABLE_X11__], [1],
+        [Defined to 1 if --enable-x11="yes" ])
+fi
 AM_CONDITIONAL(ENABLE_X11, test "x$enable_x11" = "xyes")
 
 AC_ARG_ENABLE(avformat,
     [AC_HELP_STRING([--enable-avformat], [enable avformat@<:@default=no@:>@])],
     [], [enable_avformat="no"])
 
-AS_IF([test "x$enable_avformat" = "xyes"],
-[AC_DEFINE([__ENABLE_AVFORMAT__], [1], [Defined to 0 if --enable-avformat="yes" ])],
-[TEST "X$enable_avformat" = "xno"],
-[AC_DEFINE([__ENABLE_AVFORMAT__], [1], [Defined to 1 if --disable-avformat="yes" ])],
-[])
+if test "$enable_avformat" = "yes"; then
+    AC_DEFINE([__ENABLE_AVFORMAT__], [1],
+        [Defined to 1 if --enable-avformat="yes" ])
+fi
 AM_CONDITIONAL(ENABLE_AVFORMAT, test "x$enable_avformat" = "xyes")
 
 AC_ARG_ENABLE(baytrail,

--- a/configure.ac
+++ b/configure.ac
@@ -38,15 +38,10 @@ AC_SUBST(LIBYAMI_LT_VERSION)
 AC_SUBST(LIBYAMI_LT_LDFLAGS)
 
 AC_ARG_ENABLE(debug,
-    [AC_HELP_STRING([--enable-debug],[build with extra debug])],
-    [case "${enableval}" in
-     yes) debug="yes" ;;
-     no)  debug="no";;
-     *)   AC_MSG_ERROR(bad value for --enable-debug);;
-     esac ],
-    [debug="no"])
+    [AC_HELP_STRING([--enable-debug],[build with extra debug @<:@default=no@:>@])],
+    [], [enable_debug="no"])
 
-if test "$debug" = "yes"; then
+if test "$enable_debug" = "yes"; then
 AC_DEFINE([__ENABLE_DEBUG__], [1], [Defined to 1 if --enable-debug="yes" ])
 fi
 


### PR DESCRIPTION
This series fixes a few minor bugs in configure.ac, cleans up some inconsistent line formatting and adds a summary output at the end of configure.