### PR TITLE
egl: use eglGetProcAddress instead of EGL_EGLEXT_PROTOTYPES

### DIFF
--- a/egl/egl_util.h
+++ b/egl/egl_util.h
@@ -23,7 +23,6 @@
 #ifndef __EGL_UTIL_H__
 #define __EGL_UTIL_H__
 #include <EGL/egl.h>
-#define EGL_EGLEXT_PROTOTYPES
 #include <EGL/eglext.h>
 
 #include "VideoCommonDefs.h"
@@ -31,6 +30,8 @@
 extern "C" {
 #endif /* __cplusplus */
 
+EGLImageKHR createImage(EGLDisplay, EGLContext, EGLenum, EGLClientBuffer, const EGLint *);
+EGLBoolean destroyImage(EGLDisplay, EGLImageKHR);
 EGLImageKHR createEglImageFromHandle(EGLDisplay eglDisplay, EGLContext eglContext, VideoDataMemoryType type, uint32_t dmaBuf, int width, int height, int pitch);
 
 #ifdef __cplusplus

--- a/tests/decodeoutput.cpp
+++ b/tests/decodeoutput.cpp
@@ -483,12 +483,12 @@ Decode_Status DecodeOutputDmabuf::renderOneFrame(bool drain)
         eglImage = createEglImageFromHandle(m_eglContext->eglContext.display, m_eglContext->eglContext.context, m_frame.memoryType, m_frame.handle,
                 m_frame.width, m_frame.height, m_frame.pitch[0]);
         if (eglImage != EGL_NO_IMAGE_KHR) {
-            glEGLImageTargetTexture2DOES(target, eglImage);
+            imageTargetTexture2D(target, eglImage);
             glTexParameteri(target, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
             glTexParameteri(target, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
             drawTextures(m_eglContext, target, &m_textureId, 1);
 
-            eglDestroyImageKHR(m_eglContext->eglContext.display, eglImage);
+            destroyImage(m_eglContext->eglContext.display, eglImage);
         } else {
             ERROR("fail to create EGLImage from dma_buf");
         }

--- a/tests/egl/gles2_help.c
+++ b/tests/egl/gles2_help.c
@@ -77,15 +77,26 @@ static const char *vertexShaderText_rgba =
   "   v_texcoord  = texcoord;\n"
   "}\n";
 
+static PFNGLEGLIMAGETARGETTEXTURE2DOESPROC imageTargetTexture2DProc = NULL;
+
+void imageTargetTexture2D(EGLenum target, EGLImageKHR image)
+{
+    if (!imageTargetTexture2DProc) {
+        imageTargetTexture2DProc =
+            (void *) eglGetProcAddress("glEGLImageTargetTexture2DOES");
+    }
+    imageTargetTexture2DProc(target, image);
+}
+
 GLuint
 createTextureFromPixmap(EGLContextType *context, XID pixmap)
 {
     GLuint textureId;
 
-    EGLImageKHR image = eglCreateImageKHR(context->eglContext.display, context->eglContext.context, EGL_NATIVE_PIXMAP_KHR, (EGLClientBuffer)pixmap, NULL);
+    EGLImageKHR image = createImage(context->eglContext.display, context->eglContext.context, EGL_NATIVE_PIXMAP_KHR, (EGLClientBuffer)pixmap, NULL);
     glGenTextures(1, &textureId );
     glBindTexture(GL_TEXTURE_2D, textureId);
-    glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, image);
+    imageTargetTexture2D(GL_TEXTURE_2D, image);
 
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/tests/egl/gles2_help.h
+++ b/tests/egl/gles2_help.h
@@ -28,10 +28,9 @@
 #include <EGL/egl.h>
 #include <GLES2/gl2.h>
 #include <stdint.h>
-#define EGL_EGLEXT_PROTOTYPES
 #include <EGL/eglext.h>
-#define GL_GLEXT_PROTOTYPES
 #include <GLES2/gl2ext.h>
+#include "egl/egl_util.h"
 
 typedef struct {
     EGLDisplay          display;
@@ -63,6 +62,7 @@ EGLContextType* eglInit(Display *x11Display, XID window, uint32_t fourcc, int is
 void eglRelease(EGLContextType *context);
 GLuint createTextureFromPixmap(EGLContextType *context, XID pixmap);
 int drawTextures(EGLContextType *context, GLenum target, GLuint *textureIds, int texCount);
+void imageTargetTexture2D(EGLenum, EGLImageKHR);
 
 #ifdef __cplusplus
 }

--- a/tests/v4l2decode.cpp
+++ b/tests/v4l2decode.cpp
@@ -520,7 +520,7 @@ int main(int argc, char** argv)
              if (memoryType == VIDEO_DATA_MEMORY_TYPE_DMA_BUF)
                  target = GL_TEXTURE_EXTERNAL_OES;
              glBindTexture(target, textureIds[i]);
-             glEGLImageTargetTexture2DOES(target, eglImages[i]);
+             imageTargetTexture2D(target, eglImages[i]);
 
              glTexParameteri(target, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
              glTexParameteri(target, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
@@ -596,7 +596,7 @@ int main(int argc, char** argv)
     glxRelease(glxContext, &pixmaps[0], &glxPixmaps[0], pixmaps.size());
 #else
     for (i=0; i<eglImages.size(); i++) {
-        eglDestroyImageKHR(eglContext->eglContext.display, eglImages[i]);
+        destroyImage(eglContext->eglContext.display, eglImages[i]);
     }
     /*
     there is still randomly fail in mesa; no good idea for it. seems mesa bug


### PR DESCRIPTION
eglCreateImageKHR, eglDestroyImageKHR, and glEGLImageTargetTexture2DOES
are not defined in the symbol table in newer versions (>=10.6? or
possibly earlier) of the mesa libEGL and libGLESv2 libraries.  They
should be looked up at runtime instead.  Thus, look them up with the
eglGetProcAddress at runtime.  The use of EGL_EGLEXT_PROTOTYPES is no
longer needed for this.

Fixes #229

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>