### PR TITLE
vp8: fix loop_filter_level flag error bug.

### DIFF
--- a/decoder/vaapidecoder_vp8.cpp
+++ b/decoder/vaapidecoder_vp8.cpp
@@ -221,16 +221,15 @@ bool VaapiDecoderVP8::fillPictureParam(const PicturePtr&  picture)
     }
 
     for (i = 0; i < 4; i++) {
+        int8_t level;
         if (seg->segmentation_enabled) {
-            picParam->loop_filter_level[i] = seg->lf_update_value[i];
-            if (!seg->segment_feature_mode) {
-                picParam->loop_filter_level[i] +=
-                    m_frameHdr.loop_filter_level;
-                picParam->loop_filter_level[i] =
-                    CLAMP(picParam->loop_filter_level[i], 0, 63);
-            }
-        } else
-            picParam->loop_filter_level[i] = m_frameHdr.loop_filter_level;
+            level = seg->lf_update_value[i];
+            if (!seg->segment_feature_mode)
+                level += m_frameHdr.loop_filter_level;
+        } else {
+            level = m_frameHdr.loop_filter_level;
+        }
+        picParam->loop_filter_level[i] = CLAMP(level, 0, 63);
 
         picParam->loop_filter_deltas_ref_frame[i] =
             m_parser.mb_lf_adjust.ref_frame_delta[i];


### PR DESCRIPTION
int8_t structure(seg->lf_update_value[i]) set to unsigned char(picParam->loop_filter_level[i]) causes value error.

Signed-off-by: Zhong Cong <congx.zhong@intel.com>