### PR TITLE
MD5: print MD5 under the mode -2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -134,6 +134,10 @@ if test "$enable_baytrail" = "yes"; then
 AC_DEFINE([__PLATFORM_BYT__], [1], [Defined to 1 if --enable-baytrail="yes" ])
 fi
 
+AC_ARG_ENABLE(md5,
+    [AC_HELP_STRING([--enable-md5], [enable generate md5 by per frame@<:@default=yes@:>@])],
+    [], [enable_md5="yes"])
+
 dnl vp8 decoder
 AC_ARG_ENABLE(vp8dec,
     [AC_HELP_STRING([--enable-vp8dec], [build with vp8 decoder support @<:@default=yes@:>@])],
@@ -273,6 +277,14 @@ fi
 if test "$enable_avformat" = "yes"; then
 PKG_CHECK_MODULES(LIBAVFORMAT,  libavformat libavcodec libavutil)
 fi
+
+#check openssl
+if test "$enable_md5" = "yes"; then
+PKG_CHECK_MODULES(OPENSSL, [openssl],
+	         [AC_DEFINE([__ENABLE_MD5__], [1], [Defined to 1 if MD5 API and --enable-md5[default] are enabled])],
+	         [enable_md5="no"])
+fi
+AM_CONDITIONAL(ENABLE_MD5, test "x$enable_md5" = "xyes")
 
 # Checks for library functions.
 AC_FUNC_MALLOC

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -45,6 +45,9 @@ endif
 if ENABLE_AVFORMAT
 YAMI_DECODE_LIBS += $(LIBAVFORMAT_LIBS)
 endif
+if ENABLE_MD5
+YAMI_DECODE_LIBS += -lcrypto
+endif
 
 YAMI_ENCODE_LIBS = \
 	$(YAMI_COMMON_LIBS)                             \

--- a/tests/decode.cpp
+++ b/tests/decode.cpp
@@ -65,6 +65,13 @@ int main(int argc, char** argv)
         return -1;
     }
 #endif
+#if !__ENABLE_MD5__
+    if (renderMode == -2) {
+        fprintf(stderr, "renderMode=%d is not supported, you must compile libyami without --disable-md5 option "
+                "and package libssl-dev should be installed\n", renderMode);
+        return -1;
+    }
+#endif
     input = DecodeInput::create(inputFileName);
 
     if (input==NULL) {

--- a/tests/decodehelp.h
+++ b/tests/decodehelp.h
@@ -59,6 +59,7 @@ static void print_help(const char* app)
     printf("   -f dumped fourcc [*]\n");
     printf("   -o dumped output dir\n");
     printf("   -m <render mode>\n");
+    printf("     -2: print MD5 by per frame and the whole decoded file MD5\n");
     printf("     -1: skip video rendering [*]\n");
     printf("      0: dump video frame to file\n");
     printf("      1: render to X window [*]\n");

--- a/tests/decodeoutput.h
+++ b/tests/decodeoutput.h
@@ -4,6 +4,7 @@
  *  Copyright (C) 2011-2014 Intel Corporation
  *    Author: Halley Zhao<halley.zhao@intel.com>
  *    Author: Xu Guangxin <guangxin.xu@intel.com>
+ *    Author: Liu Yangbin <yangbinx.liu@intel.com>
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public License
@@ -30,6 +31,10 @@
 #include <stdio.h>
 #include <vector>
 #include <sstream>
+
+#if  __ENABLE_MD5__
+#include <openssl/md5.h>
+#endif
 
 using namespace YamiMediaCodec;
 
@@ -69,6 +74,7 @@ class DecodeOutputRaw : public DecodeOutput
 {
 friend DecodeOutput* DecodeOutput::create(IVideoDecoder* decoder, int mode);
 public:
+    virtual bool config(const char* source, const char* dest, uint32_t fourcc) = 0;
     virtual Decode_Status renderOneFrame(bool drain);
     ~DecodeOutputRaw();
 
@@ -104,6 +110,25 @@ private:
 
 };
 
+#if  __ENABLE_MD5__
+class DecodeOutputExtractMD5 : public DecodeOutputRaw
+{
+friend DecodeOutput* DecodeOutput::create(IVideoDecoder* decoder, int mode);
+public:
+    DecodeOutputExtractMD5(IVideoDecoder* decoder);
+    ~DecodeOutputExtractMD5();
+
+    virtual bool render(VideoFrameRawData* frame);
+
+    bool config(const char* source, const char* dest, uint32_t fourcc);
+
+private:
+	std::string extractMd5ToHexStr(MD5_CTX& ctx);
+
+    MD5_CTX m_md5Ctx;
+    FILE* m_fp;
+};
+#endif
 
 //help functions
 bool renderOutputFrames(DecodeOutput* output, bool drain = false);

--- a/testscripts/autotest.py
+++ b/testscripts/autotest.py
@@ -23,10 +23,10 @@ if __name__ == '__main__':
     capidecode = os.path.join(yamitestpath, 'decodecapi')
     capiencode = os.path.join(yamitestpath, 'encodecapi')
     psnr       = os.path.join(autotestpath, 'psnr')
-    decodemodelist = ['m', '0']
+    decodemodelist = ['m', '0', '-2']
     encodemodelist = ['m', '0']
-    v4l2wmodelist  = ['w', '0', '1']
-    v4l2mmodelist  = ['m', '-1', '0', '1', '2', '3', '4']
+    v4l2wmodelist  = ['w', '0']
+    v4l2mmodelist  = ['m', '0', '3', '4']
 
     if testformat == 'decode':
         yamiobject = libyami(yamidecode, yamiencode, psnr)

--- a/testscripts/unit_test.sh
+++ b/testscripts/unit_test.sh
@@ -47,13 +47,18 @@ single_md5()
     refmd5file=`ls ${testfilepath}bits.md5`
     if [ ${refmd5file} ];then
         if [ ${refmd5file} != ${testfilepath}${file} ];then
-            ${yamipath}/tests/yamidecode -i ${testfilepath}${file}  -m 0 -f I420 -o ${outputpath}
-            mv ${file}* ${file}
-            currentmd5=`md5sum ${file} | awk '{print $1}'`
-            verify_md5 ${file} ${currentmd5}
+            ${yamipath}/tests/yamidecode -i ${testfilepath}${file} -m -2
+            currentmd5=`grep whole ${file}.md5 | awk '{print $5}'`
+            refmd5=` awk  '$2 ~/^'${file}'/{print $1}' ${refmd5file} | awk '{print $1}'`
+            if [ "$currentmd5" = "$refmd5" ]; then
+                echo "${file}    pass"  >> ${tmpass}
+            else
+                echo "${file}    fail"  >>  ${tmpfail}
+                failnumber=$(($failnumber+1))
+            fi
             i=$(($i+1))
             echo ${i}---${testfilepath}${file}
-            rm -f ${file}
+            rm -f ${file}.md5
         else
             openfile=$(($openfile-1))
             echo "${testfilepath}${file} is md5 file"


### PR DESCRIPTION
Using the mode -2 to print MD5 by per frame, and the MD5 of the whole
decoded YUV at the end, do not dump YUV to file again.