### PR TITLE
h264enc: fix h264 HDR comformance issues

### DIFF
--- a/encoder/vaapiencoder_h264.cpp
+++ b/encoder/vaapiencoder_h264.cpp
@@ -538,8 +538,12 @@ private:
             m_headers.insert(m_headers.end(), s, e);
             if (e == h.end())
                 break;
-            m_headers.insert(m_headers.end(), emulation, emulation + N_ELEMENTS(emulation));
+            
             s = e + N_ELEMENTS(zeros);
+            if (*s <= 3)
+                m_headers.insert(m_headers.end(), emulation, emulation + N_ELEMENTS(emulation));
+            else
+                m_headers.insert(m_headers.end(), zeros, zeros + N_ELEMENTS(zeros));
          } while (1);
     }
 
@@ -688,7 +692,7 @@ VaapiEncoderH264::VaapiEncoderH264():
     m_streamFormat(AVC_STREAM_FORMAT_ANNEXB)
 {
     m_videoParamCommon.profile = VAProfileH264Main;
-    m_videoParamCommon.level = 40;
+    m_videoParamCommon.level = 52;
     m_videoParamCommon.rcParams.initQP = 26;
     m_videoParamCommon.rcParams.minQP = 1;
 


### PR DESCRIPTION
1. Let h264 level equal to max level, in order to support high level
bitrate, 4K encoding for example
2. As spec, only when bitstream contains 0x000000/0x000001/0x000002/0x000003
need to insert emulation byte 0x03

This patch ties to fix https://github.com/01org/libyami/issues/266 and https://github.com/01org/libyami/issues/265