### PR TITLE
vp9dec: increase CacheBufferSize.

### DIFF
--- a/tests/decodeinput.cpp
+++ b/tests/decodeinput.cpp
@@ -38,7 +38,7 @@ using namespace YamiMediaCodec;
 class MyDecodeInput : public DecodeInput{
 public:
     static const int MaxNaluSize = 1024*1024; // assume max nalu size is 1M
-    static const int CacheBufferSize = 4 * MaxNaluSize;
+    static const int CacheBufferSize = 8 * MaxNaluSize;
     MyDecodeInput();
     virtual ~MyDecodeInput();
     bool initInput(const char* fileName);
@@ -229,6 +229,8 @@ bool DecodeInputVPX::getNextDecodeUnit(VideoDecodeBuffer &inputBuffer)
         int framesize = 0;
         framesize = (uint32_t)(m_buffer[0]) + ((uint32_t)(m_buffer[1])<<8) + ((uint32_t)(m_buffer[2])<<16);
         assert (framesize < (uint32_t) m_maxFrameSize);
+        assert (framesize <= (uint32_t) CacheBufferSize);
+
         if (framesize != fread (m_buffer, 1, framesize, m_fp)) {
             fprintf (stderr, "fail to read frame data, quit\n");
             return false;


### PR DESCRIPTION
framesize bigger than previous CacheBufferSize in some vp9 clips.
And that causes fread error.

Clips: Stress_VP9_3840x2160_150_inter_stress_1.1.vp9
       Stress_VP9_3840x2160_208_extra_lossless_stress_1.1.vp9

Signed-off-by: Zhong Cong <congx.zhong@intel.com>