### PR TITLE
compileOpt: adujst the location of compile options

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -25,5 +25,5 @@ fi
 cd "$olddir"
 
 if test -z "$NOCONFIGURE"; then
-    CXXFLAGS="-Wno-unused-function -Wno-sign-compare -Wno-cpp -Wall -Werror" $srcdir/configure "$@" && echo "Now type 'make' to compile $PROJECT."
+    $srcdir/configure "$@" && echo "Now type 'make' to compile $PROJECT."
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -206,6 +206,9 @@ if test "$enable_docs" = "yes"; then
 fi
 AM_CONDITIONAL(ENABLE_DOCS, test "$enable_docs" = "yes")
 
+: ${CFLAGS="-g -O2 -Wno-unused-function -Wno-sign-compare -Wno-cpp -Wall -Werror"}
+: ${CXXFLAGS="-g -O2 -Wno-unused-function -Wno-sign-compare -Wno-cpp -Wall -Werror"}
+
 # Checks for programs.
 AC_DISABLE_STATIC
 AC_PROG_CXX

--- a/tests/decodecapi.c
+++ b/tests/decodecapi.c
@@ -44,7 +44,6 @@ int main(int argc, char** argv)
     VideoConfigBuffer configBuffer;
     const VideoFormatInfo *formatInfo = NULL;
     Decode_Status status;
-    NativeDisplay nativeDisplay;
 
     if (!process_cmdline(argc, argv))
         return -1;

--- a/tests/egl/gles2_help.c
+++ b/tests/egl/gles2_help.c
@@ -295,8 +295,7 @@ EGLContextType *eglInit(Display *x11Display, XID x11Window, uint32_t fourcc, int
     result = eglMakeCurrent(eglDisplay, eglSurface, eglSurface, eglContext);
     EGL_CHECK_RESULT_RET(result, "eglMakeCurrent", NULL);
 
-    const unsigned char* glVersion = glGetString(GL_VERSION);
-    INFO("Runing GL version: %s, please make sure it support GL 2.0 API", glVersion);
+    INFO("Runing GL version: %s, please make sure it support GL 2.0 API", glGetString(GL_VERSION));
 
     // clear to middle blue
     glClearColor(0.0, 0.0, 0.5, 0.0);

--- a/tests/encodecapi.c
+++ b/tests/encodecapi.c
@@ -49,7 +49,7 @@ int main(int argc, char** argv)
     if (!process_cmdline(argc, argv))
         return -1;
 
-    DEBUG("inputFourcc: %.4s", &(inputFourcc));
+    DEBUG("inputFourcc: %.4s", (char*)(&inputFourcc));
     input = createEncodeInput(inputFileName, inputFourcc, videoWidth, videoHeight);
 
     if (!input) {

--- a/tests/glx/glx_help.c
+++ b/tests/glx/glx_help.c
@@ -117,8 +117,6 @@ void glxRelease(GLXContextType *glxContext, Pixmap *pixmaps, GLXPixmap *glxPixma
 
 int createPixmapForTexture(GLXContextType *glxContext, GLuint texture, uint32_t width, uint32_t height, Pixmap *pixmap, GLXPixmap *glxPixmap)
 {
-    int i;
-
     if (!glxContext || !texture || !width || !height || !pixmap || !glxPixmap)
         return -1;
 


### PR DESCRIPTION
 i set the comple options in the autogen.sh in previous commit, which is not noly a bad ideal but also just is useful for c++ compiler. 