### PR TITLE
vp9dec: fix Vp9SegmentationInfoData mistake.

### DIFF
--- a/codecparsers/vp9parser.c
+++ b/codecparsers/vp9parser.c
@@ -517,9 +517,18 @@ static void set_default_lf_deltas(Vp9Parser* parser)
   priv->mode_deltas[1] = 0;
 }
 
+static void set_default_segmentation_info(Vp9Parser* parser)
+{
+  Vp9ParserPrivate* priv = (Vp9ParserPrivate*)parser->priv;
+
+  memset(priv->segmentation, 0, sizeof(priv->segmentation));
+  priv->segmentation_abs_delta = FALSE;
+}
+
 static void setup_past_independence(Vp9Parser* parser)
 {
   set_default_lf_deltas(parser);
+  set_default_segmentation_info(parser);
 }
 
 static Vp9ParseResult vp9_parser_update(Vp9Parser* parser, const Vp9FrameHdr* const frame_hdr)


### PR DESCRIPTION
When the frame is intra only or error_resilient_mode is on,
priv->segmentation(Vp9SegmentationInfo structure) should be
set to default value(0).

clips:
Smaller_VP9_209_extra_smaller_1.1.vp9
Stress_VP9_1920x1080_150_inter_stress_1.1.vp9
Stress_VP9_3840x2160_208_extra_lossless_stress_1.1.vp9
Syntax_VP9_1920x1080_111_inter_entropy_contexts_1.1.vp9
Syntax_VP9_1920x1080_201_extra_tiles_1.1.vp9
Syntax_VP9_1920x1080_202_extra_residual_1.1.vp9
Syntax_VP9_1920x1080_203_extra_transform_1.1.vp9
Syntax_VP9_1920x1080_207_extra_lossless_1.1.vp9
Syntax_VP9_432x240_111_inter_entropy_contexts_1.1.vp9
Syntax_VP9_432x240_201_extra_tiles_1.1.vp9
Syntax_VP9_432x240_203_extra_transform_1.1.vp9
Syntax_VP9_432x240_207_extra_lossless_1.1.vp9
Stress_VP9_1920x1080_208_extra_lossless_stress_1.1.vp9
Stress_VP9_432x240_150_inter_stress_1.1.vp9
Stress_VP9_432x240_208_extra_lossless_stress_1.1.vp9
Syntax_VP9_1920x1080_206_extra_repeat_existing_1.1.vp9
Syntax_VP9_432x240_202_extra_residual_1.1.vp9
Syntax_VP9_432x240_206_extra_repeat_existing_1.1.vp9

Signed-off-by: Zhong Cong <congx.zhong@intel.com>