### PR TITLE
docs: enable hyper link for doxygen main page

### DIFF
--- a/decoder/vaapidecsurfacepool.h
+++ b/decoder/vaapidecsurfacepool.h
@@ -37,7 +37,7 @@
 
 namespace YamiMediaCodec{
 
-/**
+/***
  * \class VaapiDecSurfacePool
  * \brief surface pool used for decoding rendering
  * <pre>
@@ -55,8 +55,6 @@ namespace YamiMediaCodec{
  *    until all surface recycled.
  *</pre>
 */
-
-
 class VaapiDecSurfacePool : public std::tr1::enable_shared_from_this<VaapiDecSurfacePool>
 {
 public:

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -15,6 +15,7 @@ LIBYAMI_DOC_STRIP_FILES = vaapibuffer.h             \
     $(top_srcdir)/decoder/vaapidecoder_h264.h       \
     $(top_srcdir)/decoder/vaapidecoder_jpeg.h       \
     $(top_srcdir)/decoder/vaapidecoder_vp8.h        \
+    $(top_srcdir)/decoder/vaapidecsurfacepool.h        \
     $(top_srcdir)/decoder/vaapipicture.h            \
     $(top_srcdir)/decoder/vaapisurfacebuf_pool.h    \
     $(top_srcdir)/encoder/vaapicodedbuffer.h        \

--- a/doc/mainpage.dox
+++ b/doc/mainpage.dox
@@ -3,16 +3,16 @@
 * <pre>
 * ==== Here are API of libyami
 * == Decoder APIs
-* class IVideoDecoder
+* class YamiMediaCodec::IVideoDecoder
 * func createVideoDecoder()
 * func releaseVideoDecoder()
 *
 * == Encoder APIs
-* class IVideoEncoder
+* class YamiMediaCodec::IVideoEncoder
 * func createVideoEncoder()
 * func releaseVideoEncoder()
 *
 * ==== More information on internal implementation:
-* class VaapiSurfaceBufferPool
+* class YamiMediaCodec::VaapiDecSurfacePool
 * </pre>
 */

--- a/interface/VideoEncoderHost.h
+++ b/interface/VideoEncoderHost.h
@@ -32,9 +32,7 @@ extern "C" { // for dlsym usage
  * \brief create encoder basing on given mimetype
 */
 YamiMediaCodec::IVideoEncoder *createVideoEncoder(const char *mimeType);
-/** \fn void releaseVideoEncoder(IVideoEncoder *p)
- * \brief destroy encoder
-*/
+///brief destroy encoder
 void releaseVideoEncoder(YamiMediaCodec::IVideoEncoder * p);
 
 typedef YamiMediaCodec::IVideoEncoder *(*YamiCreateVideoEncoderFuncPtr) (const char *mimeType);


### PR DESCRIPTION
we lost hyper link since we put some major class to YamiMediaCodec namespace