### PR TITLE
vaapi_display: Remove hard coded hybrid driver name

### DIFF
--- a/vaapi/vaapidisplay.cpp
+++ b/vaapi/vaapidisplay.cpp
@@ -337,10 +337,6 @@ DisplayPtr VaapiDisplay::create(const NativeDisplay& display)
 DisplayPtr VaapiDisplay::create(const NativeDisplay& display, VAProfile profile)
 {
     SharedPtr<DisplayCache> cache = DisplayCache::getInstance();
-    const std::string name="hybrid";
-    if (profile == VAProfileVP9Profile0)
-        return cache->createDisplay(display, name);
-    else
         return cache->createDisplay(display);
 }
 } //YamiMediaCodec


### PR DESCRIPTION
We are no longer requiring hard coding of the hybrid driver.
It also breaks HW VP9 support on new Platforms.

Signed-off-by: Sean V Kelley <seanvk@posteo.de>