### PR TITLE
capi: remove non existing function encodeflush from header

### DIFF
--- a/capi/VideoEncoderCapi.h
+++ b/capi/VideoEncoderCapi.h
@@ -41,8 +41,6 @@ Encode_Status encodeStart(EncodeHandler p);
 
 void encodeStop(EncodeHandler p);
 
-void encodeflush(EncodeHandler p);
-
 Encode_Status encode(EncodeHandler p, VideoFrameRawData * inBuffer);
 
 Encode_Status encodeGetOutput(EncodeHandler p, VideoEncOutputBuffer * outBuffer, bool withWait);

--- a/vaapi/vaapidisplay.cpp
+++ b/vaapi/vaapidisplay.cpp
@@ -138,7 +138,9 @@ class NativeDisplayDrm : public NativeDisplayBase{
         if (acceptValidExternalHandle(display))
             return true;
 
-        m_handle = open("/dev/dri/card0", O_RDWR);
+        m_handle = open("/dev/dri/renderD128", O_RDWR);
+        if (m_handle < 0)
+            m_handle = open("/dev/dri/card0", O_RDWR);
         m_selfCreated = true;
         return m_handle != -1;
     };


### PR DESCRIPTION
This function does not exist in the interface and should not be in the capi.