### PR TITLE
h264dec: fix the frame flick issue.

### DIFF
--- a/decoder/vaapidecoder_h264.h
+++ b/decoder/vaapidecoder_h264.h
@@ -219,7 +219,8 @@ class VaapiDPBManager {
     /* marking pic after slice decoded */
     bool execRefPicMarking(const PicturePtr& pic, bool * hasMMCO5);
     PicturePtr addDummyPicture(const PicturePtr& pic,
-                               int32_t frameNum);
+                               int32_t frameNum,
+                               const SurfacePtr& surface);
     bool execDummyPictureMarking(const PicturePtr& dummyPic,
                                  const SliceHeaderPtr& sliceHdr,
                                  int32_t frameNum);

--- a/decoder/vaapidecoder_h264_dpb.cpp
+++ b/decoder/vaapidecoder_h264_dpb.cpp
@@ -527,9 +527,10 @@ bool VaapiDPBManager::execRefPicMarking(const PicturePtr& pic,
 }
 
 PicturePtr VaapiDPBManager::addDummyPicture(const PicturePtr& pic,
-                                            int32_t frameNum)
+                                            int32_t frameNum,
+                                            const SurfacePtr& surface)
 {
-    PicturePtr dummyPic(new VaapiDecPictureH264(pic->m_context, pic->m_surface, 0));
+    PicturePtr dummyPic(new VaapiDecPictureH264(pic->m_context, surface, 0));
     if (!dummyPic)
         return dummyPic;
 


### PR DESCRIPTION
1. fill the gaps dummy picture with surface from the previous
   valid frame, so that the next valid frame after gaps dummy
   frame can ref frame correctly.
2. Do not change the m_prevFrameNum so that the next valid frame
   after gaps dummy frame can get the correct poc.

Signed-off-by: Zhong Cong <congx.zhong@intel.com>