### PR TITLE
h264dec: dealing with droping frames when decoding several videos

### DIFF
--- a/decoder/vaapidecoder_h264_dpb.cpp
+++ b/decoder/vaapidecoder_h264_dpb.cpp
@@ -407,6 +407,7 @@ bool VaapiDPBManager::addDPB(const VaapiFrameStore::Ptr& newFrameStore,
             if (!foundPicture) {
                 bool ret = true;
                 if (newFrameStore->hasFrame()) {
+                    newFrameStore->m_outputNeeded++;
                     ret = outputDPB(newFrameStore, pic);
                 } else {
                     m_prevFrameStore = newFrameStore;   // wait for a complete frame to render


### PR DESCRIPTION
issue 286:
1.blue_sky_420_1280x720.264
2.pedestrian_area_420_720x576.264
3.V30313_B_D-Traffic_AVC_MP_num_ref_frames_6.264
droping frames when decoding
