### PR TITLE
Revert "vaapidisplay: use the libva api for driver name"

### DIFF
--- a/decoder/vaapidecoder_base.cpp
+++ b/decoder/vaapidecoder_base.cpp
@@ -375,7 +375,7 @@ Decode_Status
         INFO("setting LIBVA_DRIVER_NAME to wrapper for chromeos");
     }
 #endif
-    m_display = VaapiDisplay::create(m_externalDisplay, profile);
+    m_display = VaapiDisplay::create(m_externalDisplay);
 
     if (!m_display) {
         ERROR("failed to create display");

--- a/vaapi/vaapidisplay.cpp
+++ b/vaapi/vaapidisplay.cpp
@@ -54,16 +54,6 @@ using std::list;
 
 //helper function
 namespace YamiMediaCodec{
-static bool vaSelectDriver(VADisplay vaDisplay, const std::string& driverName)
-{
-    VAStatus vaStatus=VA_STATUS_SUCCESS;
-    if (!driverName.empty())
-    {
-        vaStatus = vaSetDriverName(vaDisplay, const_cast<char*>(driverName.c_str()));
-    }
-    return checkVaapiStatus(vaStatus, "vaSetDriverName");
-}
-
 static bool vaInit(VADisplay vaDisplay)
 {
    int majorVersion, minorVersion;
@@ -236,7 +226,7 @@ class DisplayCache
 {
 public:
     static SharedPtr<DisplayCache> getInstance();
-    DisplayPtr createDisplay(const NativeDisplay& nativeDisplay, const std::string& driverName="");
+    DisplayPtr createDisplay(const NativeDisplay& nativeDisplay);
 
     ~DisplayCache() {}
 private:
@@ -261,7 +251,7 @@ bool expired(const weak_ptr<VaapiDisplay>& weak)
     return !weak.lock();
 }
 
-DisplayPtr DisplayCache::createDisplay(const NativeDisplay& nativeDisplay, const std::string& driverName)
+DisplayPtr DisplayCache::createDisplay(const NativeDisplay& nativeDisplay)
 {
     NativeDisplayPtr nativeDisplayObj;
     VADisplay vaDisplay = NULL;
@@ -318,9 +308,6 @@ DisplayPtr DisplayCache::createDisplay(const NativeDisplay& nativeDisplay, const
         return vaapiDisplay;
     }
 
-    if (!driverName.empty())
-        vaSelectDriver(vaDisplay, driverName);
-
     if (nativeDisplay.type == NATIVE_DISPLAY_VA || vaInit(vaDisplay)) {
         DisplayPtr temp(new VaapiDisplay(nativeDisplayObj, vaDisplay));
         vaapiDisplay = temp;
@@ -335,15 +322,5 @@ DisplayPtr DisplayCache::createDisplay(const NativeDisplay& nativeDisplay, const
 DisplayPtr VaapiDisplay::create(const NativeDisplay& display)
 {
     return DisplayCache::getInstance()->createDisplay(display);
-}
-
-DisplayPtr VaapiDisplay::create(const NativeDisplay& display, VAProfile profile)
-{
-    SharedPtr<DisplayCache> cache = DisplayCache::getInstance();
-    const std::string name="hybrid";
-    if (profile == VAProfileVP9Profile0)
-        return cache->createDisplay(display, name);
-    else
-        return cache->createDisplay(display);
 }
 } //YamiMediaCodec

--- a/vaapi/vaapidisplay.h
+++ b/vaapi/vaapidisplay.h
@@ -31,7 +31,6 @@
 #include <va/va_x11.h>
 #endif
 #include <va/va_drm.h>
-#include <string>
 #include <vector>
 #include "interface/VideoCommonDefs.h"
 #include "common/lock.h"
@@ -51,7 +50,6 @@ public:
     ~VaapiDisplay();
     //FIXME: add more create functions.
     static DisplayPtr create(const NativeDisplay& display);
-    static DisplayPtr create(const NativeDisplay& display, VAProfile profile);
     virtual bool setRotation(int degree);
     VADisplay getID() const { return m_vaDisplay; }
     const VAImageFormat* getVaFormat(uint32_t fourcc);


### PR DESCRIPTION
This reverts commit 07359e9b7900477d678e82abb131f936144c76df.

Conflicts:
    vaapi/vaapidisplay.cpp

Signed-off-by: Zhang Keqiao <keqiaox.k.zhang@intel.com>