### PR TITLE
v4l2dec: fixed compiling error

### DIFF
--- a/v4l2/v4l2_decode.cpp
+++ b/v4l2/v4l2_decode.cpp
@@ -331,7 +331,7 @@ int32_t V4l2Decoder::ioctl(int command, void* arg)
         if (format->type == V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE) {
             // ::Initialize
             uint32_t size;
-            size = *(uint32_t*)format->fmt.raw_data;
+            memcpy(&size, format->fmt.raw_data, sizeof(uint32_t));
             if(size <= (sizeof(format->fmt.raw_data)-sizeof(uint32_t))) {
                 m_configBuffer.size = size;
                 m_configBuffer.data = (uint8_t*)(format->fmt.raw_data) + sizeof(uint32_t);


### PR DESCRIPTION
when the compile opton "strict-aliasing" is actively, gcc 3 manual
says "an object of one type is assumed never to reside at the same
address as an object of a different type, unless the types are
almost the same".