### PR TITLE
when using DRM try /dev/dri/renderD128 before /dev/dri/card0

### DIFF
--- a/vaapi/vaapidisplay.cpp
+++ b/vaapi/vaapidisplay.cpp
@@ -128,7 +128,9 @@ class NativeDisplayDrm : public NativeDisplayBase{
         if (acceptValidExternalHandle(display))
             return true;
 
-        m_handle = open("/dev/dri/card0", O_RDWR);
+        m_handle = open("/dev/dri/renderD128", O_RDWR);
+        if (m_handle < 0)
+            m_handle = open("/dev/dri/card0", O_RDWR);
         m_selfCreated = true;
         return m_handle != -1;
     };


### PR DESCRIPTION
Working with QuickSync on servers, I noticed sometimes libyami does not work but vainfo does work.
These servers have more then one video card.
Looking at vainfo, first it tries to open /dev/dri/renderD128, then /dev/dri/card0
This PR does similar to libva, see libva/test/common/va_display_drm.c.