### PR TITLE
configure: enable vpg driver.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -280,6 +280,19 @@ fi
 AM_CONDITIONAL(ENABLE_DOCS,
     [test "$enable_docs" = "yes"])
 
+# dnl enable vpg
+AC_ARG_ENABLE(vpg,
+    [AC_HELP_STRING([--enable-vpg],
+        [enable vpg driver @<:@default=no@:>@])],
+    [], [enable_vpg="no"])
+
+if test "$enable_vpg" = "yes"; then
+    AC_DEFINE([__ENABLE_VPG__], [1],
+        [Defined to 1 if --enable-vpg="yes"])
+fi
+AM_CONDITIONAL(ENABLE_VPG,
+    [test "x$enable_vpg" = "xyes"])
+
 : ${CFLAGS="-g -O2 -Wno-unused-function -Wno-sign-compare -Wno-cpp -Wall -Werror"}
 : ${CXXFLAGS="-g -O2 -Wno-unused-function -Wno-sign-compare -Wno-cpp -Wall -Werror"}
 

--- a/decoder/vaapidecoder_base.cpp
+++ b/decoder/vaapidecoder_base.cpp
@@ -414,10 +414,11 @@ Decode_Status
         return DECODE_FAIL;
     }
 
+#ifndef __ENABLE_VPG__
     if (!m_display->setRotation(m_configBuffer.rotationDegrees)) {
         return DECODE_FAIL;
     }
-
+#endif
 
     if (!(m_configBuffer.flag & USE_NATIVE_GRAPHIC_BUFFER)) {
         m_videoFormatInfo.surfaceWidth = m_videoFormatInfo.width;


### PR DESCRIPTION
yami can not find the implement of vaSetDisplayAttributes
in vpg libva, so the the related rotation is disabled when
the vpg driver is enabled.

Signed-off-by: Zhong Cong <congx.zhong@intel.com>