### PR TITLE
h264_dec: fix compilation error with datatype

### DIFF
--- a/decoder/vaapidecoder_h264.h
+++ b/decoder/vaapidecoder_h264.h
@@ -304,7 +304,7 @@ class VaapiDecoderH264:public VaapiDecoderBase {
     int32_t m_prevFrameNum;     // prevFrameNum
     bool m_prevPicHasMMCO5;     // prevMMCO5Pic
     uint32_t m_progressiveSequence;
-    bool m_prevPicStructure;    // previous picture structure
+    uint32_t m_prevPicStructure;    // previous picture structure
     int32_t m_frameNumOffset;   // FrameNumOffset
 
   private:


### PR DESCRIPTION
m_prevPictStructure is always assigned enumeration values while
it is defined as boolean.  Redefining it to uint32_t to avoid
compilation issues

Signed-off-by: Daniel Charles <daniel.charles@intel.com>

The error is the following

vaapidecoder_h264.cpp:360:33: error: comparison of constant '2' with boolean expression is always false [-Werror=bool-compare]
             (m_prevPicStructure == VAAPI_PICTURE_STRUCTURE_BOTTOM_FIELD ?
