### PR TITLE
h264: address the problem of decoding dropped frames

### DIFF
--- a/decoder/vaapidecoder_h264_dpb.cpp
+++ b/decoder/vaapidecoder_h264_dpb.cpp
@@ -407,7 +407,9 @@ bool VaapiDPBManager::addDPB(const VaapiFrameStore::Ptr& newFrameStore,
             if (!foundPicture) {
                 bool ret = true;
                 if (newFrameStore->hasFrame()) {
-                    newFrameStore->m_outputNeeded++;
+                    if (newFrameStore->m_outputNeeded == 0) {
+                        newFrameStore->m_outputNeeded++;
+                    }
                     ret = outputDPB(newFrameStore, pic);
                 } else {
                     m_prevFrameStore = newFrameStore;   // wait for a complete frame to render


### PR DESCRIPTION
having run the regression test.