### PR TITLE
tests: fix static compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,9 @@ LIBYAMI_LT_LDFLAGS="-version-number $LIBYAMI_LT_VERSION"
 AC_SUBST(LIBYAMI_LT_VERSION)
 AC_SUBST(LIBYAMI_LT_LDFLAGS)
 
+AM_CONDITIONAL(BUILD_STATIC,
+    [test "x$enable_static" = "xyes"])
+
 AC_ARG_ENABLE(debug,
     [AC_HELP_STRING([--enable-debug],
         [build with extra debug @<:@default=no@:>@])],

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -39,6 +39,13 @@ YAMI_DECODE_LIBS 	= \
 	$(YAMI_COMMON_LIBS)                            	\
 	$(top_builddir)/decoder/libyami_decoder.la      \
 	$(NULL)
+
+if BUILD_STATIC
+YAMI_DECODE_LDFLAGS =				\
+	-Wl,--whole-archive,$(top_builddir)/decoder/.libs/libyami_decoder.a \
+	-Wl,--no-whole-archive
+endif
+
 if ENABLE_TESTS_GLES
 YAMI_DECODE_LIBS += $(LIBEGL_LIBS) $(LIBGLES2_LIBS)
 endif
@@ -55,10 +62,25 @@ YAMI_ENCODE_LIBS = \
 	$(YAMI_DECODE_LIBS)								\
 	$(NULL)
 
+if BUILD_STATIC
+YAMI_ENCODE_LDFLAGS =				\
+	-Wl,--whole-archive,$(top_builddir)/encoder/.libs/libyami_encoder.a \
+	-Wl,--no-whole-archive
+endif
+
 V4L2_DECODE_LIBS = \
 	$(YAMI_DECODE_LIBS)                         \
 	$(top_builddir)/v4l2/libyami_v4l2.la        \
 	$(NULL)
+
+if BUILD_STATIC
+V4L2_DECODE_LDFLAGS =				\
+	-Wl,--whole-archive,$(top_builddir)/v4l2/.libs/libyami_v4l2.a \
+	-Wl,--no-whole-archive \
+	-Wl,--whole-archive,$(top_builddir)/decoder/.libs/libyami_decoder.a \
+	-Wl,--no-whole-archive
+endif
+
 if ENABLE_V4L2_GLX
 V4L2_DECODE_LIBS += $(LIBGL_LIBS)
 else
@@ -69,6 +91,14 @@ V4L2_ENCODE_LIBS = \
 	$(YAMI_ENCODE_LIBS)                         \
 	$(top_builddir)/v4l2/libyami_v4l2.la        \
 	$(NULL)
+
+if BUILD_STATIC
+V4L2_ENCODE_LDFLAGS =				\
+	-Wl,--whole-archive,$(top_builddir)/v4l2/.libs/libyami_v4l2.a \
+	-Wl,--no-whole-archive \
+	-Wl,--whole-archive,$(top_builddir)/encoder/.libs/libyami_encoder.a \
+	-Wl,--no-whole-archive
+endif
 
 CAPI_DECODE_LIBS = \
 	$(YAMI_DECODE_LIBS)							\
@@ -89,6 +119,12 @@ YAMI_VPP_LIBS = \
     $(YAMI_ENCODE_LIBS) \
 	$(NULL)
 
+if BUILD_STATIC
+YAMI_VPP_LDFLAGS =				\
+	-Wl,--whole-archive,$(top_builddir)/vpp/.libs/libyami_vpp.a \
+	-Wl,--no-whole-archive
+endif
+
 YAMI_VPP_CFLAGS = \
     $(LIBVA_CFLAGS) \
     -fpermissive \
@@ -105,26 +141,31 @@ encodecapi_LDADD	= $(CAPI_ENCODE_LIBS)
 encodecapi_SOURCES	= encodecapi.c encodehelp.h encodeinput.cpp encodeInputCamera.cpp encodeInputDecoder.cpp encodeInputCapi.cpp $(DECODE_INPUT_SOURCES)
 else
 yamidecode_LDADD	= $(YAMI_DECODE_LIBS)
+yamidecode_LDFLAGS	= $(YAMI_DECODE_LDFLAGS)
 yamidecode_SOURCES	= decode.cpp decodehelp.h $(DECODE_INPUT_SOURCES) decodeoutput.cpp
 if ENABLE_TESTS_GLES
 yamidecode_SOURCES += ../egl/egl_util.c ./egl/gles2_help.c
 endif
 
 yamiencode_LDADD    = $(YAMI_ENCODE_LIBS)
+yamiencode_LDFLAGS  = $(YAMI_ENCODE_LDFLAGS)
 yamiencode_SOURCES  = encode.cpp encodeinput.cpp encodeInputCamera.cpp encodeInputDecoder.cpp $(DECODE_INPUT_SOURCES)
 
-v4l2decode_LDADD = $(V4L2_DECODE_LIBS)
+v4l2decode_LDADD   = $(V4L2_DECODE_LIBS)
+v4l2decode_LDFLAGS = $(V4L2_DECODE_LDFLAGS)
 v4l2decode_SOURCES = v4l2decode.cpp decodehelp.h $(DECODE_INPUT_SOURCES)
 if ENABLE_V4L2_GLX
 v4l2decode_SOURCES += ./glx/glx_help.c
 else
-v4l2decode_SOURCES += ../egl/egl_util.c ./egl/gles2_help.c
+v4l2decode_SOURCES += ./egl/gles2_help.c
 endif
 
-v4l2encode_LDADD = $(V4L2_ENCODE_LIBS)
+v4l2encode_LDADD   = $(V4L2_ENCODE_LIBS)
+v4l2encode_LDFLAGS = $(V4L2_ENCODE_LDFLAGS)
 v4l2encode_SOURCES = v4l2encode.cpp encodeinput.h encodeinput.cpp encodeInputCamera.cpp encodeInputDecoder.cpp $(DECODE_INPUT_SOURCES)
 endif
 
 yamivpp_LDADD    = $(YAMI_VPP_LIBS)
+yamivpp_LDFLAGS  = $(YAMI_VPP_LDFLAGS)
 yamivpp_SOURCES  = vppinputoutput.cpp vppoutputencode.cpp  vpp.cpp encodeinput.cpp encodeInputCamera.cpp encodeInputDecoder.cpp $(DECODE_INPUT_SOURCES)
 


### PR DESCRIPTION
When linking a static library, ld strips symbols that it
thinks aren't being used.  The factory model for registering
codecs fools the linker into thinking the static registration
does not result in usage of the result.

The only way to fix this without changing the factory
registration model is to force the linker to include
the entire static library archive.

Fixes #330

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>