### PR TITLE
Fix Static Library Support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,9 @@ LIBYAMI_LT_LDFLAGS="-version-number $LIBYAMI_LT_VERSION"
 AC_SUBST(LIBYAMI_LT_VERSION)
 AC_SUBST(LIBYAMI_LT_LDFLAGS)
 
+AM_CONDITIONAL(BUILD_STATIC,
+    [test "x$enable_static" = "xyes"])
+
 AC_ARG_ENABLE(debug,
     [AC_HELP_STRING([--enable-debug],
         [build with extra debug @<:@default=no@:>@])],

--- a/configure.ac
+++ b/configure.ac
@@ -316,47 +316,58 @@ AC_SUBST(pkgconfigdir)
 
 # Check for libva (vaapi version)
 VA_API_VERSION=va_api_version
-PKG_CHECK_MODULES([LIBVA], [libva >= $VA_API_VERSION])
+AX_PKG_CHECK_MODULES([LIBVA], [libva >= $VA_API_VERSION], [], [], [],
+    [AX_LIBVA_PKG_REQ], [AX_LIBVA_PKG_REQ_PRIV])
 AC_SUBST(LIBVA_VERSION)
 
-PKG_CHECK_MODULES(LIBVA_DRM, [libva-drm])
+AX_PKG_CHECK_MODULES([LIBVA_DRM], [libva-drm], [], [], [],
+    [AX_LIBVA_DRM_PKG_REQ], [AX_LIBVA_DRM_PKG_REQ_PRIV])
 if test "$enable_x11" = "yes" -o "$enable_v4l2_glx" = "yes"; then
-    PKG_CHECK_MODULES(LIBVA_X11, [libva-x11],
+    AX_PKG_CHECK_MODULES([LIBVA_X11], [libva-x11], [],
         [AC_DEFINE([HAVE_VA_X11], [1],
-            [Defined to 1 if VA/X11 API is enabled])])
-    PKG_CHECK_MODULES(X11, [x11])
+            [Defined to 1 if VA/X11 API is enabled])],
+        [], [AX_LIBVA_X11_PKG_REQ], [AX_LIBVA_X11_PKG_REQ_PRIV])
+    AX_PKG_CHECK_MODULES([X11], [x11], [], [], [],
+        [AX_X11_PKG_REQ], [AX_X11_PKG_REQ_PRIV])
 fi
 
 if test "$enable_v4l2" = "yes"; then
-    PKG_CHECK_MODULES(LIBV4L2, [libv4l2])
+    AX_PKG_CHECK_MODULES([LIBV4L2], [libv4l2], [], [], [],
+        [AX_LIBV4L2_PKG_REQ], [AX_LIBV4L2_PKG_REQ_PRIV])
 fi
 
 if test ["$enable_v4l2" = "yes" -a "$enable_v4l2_glx" = "no"] -o "$enable_tests_gles" = "yes"; then
-    PKG_CHECK_MODULES(LIBEGL, [egl])
+    AX_PKG_CHECK_MODULES([LIBEGL], [egl], [], [], [],
+        [AX_LIBEGL_PKG_REQ], [AX_LIBEGL_PKG_REQ_PRIV])
 fi
 
 if test ["$enable_v4l2" = "yes" -a "$enable_v4l2_glx" = "no"  -a "$enable_tests" = "yes"] -o "$enable_tests_gles" = "yes"; then
-    PKG_CHECK_MODULES(LIBGLES2, [glesv2])
+    AX_PKG_CHECK_MODULES([LIBGLES2], [glesv2], [], [], [],
+        [AX_LIBGLES2_PKG_REQ], [AX_LIBGLES2_PKG_REQ_PRIV])
 fi
 
 # drm_fourcc.h for dma_buf support
 if test "$enable_dmabuf" = "yes"; then
-    PKG_CHECK_MODULES(LIBDRM, [libdrm])
+    AX_PKG_CHECK_MODULES([LIBDRM], [libdrm], [], [], [],
+        [AX_LIBDRM_PKG_REQ], [AX_LIBDRM_PKG_REQ_PRIV])
 fi
 
 if test "$enable_v4l2_glx" = "yes"; then
-    PKG_CHECK_MODULES(LIBGL, [gl])
+    AX_PKG_CHECK_MODULES([LIBGL], [gl], [], [], [],
+        [AX_LIBGL_PKG_REQ], [AX_LIBGL_PKG_REQ_PRIV])
 fi
 
 if test "$enable_avformat" = "yes"; then
-    PKG_CHECK_MODULES(LIBAVFORMAT,  [libavformat libavcodec libavutil])
+    AX_PKG_CHECK_MODULES(LIBAVFORMAT,  [libavformat libavcodec libavutil],
+        [], [], [], [AX_LIBAVFORMAT_PKG_REQ], [AX_LIBAVFORMAT_PKG_REQ_PRIV])
 fi
 
 #check openssl
 if test "$enable_md5" = "yes"; then
-PKG_CHECK_MODULES(OPENSSL, [openssl],
-	         [AC_DEFINE([__ENABLE_MD5__], [1], [Defined to 1 if MD5 API and --enable-md5[default] are enabled])],
-	         [enable_md5="no"])
+    AX_PKG_CHECK_MODULES([OPENSSL], [openssl], [],
+        [AC_DEFINE([__ENABLE_MD5__], [1],
+            [Defined to 1 if MD5 API and --enable-md5[default] are enabled])],
+        [enable_md5="no"], [AX_OPENSSL_PKG_REQ], [AX_OPENSSL_PKG_REQ_PRIV])
 fi
 AM_CONDITIONAL(ENABLE_MD5, test "x$enable_md5" = "xyes")
 

--- a/configure.ac
+++ b/configure.ac
@@ -396,6 +396,7 @@ AC_OUTPUT([
          pkgconfig/libyami_common.pc
          pkgconfig/libyami_decoder.pc
          pkgconfig/libyami_encoder.pc
+         pkgconfig/libyami_vaapi.pc
          pkgconfig/libyami_vpp.pc
 ])
 

--- a/decoder/Makefile.am
+++ b/decoder/Makefile.am
@@ -80,8 +80,14 @@ libyami_decoder_la_LIBADD = \
 
 libyami_decoder_ldflags = \
         $(LIBYAMI_LT_LDFLAGS) \
+        $(LIBVA_LIBS) \
+        $(LIBVA_DRM_LIBS) \
         -ldl                 \
         $(NULL)
+
+if ENABLE_X11
+libyami_decoder_ldflags += $(LIBVA_X11_LIBS) $(X11_LIBS)
+endif
 
 libyami_decoder_cppflags = \
         $(LIBVA_CFLAGS) \

--- a/encoder/Makefile.am
+++ b/encoder/Makefile.am
@@ -64,8 +64,13 @@ libyami_encoder_la_LIBADD = \
 
 libyami_encoder_ldflags = \
         $(LIBYAMI_LT_LDFLAGS) \
+        $(LIBVA_LIBS) \
+        $(LIBVA_DRM_LIBS) \
         -ldl                 \
         $(NULL)
+if ENABLE_X11
+libyami_encoder_ldflags += $(LIBVA_X11_LIBS) $(X11_LIBS)
+endif
 
 libyami_encoder_cppflags = \
         $(LIBVA_CFLAGS) \

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -51,6 +51,13 @@ YAMI_DECODE_LIBS 	= \
 	$(top_builddir)/decoder/libyami_decoder.la      \
 	$(NULL)
 
+if BUILD_STATIC
+YAMI_DECODE_LDFLAGS =						\
+	-Wl,--whole-archive					\
+	-Wl,$(top_builddir)/decoder/.libs/libyami_decoder.a	\
+	-Wl,--no-whole-archive
+endif
+
 if ENABLE_TESTS_GLES
 YAMI_DECODE_LIBS += $(LIBEGL_LIBS) $(LIBGLES2_LIBS)
 endif
@@ -65,6 +72,14 @@ YAMI_ENCODE_LIBS = \
 	$(YAMI_DECODE_LIBS)								\
 	$(NULL)
 
+if BUILD_STATIC
+YAMI_ENCODE_LDFLAGS =						\
+	-Wl,--whole-archive					\
+	-Wl,$(top_builddir)/encoder/.libs/libyami_encoder.a	\
+	-Wl,--no-whole-archive					\
+	$(YAMI_DECODE_LDFLAGS)
+endif
+
 VPP_INPUT_LIBS = \
     $(YAMI_COMMON_LIBS)   \
     $(top_builddir)/vpp/libyami_vpp.la	\
@@ -74,6 +89,14 @@ VPP_INPUT_LIBS = \
     $(YAMI_ENCODE_LIBS) \
 	$(NULL)
 
+if BUILD_STATIC
+VPP_INPUT_LDFLAGS =					\
+	-Wl,--whole-archive				\
+	-Wl,$(top_builddir)/vpp/.libs/libyami_vpp.a	\
+	-Wl,--no-whole-archive				\
+	$(YAMI_ENCODE_LDFLAGS)
+endif
+
 VPP_INPUT_CFLAGS = \
     $(LIBVA_CFLAGS) \
     -fpermissive \
@@ -81,6 +104,7 @@ VPP_INPUT_CFLAGS = \
 
 if ENABLE_X11
 simpleplayer_LDADD = $(YAMI_DECODE_LIBS)
+simpleplayer_LDFLAGS = $(YAMI_DECODE_LDFLAGS)
 simpleplayer_SOURCES	= simpleplayer.cpp $(DECODE_INPUT_SOURCES)
 endif
 
@@ -88,5 +112,6 @@ if ENABLE_DMABUF
 grid_CFLAGS = $(LIBDRM_CFLAGS)
 grid_CXXFLAGS = $(LIBDRM_CFLAGS)
 grid_LDADD = $(VPP_INPUT_LIBS) $(LIBDRM_LIBS) -lpthread
+grid_LDFLAGS = $(VPP_INPUT_LDFLAGS)
 grid_SOURCES = grid.cpp $(VPP_INPUT_SOURCES)
 endif

--- a/m4/m4-ax_pkg_check_modules.m4
+++ b/m4/m4-ax_pkg_check_modules.m4
@@ -1,0 +1,69 @@
+# ===========================================================================
+#   http://www.gnu.org/software/autoconf-archive/ax_pkg_check_modules.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PKG_CHECK_MODULES(PREFIX, PUBLIC-MODULES, PRIVATE-MODULES, [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND], [PUBLIC-VARIABLE], [PRIVATE-VARIABLE])
+#
+# DESCRIPTION
+#
+#   A wrapper around PKG_CHECK_MODULES which splits the list of modules into
+#   public and private dependencies, and produces two variables listing the
+#   dependencies across all invocations of AX_PKG_CHECK_MODULES. These two
+#   variables are exposed via AC_SUBST, and should be used in a pkg-config
+#   file as the substituted values for Requires and Requires.private.
+#
+#   The PREFIX, PUBLIC-MODULES and PRIVATE-MODULES arguments should be
+#   specified as for PKG_CHECK_MODULES, with the concatenation of
+#   PUBLIC-MODULES and PRIVATE-MODULES equaling the LIST-OF-MODULES from
+#   PKG_CHECK_MODULES.  The ACTION-IF-FOUND and ACTION-IF-NOT-FOUND
+#   arguments are optional, and should also be specified as for
+#   PKG_CHECK_MODULES.  ACTION-IF-FOUND is evaluated if the full
+#   LIST-OF-MODULES is found; ACTION-IF-NOT-FOUND similarly.
+#
+#   PUBLIC-VARIABLE defaults to AX_PACKAGE_REQUIRES, and PRIVATE-VARIABLE
+#   defaults to AX_PACKAGE_REQUIRES_PRIVATE.  Both variables are AC_SUBST-ed
+#   by this macro.
+#
+#   For example:
+#
+#     AX_PKG_CHECK_MODULES([GLIB],[glib-2.0 gio-2.0],[gthread-2.0])
+#     AX_PKG_CHECK_MODULES([DBUS],[],[dbus-glib-1 >= 0.98 dbus-1])
+#
+#   results in the substitutions:
+#
+#     AX_PACKAGE_REQUIRES="glib-2.0 gio-2.0"
+#     AX_PACKAGE_REQUIRES_PRIVATE="gthread-2.0 dbus-glib-1 >= 0.98 dbus-1"
+#
+#   and can be used with a template pkg-config file (.pc.in) using:
+#
+#     Requires: @AX_PACKAGE_REQUIRES@
+#     Requires.private: @AX_PACKAGE_REQUIRES_PRIVATE@
+#
+# LICENSE
+#
+#   Copyright (c) 2014 Philip Withnall <philip@tecnocode.co.uk>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 2
+
+AC_DEFUN([AX_PKG_CHECK_MODULES],[
+    m4_define([ax_package_requires],
+              [m4_default_quoted([$6],[AX_PACKAGE_REQUIRES])])
+    m4_define([ax_package_requires_private],
+              [m4_default_quoted([$7],[AX_PACKAGE_REQUIRES_PRIVATE])])
+
+    ax_package_requires="$[]ax_package_requires $2"
+    ax_package_requires_private="$[]ax_package_requires_private $3"
+
+    PKG_CHECK_MODULES([$1],[$2 $3],[$4],[$5])
+
+    # Substitute output.
+    AC_SUBST(ax_package_requires)
+    AC_SUBST(ax_package_requires_private)
+])dnl AX_PKG_CHECK_MODULES

--- a/pkgconfig/Makefile.am
+++ b/pkgconfig/Makefile.am
@@ -3,6 +3,7 @@ pkg_config_files = \
 	libyami_common.pc \
 	libyami_decoder.pc \
 	libyami_encoder.pc \
+	libyami_vaapi.pc \
 	libyami_vpp.pc \
 	$(NULL)
 

--- a/pkgconfig/libyami_common.pc.in
+++ b/pkgconfig/libyami_common.pc.in
@@ -6,5 +6,7 @@ includedir=@includedir@
 Name: libyami decoder part
 Description: Intel Open source decoder based on libva
 Version: 1.0.0
+Requires:@AX_LIBVA_PKG_REQ@@AX_LIBVA_DRM_PKG_REQ@
+Requires.private:@AX_LIBVA_PKG_REQ_PRIV@@AX_LIBVA_DRM_PKG_REQ_PRIV@
 Libs: -L${libdir} -lyami_common
 Cflags: -I${includedir}/libyami_common

--- a/pkgconfig/libyami_decoder.pc.in
+++ b/pkgconfig/libyami_decoder.pc.in
@@ -6,5 +6,15 @@ includedir=@includedir@
 Name: libyami decoder part
 Description: Intel Open source decoder based on libva
 Version: 1.0.0
-Libs: -L${libdir} -lyami_decoder -lyami_common -lyami_codecparser
+Requires: libyami_common libyami_codecparser libyami_vaapi \
+          @AX_LIBVA_PKG_REQ@ \
+          @AX_LIBVA_DRM_PKG_REQ@ \
+          @AX_LIBVA_X11_PKG_REQ@ \
+          @AX_X11_PKG_REQ@
+Requires.private: @AX_LIBVA_PKG_REQ_PRIV@ \
+                  @AX_LIBVA_DRM_PKG_REQ_PRIV@ \
+                  @AX_LIBVA_X11_PKG_REQ_PRIV@ \
+                  @AX_X11_PKG_REQ_PRIV@
+Libs: -L${libdir} -lyami_decoder
+Libs.private: -Wl,--whole-archive -lyami_decoder -Wl,--no-whole-archive
 Cflags: -I${includedir}/libyami_decoder

--- a/pkgconfig/libyami_encoder.pc.in
+++ b/pkgconfig/libyami_encoder.pc.in
@@ -6,5 +6,15 @@ includedir=@includedir@
 Name: libyami encoder part
 Description: Intel Open source encoder based on libva
 Version: 1.0.0
-Libs: -L${libdir} -lyami_encoder -lyami_common -lyami_codecparser
+Requires: libyami_common libyami_codecparser libyami_vaapi \
+          @AX_LIBVA_PKG_REQ@ \
+          @AX_LIBVA_DRM_PKG_REQ@ \
+          @AX_LIBVA_X11_PKG_REQ@ \
+          @AX_X11_PKG_REQ@
+Requires.private: @AX_LIBVA_PKG_REQ_PRIV@ \
+                  @AX_LIBVA_DRM_PKG_REQ_PRIV@ \
+                  @AX_LIBVA_X11_PKG_REQ_PRIV@ \
+                  @AX_X11_PKG_REQ_PRIV@
+Libs: -L${libdir} -lyami_encoder
+Libs.private: -Wl,--whole-archive -lyami_encoder -Wl,--no-whole-archive
 Cflags: -I${includedir}/libyami_encoder

--- a/pkgconfig/libyami_vaapi.pc.in
+++ b/pkgconfig/libyami_vaapi.pc.in
@@ -6,7 +6,8 @@ includedir=@includedir@
 Name: libyami vaapi part
 Description: Intel Open source libyami interface to vaapi
 Version: 1.0.0
-Requires: @AX_LIBVA_PKG_REQ@ \
+Requires: libyami_common \
+          @AX_LIBVA_PKG_REQ@ \
           @AX_LIBVA_DRM_PKG_REQ@ \
           @AX_LIBVA_X11_PKG_REQ@ \
           @AX_X11_PKG_REQ@

--- a/pkgconfig/libyami_vaapi.pc.in
+++ b/pkgconfig/libyami_vaapi.pc.in
@@ -1,0 +1,17 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libyami vaapi part
+Description: Intel Open source libyami interface to vaapi
+Version: 1.0.0
+Requires: @AX_LIBVA_PKG_REQ@ \
+          @AX_LIBVA_DRM_PKG_REQ@ \
+          @AX_LIBVA_X11_PKG_REQ@ \
+          @AX_X11_PKG_REQ@
+Requires.private: @AX_LIBVA_PKG_REQ_PRIV@ \
+                  @AX_LIBVA_DRM_PKG_REQ_PRIV@ \
+                  @AX_LIBVA_X11_PKG_REQ_PRIV@ \
+                  @AX_X11_PKG_REQ_PRIV@
+Libs: -L${libdir} -lyami_vaapi

--- a/pkgconfig/libyami_vpp.pc.in
+++ b/pkgconfig/libyami_vpp.pc.in
@@ -6,5 +6,11 @@ includedir=@includedir@
 Name: libyami video post process part
 Description: Intel Open source video post process based on libva
 Version: 1.0.0
-Libs: -L${libdir} -lyami_vpp -lyami_common
+Requires: libyami_common libyami_vaapi \
+          @AX_LIBVA_PKG_REQ@ \
+          @AX_LIBVA_DRM_PKG_REQ@
+Requires.private: @AX_LIBVA_PKG_REQ_PRIV@ \
+                  @AX_LIBVA_DRM_PKG_REQ_PRIV@
+Libs: -L${libdir} -lyami_vpp
+Libs.private: -Wl,--whole-archive -lyami_vpp -Wl,--no-whole-archive
 Cflags: -I${includedir}/libyami_vpp

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -39,6 +39,14 @@ YAMI_DECODE_LIBS 	= \
 	$(YAMI_COMMON_LIBS)                            	\
 	$(top_builddir)/decoder/libyami_decoder.la      \
 	$(NULL)
+
+if BUILD_STATIC
+YAMI_DECODE_LDFLAGS =						\
+	-Wl,--whole-archive					\
+	-Wl,$(top_builddir)/decoder/.libs/libyami_decoder.a	\
+	-Wl,--no-whole-archive
+endif
+
 if ENABLE_TESTS_GLES
 YAMI_DECODE_LIBS += $(LIBEGL_LIBS) $(LIBGLES2_LIBS)
 endif
@@ -55,10 +63,25 @@ YAMI_ENCODE_LIBS = \
 	$(YAMI_DECODE_LIBS)								\
 	$(NULL)
 
+if BUILD_STATIC
+YAMI_ENCODE_LDFLAGS =						\
+	-Wl,--whole-archive					\
+	-Wl,$(top_builddir)/encoder/.libs/libyami_encoder.a	\
+	-Wl,--no-whole-archive
+endif
+
 V4L2_DECODE_LIBS = \
 	$(YAMI_DECODE_LIBS)                         \
 	$(top_builddir)/v4l2/libyami_v4l2.la        \
 	$(NULL)
+
+if BUILD_STATIC
+V4L2_DECODE_LDFLAGS =						\
+	-Wl,--whole-archive					\
+	-Wl,$(top_builddir)/decoder/.libs/libyami_decoder.a	\
+	-Wl,--no-whole-archive
+endif
+
 if ENABLE_V4L2_GLX
 V4L2_DECODE_LIBS += $(LIBGL_LIBS)
 else
@@ -69,6 +92,13 @@ V4L2_ENCODE_LIBS = \
 	$(YAMI_ENCODE_LIBS)                         \
 	$(top_builddir)/v4l2/libyami_v4l2.la        \
 	$(NULL)
+
+if BUILD_STATIC
+V4L2_ENCODE_LDFLAGS =						\
+	-Wl,--whole-archive					\
+	-Wl,$(top_builddir)/encoder/.libs/libyami_encoder.a	\
+	-Wl,--no-whole-archive
+endif
 
 CAPI_DECODE_LIBS = \
 	$(YAMI_DECODE_LIBS)							\
@@ -89,6 +119,13 @@ YAMI_VPP_LIBS = \
     $(YAMI_ENCODE_LIBS) \
 	$(NULL)
 
+if BUILD_STATIC
+YAMI_VPP_LDFLAGS =					\
+	-Wl,--whole-archive				\
+	-Wl,$(top_builddir)/vpp/.libs/libyami_vpp.a	\
+	-Wl,--no-whole-archive
+endif
+
 YAMI_VPP_CFLAGS = \
     $(LIBVA_CFLAGS) \
     -fpermissive \
@@ -105,26 +142,31 @@ encodecapi_LDADD	= $(CAPI_ENCODE_LIBS)
 encodecapi_SOURCES	= encodecapi.c encodehelp.h encodeinput.cpp encodeInputCamera.cpp encodeInputDecoder.cpp encodeInputCapi.cpp $(DECODE_INPUT_SOURCES)
 else
 yamidecode_LDADD	= $(YAMI_DECODE_LIBS)
+yamidecode_LDFLAGS	= $(YAMI_DECODE_LDFLAGS)
 yamidecode_SOURCES	= decode.cpp decodehelp.h $(DECODE_INPUT_SOURCES) decodeoutput.cpp
 if ENABLE_TESTS_GLES
 yamidecode_SOURCES += ../egl/egl_util.c ./egl/gles2_help.c
 endif
 
 yamiencode_LDADD    = $(YAMI_ENCODE_LIBS)
+yamiencode_LDFLAGS  = $(YAMI_ENCODE_LDFLAGS)
 yamiencode_SOURCES  = encode.cpp encodeinput.cpp encodeInputCamera.cpp encodeInputDecoder.cpp $(DECODE_INPUT_SOURCES)
 
-v4l2decode_LDADD = $(V4L2_DECODE_LIBS)
+v4l2decode_LDADD   = $(V4L2_DECODE_LIBS)
+v4l2decode_LDFLAGS = $(V4L2_DECODE_LDFLAGS)
 v4l2decode_SOURCES = v4l2decode.cpp decodehelp.h $(DECODE_INPUT_SOURCES)
 if ENABLE_V4L2_GLX
 v4l2decode_SOURCES += ./glx/glx_help.c
 else
-v4l2decode_SOURCES += ../egl/egl_util.c ./egl/gles2_help.c
+v4l2decode_SOURCES += ./egl/gles2_help.c
 endif
 
-v4l2encode_LDADD = $(V4L2_ENCODE_LIBS)
+v4l2encode_LDADD   = $(V4L2_ENCODE_LIBS)
+v4l2encode_LDFLAGS = $(V4L2_ENCODE_LDFLAGS)
 v4l2encode_SOURCES = v4l2encode.cpp encodeinput.h encodeinput.cpp encodeInputCamera.cpp encodeInputDecoder.cpp $(DECODE_INPUT_SOURCES)
 endif
 
 yamivpp_LDADD    = $(YAMI_VPP_LIBS)
+yamivpp_LDFLAGS  = $(YAMI_VPP_LDFLAGS)
 yamivpp_SOURCES  = vppinputoutput.cpp vppoutputencode.cpp  vpp.cpp encodeinput.cpp encodeInputCamera.cpp encodeInputDecoder.cpp $(DECODE_INPUT_SOURCES)
 

--- a/vaapi/Makefile.am
+++ b/vaapi/Makefile.am
@@ -37,12 +37,13 @@ libyami_vaapi_cppflags = \
         -fpermissive \
 	$(NULL)
 
-lib_LTLIBRARIES	              = libyami_vaapi.la
+lib_LTLIBRARIES              = libyami_vaapi.la
 libyami_vaapiincludedir      = ${includedir}/libyami_vaapi
 libyami_vaapiinclude_HEADERS = $(libyami_vaapi_source_h)
 libyami_vaapi_la_SOURCES     = $(libyami_vaapi_source_c)
 libyami_vaapi_la_LDFLAGS     = $(libyami_vaapi_ldflags)
 libyami_vaapi_la_CPPFLAGS    = $(libyami_vaapi_cppflags)
+libyami_vaapi_la_LIBADD      = $(top_builddir)/common/libyami_common.la
 
 DISTCLEANFILES = \
 	Makefile.in 

--- a/vaapi/Makefile.am
+++ b/vaapi/Makefile.am
@@ -29,7 +29,7 @@ libyami_vaapi_ldflags = \
         $(LIBVA_DRM_LIBS) \
 	$(NULL)
 if ENABLE_X11
-libyami_vaapi_ldflags += $(LIBVA_X11_LIBS) -lX11
+libyami_vaapi_ldflags += $(LIBVA_X11_LIBS) $(X11_LIBS)
 endif
 
 libyami_vaapi_cppflags = \

--- a/vpp/Makefile.am
+++ b/vpp/Makefile.am
@@ -29,6 +29,8 @@ libyami_vpp_la_LIBADD = \
 
 libyami_vpp_ldflags = \
         $(LIBYAMI_LT_LDFLAGS) \
+        $(LIBVA_LIBS) \
+        $(LIBVA_DRM_LIBS) \
         -ldl                 \
         $(NULL)
 

--- a/vpp/Makefile.am
+++ b/vpp/Makefile.am
@@ -12,6 +12,7 @@ libyami_vpp_source_c = \
 
 
 libyami_vpp_source_h = \
+        ../interface/VideoCommonDefs.h                \
         ../interface/VideoPostProcessHost.h           \
         ../interface/VideoPostProcessInterface.h      \
         $(NULL)


### PR DESCRIPTION
These patches fix several issues when external programs try to link to static libyami_* libraries.  Also, fixes the static linking for the internal tests and examples.

External programs should specify `--static` to `pkg-config` when linking to libyami_* static libraries.  For example, `pkg-config --cflags --libs --static libyami_decoder`.

Fixes #330 