### PR TITLE
v4l2decode: fix some build issue when there is no x11

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -28,6 +28,7 @@ endif
 AM_CPPFLAGS = $(AM_CFLAGS)
 
 YAMI_COMMON_LIBS 	= \
+	$(LIBVA_LIBS)								\
 	$(top_builddir)/common/libyami_common.la	\
 	$(top_builddir)/vaapi/libyami_vaapi.la		\
 	$(NULL)

--- a/tests/egl/gles2_help.c
+++ b/tests/egl/gles2_help.c
@@ -318,11 +318,13 @@ EGLContextType *eglInit(Display *x11Display, XID x11Window, uint32_t fourcc, int
     glEnable(GL_DEPTH_TEST);
     glClearDepthf(1.0f);
     {
-        unsigned int width, height;
+        unsigned int width=800, height=600;
+#ifdef __ENABLE_X11__
         Window root;
         int x, y;
         unsigned int borderWidth, depth;
         XGetGeometry(x11Display, x11Window, &root, &x, &y, &width, &height, &borderWidth, &depth);
+#endif
         glViewport(0, 0, width, height);
     }
     if (isExternalTexture)

--- a/tests/v4l2decode.cpp
+++ b/tests/v4l2decode.cpp
@@ -276,8 +276,9 @@ int main(int argc, char** argv)
     renderMode = 3; // set default render mode to 3
 
     yamiTraceInit();
+#if __ENABLE_V4L2_GLX__
     XInitThreads();
-
+#endif
     if (!process_cmdline(argc, argv))
         return -1;
 
@@ -319,9 +320,9 @@ int main(int argc, char** argv)
     fd = YamiV4L2_Open("decoder", 0);
     ASSERT(fd!=-1);
 
+#if __ENABLE_V4L2_GLX__
     x11Display = XOpenDisplay(NULL);
     ASSERT(x11Display);
-#if __ENABLE_V4L2_GLX__
     ioctlRet = YamiV4L2_SetXDisplay(fd, x11Display);
 #endif
     // set output frame memory type
@@ -450,11 +451,11 @@ int main(int argc, char** argv)
     ASSERT(reqbufs.count>0);
     outputQueueCapacity = reqbufs.count;
 
+#if __ENABLE_V4L2_GLX__
     x11Window = XCreateSimpleWindow(x11Display, DefaultRootWindow(x11Display)
         , 0, 0, videoWidth, videoHeight, 0, 0
         , WhitePixel(x11Display, 0));
     XMapWindow(x11Display, x11Window);
-#if __ENABLE_V4L2_GLX__
     pixmaps.resize(outputQueueCapacity);
     glxPixmaps.resize(outputQueueCapacity);
     textureIds.resize(outputQueueCapacity);
@@ -635,10 +636,12 @@ int main(int argc, char** argv)
     if (dumpOutputName)
         free(dumpOutputName);
 
+#if __ENABLE_V4L2_GLX__
     if (x11Display && x11Window)
         XDestroyWindow(x11Display, x11Window);
     if (x11Display)
         XCloseDisplay(x11Display);
+#endif
 
     fprintf(stdout, "decode done\n");
 }

--- a/v4l2/v4l2_wrapper.h
+++ b/v4l2/v4l2_wrapper.h
@@ -27,10 +27,13 @@
 #else
 #include <EGL/egl.h>
 #endif
-#include "interface/VideoCommonDefs.h"
+#include "VideoCommonDefs.h"
 
 #ifndef v4l2_wrapper_h
 #define v4l2_wrapper_h
+#ifndef V4L2_EVENT_RESOLUTION_CHANGE
+    #define V4L2_EVENT_RESOLUTION_CHANGE 5
+#endif
 extern "C" {
 int32_t YamiV4L2_Open(const char* name, int32_t flags);
 int32_t YamiV4L2_Close(int32_t fd);


### PR DESCRIPTION
- include VideoCommonDefs.h without prefix since the folder name
  is different in original source and installed dir

- define V4L2_EVENT_RESOLUTION_CHANGE if there is not it yet, in v4l2_wrapper.h