### PR TITLE
Integrate GTest Framework

### DIFF
--- a/capi/Makefile.am
+++ b/capi/Makefile.am
@@ -36,6 +36,34 @@ libyami_capi_la_SOURCES     = $(libyami_capi_source_c)
 libyami_capi_la_LDFLAGS     = $(libyami_capi_ldflags)
 libyami_capi_la_CPPFLAGS    = $(libyami_capi_cppflags)
 
+if ENABLE_UNITTESTS
+noinst_PROGRAMS = unittest
+
+unittest_SOURCES = \
+	$(top_builddir)/common/unittest_main.cpp \
+	$(NULL)
+
+unittest_LDFLAGS = \
+	$(GTEST_LDFLAGS) \
+	$(NULL)
+
+unittest_LDADD = \
+	libyami_capi.la \
+	$(GTEST_LIBS) \
+	$(NULL)
+
+unittest_CPPFLAGS = \
+	$(GTEST_CPPFLAGS) \
+	$(NULL)
+
+unittest_CXXFLAGS = \
+	$(GTEST_CXXFLAGS) \
+	$(NULL)
+
+check-local: unittest
+	$(builddir)/unittest
+endif
+
 DISTCLEANFILES = \
 	Makefile.in
 

--- a/codecparsers/Makefile.am
+++ b/codecparsers/Makefile.am
@@ -69,6 +69,34 @@ libyami_codecparser_la_SOURCES     = $(libyami_codecparser_source_c)
 libyami_codecparser_la_LDFLAGS     = $(libyami_codecparser_ldflags)
 libyami_codecparser_la_CPPFLAGS    = $(libyami_codecparser_cppflags)
 
+if ENABLE_UNITTESTS
+noinst_PROGRAMS = unittest
+
+unittest_SOURCES = \
+	$(top_builddir)/common/unittest_main.cpp \
+	$(NULL)
+
+unittest_LDFLAGS = \
+	$(GTEST_LDFLAGS) \
+	$(NULL)
+
+unittest_LDADD = \
+	libyami_codecparser.la \
+	$(GTEST_LIBS) \
+	$(NULL)
+
+unittest_CPPFLAGS = \
+	$(GTEST_CPPFLAGS) \
+	$(NULL)
+
+unittest_CXXFLAGS = \
+	$(GTEST_CXXFLAGS) \
+	$(NULL)
+
+check-local: unittest
+	$(builddir)/unittest
+endif
+
 DISTCLEANFILES = \
 	Makefile.in
 

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -30,6 +30,34 @@ libyami_common_la_SOURCES     = $(libyami_common_source_c)
 libyami_common_la_LDFLAGS     = $(libyami_common_ldflags)
 libyami_common_la_CPPFLAGS    = $(libyami_common_cppflags)
 
+if ENABLE_UNITTESTS
+noinst_PROGRAMS = unittest
+
+unittest_SOURCES = \
+	$(top_builddir)/common/unittest_main.cpp \
+	$(NULL)
+
+unittest_LDFLAGS = \
+	$(GTEST_LDFLAGS) \
+	$(NULL)
+
+unittest_LDADD = \
+	libyami_common.la \
+	$(GTEST_LIBS) \
+	$(NULL)
+
+unittest_CPPFLAGS = \
+	$(GTEST_CPPFLAGS) \
+	$(NULL)
+
+unittest_CXXFLAGS = \
+	$(GTEST_CXXFLAGS) \
+	$(NULL)
+
+check-local: unittest
+	$(builddir)/unittest
+endif
+
 DISTCLEANFILES = \
 	Makefile.in 
 

--- a/common/unittest_main.cpp
+++ b/common/unittest_main.cpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/configure.ac
+++ b/configure.ac
@@ -74,6 +74,12 @@ fi
 AM_CONDITIONAL(ENABLE_TESTS_GLES,
     [test "x$enable_tests_gles" = "xyes"])
 
+HAVE_GTEST="no"
+ifdef([GTEST_LIB_CHECK],
+    [GTEST_LIB_CHECK([1.7.0], [:], [:])])
+AM_CONDITIONAL([ENABLE_UNITTESTS],
+    [test "x$HAVE_GTEST" = "xyes"])
+
 AC_ARG_ENABLE(dmabuf,
     [AC_HELP_STRING([--enable-dmabuf],
         [support dma_buf buffer sharing @<:@default=no@:>@])],

--- a/decoder/Makefile.am
+++ b/decoder/Makefile.am
@@ -108,6 +108,34 @@ libyami_decoder_la_SOURCES     = $(libyami_decoder_source_c)
 libyami_decoder_la_LDFLAGS     = $(libyami_decoder_ldflags)
 libyami_decoder_la_CPPFLAGS    = $(libyami_decoder_cppflags)
 
+if ENABLE_UNITTESTS
+noinst_PROGRAMS = unittest
+
+unittest_SOURCES = \
+	$(top_builddir)/common/unittest_main.cpp \
+	$(NULL)
+
+unittest_LDFLAGS = \
+	$(GTEST_LDFLAGS) \
+	$(NULL)
+
+unittest_LDADD = \
+	libyami_decoder.la \
+	$(GTEST_LIBS) \
+	$(NULL)
+
+unittest_CPPFLAGS = \
+	$(GTEST_CPPFLAGS) \
+	$(NULL)
+
+unittest_CXXFLAGS = \
+	$(GTEST_CXXFLAGS) \
+	$(NULL)
+
+check-local: unittest
+	$(builddir)/unittest
+endif
+
 DISTCLEANFILES = \
 	Makefile.in 
 

--- a/encoder/Makefile.am
+++ b/encoder/Makefile.am
@@ -91,5 +91,33 @@ libyami_encoder_la_SOURCES     = $(libyami_encoder_source_c)
 libyami_encoder_la_LDFLAGS     = $(libyami_encoder_ldflags)
 libyami_encoder_la_CPPFLAGS    = $(libyami_encoder_cppflags)
 
+if ENABLE_UNITTESTS
+noinst_PROGRAMS = unittest
+
+unittest_SOURCES = \
+	$(top_builddir)/common/unittest_main.cpp \
+	$(NULL)
+
+unittest_LDFLAGS = \
+	$(GTEST_LDFLAGS) \
+	$(NULL)
+
+unittest_LDADD = \
+	libyami_encoder.la \
+	$(GTEST_LIBS) \
+	$(NULL)
+
+unittest_CPPFLAGS = \
+	$(GTEST_CPPFLAGS) \
+	$(NULL)
+
+unittest_CXXFLAGS = \
+	$(GTEST_CXXFLAGS) \
+	$(NULL)
+
+check-local: unittest
+	$(builddir)/unittest
+endif
+
 DISTCLEANFILES = \
 	Makefile.in

--- a/v4l2/Makefile.am
+++ b/v4l2/Makefile.am
@@ -58,6 +58,34 @@ libyami_v4l2_la_SOURCES     = $(libyami_v4l2_source_c)
 libyami_v4l2_la_LDFLAGS     = $(libyami_v4l2_ldflags)
 libyami_v4l2_la_CPPFLAGS    = $(libyami_v4l2_cppflags)
 
+if ENABLE_UNITTESTS
+noinst_PROGRAMS = unittest
+
+unittest_SOURCES = \
+	$(top_builddir)/common/unittest_main.cpp \
+	$(NULL)
+
+unittest_LDFLAGS = \
+	$(GTEST_LDFLAGS) \
+	$(NULL)
+
+unittest_LDADD = \
+	libyami_v4l2.la \
+	$(GTEST_LIBS) \
+	$(NULL)
+
+unittest_CPPFLAGS = \
+	$(GTEST_CPPFLAGS) \
+	$(NULL)
+
+unittest_CXXFLAGS = \
+	$(GTEST_CXXFLAGS) \
+	$(NULL)
+
+check-local: unittest
+	$(builddir)/unittest
+endif
+
 DISTCLEANFILES = \
 	Makefile.in
 

--- a/vaapi/Makefile.am
+++ b/vaapi/Makefile.am
@@ -45,6 +45,34 @@ libyami_vaapi_la_LDFLAGS     = $(libyami_vaapi_ldflags)
 libyami_vaapi_la_CPPFLAGS    = $(libyami_vaapi_cppflags)
 libyami_vaapi_la_LIBADD      = $(top_builddir)/common/libyami_common.la
 
+if ENABLE_UNITTESTS
+noinst_PROGRAMS = unittest
+
+unittest_SOURCES = \
+	$(top_builddir)/common/unittest_main.cpp \
+	$(NULL)
+
+unittest_LDFLAGS = \
+	$(GTEST_LDFLAGS) \
+	$(NULL)
+
+unittest_LDADD = \
+	libyami_vaapi.la \
+	$(GTEST_LIBS) \
+	$(NULL)
+
+unittest_CPPFLAGS = \
+	$(GTEST_CPPFLAGS) \
+	$(NULL)
+
+unittest_CXXFLAGS = \
+	$(GTEST_CXXFLAGS) \
+	$(NULL)
+
+check-local: unittest
+	$(builddir)/unittest
+endif
+
 DISTCLEANFILES = \
 	Makefile.in 
 

--- a/vpp/Makefile.am
+++ b/vpp/Makefile.am
@@ -49,5 +49,33 @@ libyami_vpp_la_SOURCES      = $(libyami_vpp_source_c)
 libyami_vpp_la_LDFLAGS      = $(libyami_vpp_ldflags)
 libyami_vpp_la_CPPFLAGS     = $(libyami_vpp_cppflags)
 
+if ENABLE_UNITTESTS
+noinst_PROGRAMS = unittest
+
+unittest_SOURCES = \
+	$(top_builddir)/common/unittest_main.cpp \
+	$(NULL)
+
+unittest_LDFLAGS = \
+	$(GTEST_LDFLAGS) \
+	$(NULL)
+
+unittest_LDADD = \
+	libyami_vpp.la \
+	$(GTEST_LIBS) \
+	$(NULL)
+
+unittest_CPPFLAGS = \
+	$(GTEST_CPPFLAGS) \
+	$(NULL)
+
+unittest_CXXFLAGS = \
+	$(GTEST_CXXFLAGS) \
+	$(NULL)
+
+check-local: unittest
+	$(builddir)/unittest
+endif
+
 DISTCLEANFILES = \
 	Makefile.in


### PR DESCRIPTION
GTest is a C++ test framework with a rich set of features that allow you to easily write tests for your project (https://code.google.com/p/googletest/).  This set of patches adds gtest as a dependency (currently optional, but required for unit test compilation).  Each libyami library will compile its own `unittest` executable, which can be individually executed directly or all of them through `make check`.  The unit tests do not require any user interaction and provides multiple types of result output formats. Therefore, they can be easily integrated into an automated testing framework.

On Fedora, the `gtest` and `gtest-devel` packages can be installed via 'yum' or 'dnf'.  I have not checked if other distros provide pre-built packages for gtest.  If they don't, then gtest can be compiled and installed from source easily.

The recommendation is that developers create unit tests to test new code they add, as appropriate.  However, this does not mean that everything can be tested with a unit test, so that judgement will need to be made on a case-by-case basis.

I also recommend that the policy be that all unit tests pass before submitting/merging code to libyami (i.e. no unit test regressions allowed).

Once this patchset is merged, we can start filling in the unit tests to cover the current code.  I've already started some of this in the following branches [unittest-common](https://github.com/uartie/libyami/commits/unittest-common), [unittest-decoder](https://github.com/uartie/libyami/commits/unittest-decoder), and [unittest-encoder](https://github.com/uartie/libyami/commits/unittest-encoder)
