### PR TITLE
log: prompt when log isn't enabled at compile time

### DIFF
--- a/common/log.cpp
+++ b/common/log.cpp
@@ -39,6 +39,7 @@ static YamiMediaCodec::Lock g_traceLock;
 
 void yamiTraceInit()
 {
+#ifdef __ENABLE_DEBUG__
     YamiMediaCodec::AutoLock locker(g_traceLock);
     if(!isInit){
         char* libyamiLogLevel = getenv("LIBYAMI_LOG_LEVEL");
@@ -76,4 +77,7 @@ void yamiTraceInit()
         }
         isInit = 1;
     }
+ #else
+     fprintf(stderr, "yami log isn't enabled (--enable-debug)\n");
+ #endif
 }


### PR DESCRIPTION
it cost me some time to find out why i don't see yami log.

it's better to add prompt