### PR TITLE
v4l2: fix pthread linkage

### DIFF
--- a/v4l2/Makefile.am
+++ b/v4l2/Makefile.am
@@ -30,7 +30,7 @@ libyami_v4l2_la_LIBADD = \
 
 libyami_v4l2_ldflags = \
 	$(LIBYAMI_LT_LDFLAGS) \
-	-lpthread             \
+	-pthread \
 	$(NULL)
 
 if !ENABLE_V4L2_GLX


### PR DESCRIPTION
Don't use -lpthread since it is less portable then -pthread.
Use -pthread instead with GCC.

On Ubuntu 14.04, attempting to link a program with two libraries,
where one was linked with -lpthread and one that linked with
-pthread, can cause the link phase to fail with undefined
references to various pthread functions.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>