### PR TITLE
make: delete compiling flag '-Wno-sign-compare'

### DIFF
--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -46,7 +46,7 @@ uint32_t guessFourcc(const char* fileName)
     const char* extension = strrchr(fileName, '.');
     if (extension) {
         extension++;
-        for (int i = 0; i < N_ELEMENTS(possibleFourcc); i++) {
+        for (uint32_t i = 0; i < N_ELEMENTS(possibleFourcc); i++) {
             const char* fourcc = possibleFourcc[i];
             if (!strcasecmp(fourcc, extension)) {
                 uint32_t ret = VA_FOURCC(fourcc[0], fourcc[1], fourcc[2], fourcc[3]);
@@ -244,7 +244,7 @@ bool fillFrameRawData(VideoFrameRawData* frame, uint32_t fourcc, uint32_t width,
     frame->memoryType = VIDEO_DATA_MEMORY_TYPE_RAW_POINTER;
 
     uint32_t offset = 0;
-    for (int i = 0; i < planes; i++) {
+    for (uint32_t i = 0; i < planes; i++) {
         frame->pitch[i] = w[i];
         frame->offset[i] = offset;
         offset += w[i] * h[i];

--- a/configure.ac
+++ b/configure.ac
@@ -283,8 +283,8 @@ fi
 AM_CONDITIONAL(ENABLE_DOCS,
     [test "$enable_docs" = "yes"])
 
-: ${CFLAGS="-g -O2 -Wno-unused-function -Wno-sign-compare -Wno-cpp -Wall -Werror"}
-: ${CXXFLAGS="-g -O2 -Wno-unused-function -Wno-sign-compare -Wno-cpp -Wall -Werror"}
+: ${CFLAGS="-g -O2 -Wno-unused-function -Wno-cpp -Wall -Werror"}
+: ${CXXFLAGS="-g -O2 -Wno-unused-function -Wno-cpp -Wall -Werror"}
 
 # Checks for programs.
 AC_DISABLE_STATIC

--- a/decoder/vaapidecoder_h264.h
+++ b/decoder/vaapidecoder_h264.h
@@ -267,8 +267,8 @@ class VaapiDPBManager {
 
     bool execRefPicMarkingSlidingWindow(const PicturePtr& picture);
 
-    int32_t findShortTermReference(uint32_t picNum);
-    int32_t findLongTermReference(uint32_t longTermPicNum);
+    int32_t findShortTermReference(int32_t picNum);
+    int32_t findLongTermReference(int32_t longTermPicNum);
     void removeShortReference(const PicturePtr& picture);
     void removeDPBIndex(uint32_t idx);
     void debugDPBStatus();

--- a/decoder/vaapidecoder_h264_dpb.cpp
+++ b/decoder/vaapidecoder_h264_dpb.cpp
@@ -55,7 +55,7 @@ static uint32_t roundLog2(uint32_t value)
 {
     uint32_t ret = 0;
     uint32_t valueSquare = value * value;
-    while ((1 << (ret + 1)) <= valueSquare)
+    while ((uint32_t)(1 << (ret + 1)) <= valueSquare)
         ++ret;
 
     ret = (ret + 1) >> 1;
@@ -331,7 +331,7 @@ void VaapiDPBManager::drainDPB()
 
 void VaapiDPBManager::debugDPBStatus()
 {
-    int i;
+    uint32_t i;
     VaapiFrameStore::Ptr frameStore;
 
     for (i = 0; i < DPBLayer->DPBCount; i++) {
@@ -443,7 +443,7 @@ void VaapiDPBManager::resetDPB(H264SPS * sps)
 */
 bool VaapiDPBManager::outputImmediateBFrame()
 {
-    int i;
+    uint32_t i;
     int ret = true;
 
     if (m_prevFrameStore.get()) {
@@ -959,7 +959,7 @@ void VaapiDPBManager::execPictureRefsModification1(const PicturePtr& picture,
 
     //FIXME: without this we will crash in MR3_TANDBERG_B.264
     //shold review this after we fix it
-    for (int j = refListCount; j < numRefs; j++)
+    for (uint32_t j = refListCount; j < numRefs; j++)
         refList[j] = NULL;
     //end
 
@@ -1074,9 +1074,10 @@ bool VaapiDPBManager::execRefPicMarkingAdaptive1(const PicturePtr& picture,
                                                  H264RefPicMarking *refPicMarking,
                                                  uint32_t MMCO)
 {
-    uint32_t picNumX, longTermFrameIdxPlus1, i;
+    uint32_t longTermFrameIdxPlus1, i;
     VaapiDecPictureH264 *refPicture;
     int32_t foundIdx = 0;
+    int32_t picNumX;
 
     switch (MMCO) {
     case 1:
@@ -1247,7 +1248,7 @@ bool VaapiDPBManager::execRefPicMarkingSlidingWindow(const PicturePtr& picture)
     return true;
 }
 
-int32_t VaapiDPBManager::findShortTermReference(uint32_t picNum)
+int32_t VaapiDPBManager::findShortTermReference(int32_t picNum)
 {
     uint32_t i;
 
@@ -1260,7 +1261,7 @@ int32_t VaapiDPBManager::findShortTermReference(uint32_t picNum)
     return -1;
 }
 
-int32_t VaapiDPBManager::findLongTermReference(uint32_t longTermPicNum)
+int32_t VaapiDPBManager::findLongTermReference(int32_t longTermPicNum)
 {
     uint32_t i;
 
@@ -1277,7 +1278,7 @@ void VaapiDPBManager::removeShortReference(const PicturePtr& picture)
 {
     VaapiDecPictureH264 *refPicture;
     uint32_t i;
-    uint32_t frameNum = picture->m_frameNum;
+    int32_t frameNum = picture->m_frameNum;
 
     PicturePtr strong = picture->m_otherField.lock();
     VaapiDecPictureH264* other = strong.get();

--- a/decoder/vaapidecoder_h265.cpp
+++ b/decoder/vaapidecoder_h265.cpp
@@ -366,7 +366,7 @@ bool VaapiDecoderH265::DPB::checkLatency(const H265SPS* const sps)
 bool VaapiDecoderH265::DPB::checkDpbSize(const H265SPS* const sps)
 {
     uint8_t highestTid = sps->max_sub_layers_minus1;
-    return m_pictures.size() >= (sps->max_dec_pic_buffering_minus1[highestTid] + 1);
+    return m_pictures.size() >= (size_t)(sps->max_dec_pic_buffering_minus1[highestTid] + 1);
 }
 
 //C.5.2.2
@@ -509,7 +509,7 @@ Decode_Status VaapiDecoderH265::decodeCurrent()
 #define FILL_SCALING_LIST(mxm) \
 void fillScalingList##mxm(VAIQMatrixBufferHEVC* iqMatrix, const H265ScalingList* const scalingList) \
 { \
-    for (int i = 0; i < N_ELEMENTS(iqMatrix->ScalingList##mxm); i++) { \
+    for (uint32_t i = 0; i < N_ELEMENTS(iqMatrix->ScalingList##mxm); i++) { \
         h265_quant_matrix_##mxm##_get_raster_from_uprightdiagonal(iqMatrix->ScalingList##mxm[i], \
             scalingList->scaling_lists_##mxm[i]); \
     } \
@@ -523,7 +523,7 @@ FILL_SCALING_LIST(32x32)
 #define FILL_SCALING_LIST_DC(mxm) \
 void fillScalingListDc##mxm(VAIQMatrixBufferHEVC* iqMatrix, const H265ScalingList* const scalingList) \
 { \
-    for (int i = 0; i < N_ELEMENTS(iqMatrix->ScalingListDC##mxm); i++) { \
+    for (uint32_t i = 0; i < N_ELEMENTS(iqMatrix->ScalingListDC##mxm); i++) { \
         iqMatrix->ScalingListDC##mxm[i] = \
             scalingList->scaling_list_dc_coef_minus8_##mxm[i] + 8; \
     } \
@@ -565,7 +565,7 @@ void VaapiDecoderH265::fillReference(VAPictureHEVC* refs, int32_t& n,
     const RefSet& refset, uint32_t flags)
 {
   //ERROR("fill ref(%x):", flags);
-    for (int32_t i = 0; i < refset.size(); i++) {
+    for (size_t i = 0; i < refset.size(); i++) {
         VAPictureHEVC* r = refs + n;
         const VaapiDecPictureH265* pic = refset[i];
 

--- a/decoder/vaapidecoder_jpeg.h
+++ b/decoder/vaapidecoder_jpeg.h
@@ -58,8 +58,8 @@ class VaapiDecoderJpeg:public VaapiDecoderBase {
 
   private:
     VaapiProfile m_profile;
-    uint32_t m_width;
-    uint32_t m_height;
+    int32_t m_width;
+    int32_t m_height;
     PicturePtr m_picture;
     JpegFrameHdr m_frameHdr;
     JpegHuffmanTables m_hufTables;

--- a/decoder/vaapidecsurfacepool.cpp
+++ b/decoder/vaapidecsurfacepool.cpp
@@ -266,7 +266,7 @@ bool VaapiDecSurfacePool::getOutput(VideoFrameRawData* frame)
 
 bool VaapiDecSurfacePool::populateOutputHandles(VideoFrameRawData *frames, uint32_t &frameCount)
 {
-    int i;
+    uint32_t i;
     if (!frameCount) { // output frame count negotiation
         ASSERT(frames);
         if (frames[0].fourcc && frames[0].fourcc != VA_FOURCC_NV12)

--- a/encoder/vaapiencoder_base.cpp
+++ b/encoder/vaapiencoder_base.cpp
@@ -395,7 +395,7 @@ const ProfileMapItem g_profileMap[] =
 
 VaapiProfile VaapiEncoderBase::profile() const
 {
-    for (int i = 0; i < N_ELEMENTS(g_profileMap); i++) {
+    for (uint32_t i = 0; i < N_ELEMENTS(g_profileMap); i++) {
         if (m_videoParamCommon.profile == g_profileMap[i].vaProfile)
             return g_profileMap[i].vaapiProfile;
     }

--- a/encoder/vaapiencoder_h264.cpp
+++ b/encoder/vaapiencoder_h264.cpp
@@ -559,7 +559,7 @@ private:
         headers.push_back(&m_sps);
         headers.push_back(&m_pps);
         uint8_t sync[] = {0, 0, 0, 1};
-        for (int i = 0; i < headers.size(); i++) {
+        for (size_t i = 0; i < headers.size(); i++) {
             m_headers.insert(m_headers.end(), sync, sync + N_ELEMENTS(sync));
             appendHeaderWithEmulation(*headers[i]);
         }
@@ -662,7 +662,7 @@ private:
         outBuffer->dataSize = 0;
 
         Encode_Status ret;
-        for (int i = 0; i < functions.size(); i++) {
+        for (size_t i = 0; i < functions.size(); i++) {
             ret = functions[i]();
             if (ret != ENCODE_SUCCESS)
                 return ret;
@@ -1254,7 +1254,7 @@ bool VaapiEncoderH264::addSliceHeaders (const PicturePtr& picture) const
     sliceOfMbs = mbSize / m_numSlices;
     sliceModMbs = mbSize % m_numSlices;
     lastMbIndex = 0;
-    for (int i = 0; i < m_numSlices; ++i) {
+    for (uint32_t i = 0; i < m_numSlices; ++i) {
         curSliceMbs = sliceOfMbs;
         if (sliceModMbs) {
             ++curSliceMbs;

--- a/interface/VideoEncoderDefs.h
+++ b/interface/VideoEncoderDefs.h
@@ -346,7 +346,7 @@ typedef struct VideoParamsCommon {
     AirParams airParams;
     uint32_t disableDeblocking;
     bool syncEncMode;
-    int32_t leastInputCount;
+    uint32_t leastInputCount;
 }VideoParamsCommon;
 
 typedef struct VideoParamsAVC {

--- a/tests/decode.cpp
+++ b/tests/decode.cpp
@@ -51,7 +51,7 @@ int main(int argc, char** argv)
     const VideoFormatInfo *formatInfo = NULL;
     Decode_Status status;
     class CalcFps calcFpsGross, calcFpsNet;
-    int skipFrameCount4NetFps = 0;
+    uint32_t skipFrameCount4NetFps = 0;
 #ifdef __ENABLE_X11__
     // XInitThreads();
 #endif

--- a/tests/decodeinput.cpp
+++ b/tests/decodeinput.cpp
@@ -37,8 +37,8 @@ using namespace YamiMediaCodec;
 
 class MyDecodeInput : public DecodeInput{
 public:
-    static const int MaxNaluSize = 1024*1024*4; // assume max nalu size is 4M
-    static const int CacheBufferSize = 8 * MaxNaluSize;
+    static const size_t MaxNaluSize = 1024*1024*4; // assume max nalu size is 4M
+    static const size_t CacheBufferSize = 8 * MaxNaluSize;
     MyDecodeInput();
     virtual ~MyDecodeInput();
     bool initInput(const char* fileName);
@@ -63,8 +63,8 @@ public:
     bool init();
     virtual bool getNextDecodeUnit(VideoDecodeBuffer &inputBuffer);
 private:
-    const int m_ivfFrmHdrSize;
-    const int m_maxFrameSize;
+    const size_t m_ivfFrmHdrSize;
+    const size_t m_maxFrameSize;
     const char* m_mimeType;
 };
 
@@ -248,10 +248,10 @@ bool DecodeInputVPX::init()
 bool DecodeInputVPX::getNextDecodeUnit(VideoDecodeBuffer &inputBuffer)
 {
     if(m_ivfFrmHdrSize == fread (m_buffer, 1, m_ivfFrmHdrSize, m_fp)) {
-        int framesize = 0;
+        size_t framesize = 0;
         framesize = (uint32_t)(m_buffer[0]) + ((uint32_t)(m_buffer[1])<<8) + ((uint32_t)(m_buffer[2])<<16);
-        assert (framesize < (uint32_t) m_maxFrameSize);
-        assert (framesize <= (uint32_t) CacheBufferSize);
+        assert (framesize < m_maxFrameSize);
+        assert (framesize <= CacheBufferSize);
 
         if (framesize != fread (m_buffer, 1, framesize, m_fp)) {
             fprintf (stderr, "fail to read frame data, quit\n");
@@ -292,7 +292,7 @@ bool DecodeInputRaw::init()
 
 bool DecodeInputRaw::ensureBufferData()
 {
-    int readCount = 0;
+    size_t readCount = 0;
 
     if (m_readToEOS)
         return true;

--- a/tests/decodeinputavformat.cpp
+++ b/tests/decodeinputavformat.cpp
@@ -44,7 +44,7 @@ bool DecodeInputAvFormat::initInput(const char* fileName)
     ret = avformat_find_stream_info(m_format, NULL);
     if (ret < 0)
         goto error;
-    int i;
+    uint32_t i;
     for (i = 0; i < m_format->nb_streams; i++)
     {
         AVCodecContext* ctx = m_format->streams[i]->codec;
@@ -89,7 +89,7 @@ static const MimeEntry MimeEntrys[] = {
 
 const char * DecodeInputAvFormat::getMimeType()
 {
-    for (int i = 0; i < N_ELEMENTS(MimeEntrys); i++) {
+    for (uint32_t i = 0; i < N_ELEMENTS(MimeEntrys); i++) {
         if (MimeEntrys[i].id == m_codecId)
             return MimeEntrys[i].mime;
     }

--- a/tests/decodeoutput.cpp
+++ b/tests/decodeoutput.cpp
@@ -124,7 +124,7 @@ private:
         uint32_t height, uint32_t pitch)
     {
         data += offset;
-        for (int h = 0; h < height; h++) {
+        for (uint32_t h = 0; h < height; h++) {
             v.insert(v.end(), data, data + width);
             data += pitch;
         }
@@ -134,7 +134,7 @@ private:
         uint32_t height, uint32_t pitch)
     {
         data += offset;
-        for (int h = 0; h < height; h++) {
+        for (uint32_t h = 0; h < height; h++) {
             uint8_t* start = data;
             uint8_t* end = data + width;
             while (start < end) {
@@ -247,10 +247,10 @@ bool DecodeOutputFileDump::render(VideoFrameRawData* frame)
     //ASSERT(m_width == frame->width && m_height == frame->height);
     if (!getPlaneResolution(frame->fourcc, frame->width, frame->height, width, height, planes))
         return false;
-    for (int i = 0; i < planes; i++) {
+    for (uint32_t i = 0; i < planes; i++) {
         uint8_t* data = reinterpret_cast<uint8_t*>(frame->handle);
         data += frame->offset[i];
-        for (int h = 0; h < height[i]; h++) {
+        for (uint32_t h = 0; h < height[i]; h++) {
             fwrite(data, 1, width[i], m_fp);
             data += frame->pitch[i];
         }
@@ -578,7 +578,7 @@ Decode_Status DecodeOutputDmabuf::renderOneFrame(bool drain)
     Decode_Status status = m_decoder->getOutput(&m_frame, drain);
     if (status == RENDER_SUCCESS) {
        EGLImageKHR eglImage = EGL_NO_IMAGE_KHR;
-        ASSERT(m_width == m_frame.width && m_height == m_frame.height);
+        ASSERT((uint32_t)m_width == m_frame.width && (uint32_t)m_height == m_frame.height);
         eglImage = createEglImageFromHandle(m_eglContext->eglContext.display, m_eglContext->eglContext.context, m_frame.memoryType, m_frame.handle,
                 m_frame.width, m_frame.height, m_frame.pitch[0]);
         if (eglImage != EGL_NO_IMAGE_KHR) {

--- a/tests/encodeInputCamera.cpp
+++ b/tests/encodeInputCamera.cpp
@@ -93,7 +93,7 @@ bool EncodeInputCamera::initDevice(const char *cameraDevicePath)
     IOCTL_CHECK_RET(m_fd, VIDIOC_S_FMT, "VIDIOC_S_FMT", fmt, false);
     DEBUG("video resolution: %dx%d = %dx%d", m_width, m_height, fmt.fmt.pix.width, fmt.fmt.pix.height);
     IOCTL_CHECK_RET(m_fd, VIDIOC_G_FMT, "VIDIOC_G_FMT", fmt, false);
-    if (m_width != fmt.fmt.pix.width || m_height != fmt.fmt.pix.height) {
+    if ((uint32_t)m_width != fmt.fmt.pix.width || (uint32_t)m_height != fmt.fmt.pix.height) {
         ERROR("not supported resolution(%dx%d), use %dx%d from camera\n", m_width, m_height, fmt.fmt.pix.width, fmt.fmt.pix.height);
         m_width = fmt.fmt.pix.width;
         m_height = fmt.fmt.pix.height;
@@ -116,7 +116,7 @@ bool EncodeInputCamera::initDevice(const char *cameraDevicePath)
 bool EncodeInputCamera::initMmap(void)
 {
     struct v4l2_requestbuffers rqbufs;
-    int index;
+    uint32_t index;
 
     INFO();
     memset(&rqbufs, 0, sizeof(rqbufs));
@@ -274,7 +274,7 @@ int32_t EncodeInputCamera::dequeFrame(void)
 
 bool EncodeInputCamera::enqueFrame(int32_t index)
 {
-    assert(index >=0 && index < m_frameBufferCount);
+    assert(index >=0 && (uint32_t)index < m_frameBufferCount);
     struct v4l2_buffer buf;
     memset(&buf, 0, sizeof(buf));
 
@@ -298,7 +298,7 @@ bool EncodeInputCamera::enqueFrame(int32_t index)
 bool EncodeInputCamera::getOneFrameInput(VideoFrameRawData &inputBuffer)
 {
     int frameIndex = dequeFrame();
-    ASSERT(frameIndex>=0 && frameIndex<m_frameBufferCount);
+    ASSERT((frameIndex >= 0) && ((uint32_t)frameIndex < m_frameBufferCount));
 
     memset(&inputBuffer, 0, sizeof(inputBuffer));
     bool ret = fillFrameRawData(&inputBuffer, m_fourcc, m_width, m_height, m_frameBuffers[frameIndex]);

--- a/tests/encodeinput.cpp
+++ b/tests/encodeinput.cpp
@@ -214,7 +214,7 @@ bool EncodeOutput::init(const char* outputFileName, int width , int height)
 
 bool EncodeOutput::write(void* data, int size)
 {
-    return fwrite(data, 1, size, m_fp) == size;
+    return fwrite(data, 1, size, m_fp) == (size_t)size;
 }
 
 const char* EncodeOutputH264::getMimeType()

--- a/tests/vppinputoutput.h
+++ b/tests/vppinputoutput.h
@@ -108,7 +108,7 @@ public:
             return false;
         }
         std::deque<SharedPtr<VideoFrame> > buffers;
-        for (int i = 0;  i < m_surfaces.size(); i++) {
+        for (size_t i = 0;  i < m_surfaces.size(); i++) {
             SharedPtr<VideoFrame> f(new VideoFrame);
             memset(f.get(), 0, sizeof(VideoFrame));
             f->surface = (intptr_t)m_surfaces[i];
@@ -169,10 +169,10 @@ public:
             return false;
         }
         bool ret = true;
-        for (int i = 0; i < planes; i++) {
+        for (uint32_t i = 0; i < planes; i++) {
             char* ptr = buf + image.offsets[i];
             int w = byteWidth[i];
-            for (int j = 0; j < byteHeight[i]; j++) {
+            for (uint32_t j = 0; j < byteHeight[i]; j++) {
                 ret = m_io(ptr, w, fp);
                 if (!ret)
                     goto out;
@@ -206,7 +206,7 @@ private:
     SharedPtr<VaapiFrameIO> m_frameio;
     static bool readFromFile(char* ptr, int size, FILE* fp)
     {
-        return fread(ptr, 1, size, fp) == size;
+        return fread(ptr, 1, size, fp) == (size_t)size;
     }
 };
 
@@ -225,7 +225,7 @@ private:
     SharedPtr<VaapiFrameIO> m_frameio;
     static bool writeToFile(char* ptr, int size, FILE* fp)
     {
-        return fwrite(ptr, 1, size, fp) == size;
+        return fwrite(ptr, 1, size, fp) == (size_t)size;
     }
 };
 //vaapi related operation end

--- a/tests/vppoutputencode.cpp
+++ b/tests/vppoutputencode.cpp
@@ -44,7 +44,7 @@ const char* guessMime(const char* filename)
     if(ext==NULL)
         return NULL;
     ext++;
-    for (int i = 0; i < N_ELEMENTS(MimeEntrys); i++) {
+    for (uint32_t i = 0; i < N_ELEMENTS(MimeEntrys); i++) {
         const MimeEntry* entry = MimeEntrys + i;
         if (strcasecmp(entry->ext, ext) == 0) {
             return entry->mime;

--- a/tests/yamitranscode.cpp
+++ b/tests/yamitranscode.cpp
@@ -140,7 +140,7 @@ public:
     {
 
         SharedPtr<VideoFrame> src;
-        int count = 0;
+        uint32_t count = 0;
         while (m_input->read(src)) {
             if(!m_output->output(src))
                 break;

--- a/vaapi/vaapidisplay.cpp
+++ b/vaapi/vaapidisplay.cpp
@@ -214,7 +214,7 @@ const VAImageFormat *
 VaapiDisplay::getVaFormat(uint32_t fourcc)
 {
     AutoLock locker(m_lock);
-    int i;
+    size_t i;
 
     if (m_vaImageFormats.empty()) {
         VAStatus vaStatus;

--- a/vaapi/vaapiimage.cpp
+++ b/vaapi/vaapiimage.cpp
@@ -121,7 +121,7 @@ bool VaapiImageRaw::copyFrom(const uint8_t* src, uint32_t size)
     uint32_t off = 0;
     uint32_t planes;
     getPlaneResolution(width, height, planes);
-    for (int i = 0; i < planes; i++) {
+    for (uint32_t i = 0; i < planes; i++) {
         offset[i] = off;
         off += width[i] * height[i];
     }
@@ -146,7 +146,7 @@ bool VaapiImageRaw::copy(uint8_t* destBase,
               const uint32_t srcOffsets[3], const uint32_t srcPitches[3],
               const uint32_t width[3], const uint32_t height[3], uint32_t planes)
 {
-    for (int i = 0; i < planes; i++) {
+    for (uint32_t i = 0; i < planes; i++) {
         uint32_t w = width[i];
         uint32_t h = height[i];
         if (w > destPitches[i] || w > srcPitches[i]) {
@@ -158,7 +158,7 @@ bool VaapiImageRaw::copy(uint8_t* destBase,
         uint8_t* dest = destBase + destOffsets[i];
 
 
-        for (int j = 0; j < h; j++) {
+        for (uint32_t j = 0; j < h; j++) {
             memcpy(dest, src, w);
             src += srcPitches[i];
             dest += destPitches[i];

--- a/vaapi/vaapiimagepool.cpp
+++ b/vaapi/vaapiimagepool.cpp
@@ -37,7 +37,7 @@ ImagePoolPtr VaapiImagePool::create(const DisplayPtr& display, uint32_t format, 
     ImagePoolPtr pool;
     std::vector<ImagePtr> images;
     images.reserve(count);
-    for (size_t i = 0; i < count; ++i) {
+    for (int32_t i = 0; i < count; ++i) {
         ImagePtr image = VaapiImage::create(display, format, width, height);
         if (!image)
             return pool;
@@ -112,7 +112,7 @@ ImagePtr VaapiImagePool::acquireWithWait()
 void VaapiImagePool::flush()
 {
     AutoLock lock(m_lock);
-    if ( m_freeIndex.size() != m_poolSize)
+    if ( m_freeIndex.size() != (size_t)m_poolSize)
         m_flushing = true;
 }
 
@@ -129,7 +129,7 @@ void VaapiImagePool::recycleID(VAImageID imageID)
     ASSERT(index >=0 && index < m_poolSize);
     m_freeIndex.push_back(index);
 
-    if (m_flushing && m_freeIndex.size() == m_poolSize)
+    if (m_flushing && m_freeIndex.size() == (size_t)m_poolSize)
         m_flushing = false;
 
     m_cond.signal();

--- a/vaapi/vaapisurface.cpp
+++ b/vaapi/vaapisurface.cpp
@@ -48,7 +48,7 @@ static uint32_t vaapiChromaToVaChroma(VaapiChromaType chroma)
         {VAAPI_CHROMA_TYPE_YUV422, VA_RT_FORMAT_YUV422},
         {VAAPI_CHROMA_TYPE_YUV444, VA_RT_FORMAT_YUV444}
     };
-    for (int i = 0; i < N_ELEMENTS(chromaMap); i++) {
+    for (uint32_t i = 0; i < N_ELEMENTS(chromaMap); i++) {
         if (chromaMap[i].vaapiChroma == chroma)
             return chromaMap[i].vaChroma;
     }


### PR DESCRIPTION
delete the '-Wno-sign-compare' of both CFLAGS and CXXFLAGS in file configure.ac, and work out the compiling error in comparison between signed and unsigned integer expression. I still use some type converion(convert 'int' into 'uint'), because changing the variabe type from its definition need too many code modifications.