### PR TITLE
[v4l2] capture device node starts as late as possible

### DIFF
--- a/tests/v4l2decode.cpp
+++ b/tests/v4l2decode.cpp
@@ -449,13 +449,8 @@ int main(int argc, char** argv)
     ioctlRet = SIMULATE_V4L2_OP(Ioctl)(fd, VIDIOC_S_FMT, &format);
     ASSERT(ioctlRet != -1);
 
-    // start input port
+    // input port starts as early as possible to decide output frame format
     __u32 type = V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE;
-    ioctlRet = SIMULATE_V4L2_OP(Ioctl)(fd, VIDIOC_STREAMON, &type);
-    ASSERT(ioctlRet != -1);
-
-    // start output port
-    type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
     ioctlRet = SIMULATE_V4L2_OP(Ioctl)(fd, VIDIOC_STREAMON, &type);
     ASSERT(ioctlRet != -1);
 
@@ -632,6 +627,11 @@ int main(int argc, char** argv)
             ASSERT(0);
         }
     }
+
+    // output port starts as late as possible to adopt user provide output buffer
+    type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
+    ioctlRet = SIMULATE_V4L2_OP(Ioctl)(fd, VIDIOC_STREAMON, &type);
+    ASSERT(ioctlRet != -1);
 
     bool event_pending=true; // try to get video resolution.
     int dqCountAfterEOS = 0;

--- a/v4l2/v4l2_wrapper.cpp
+++ b/v4l2/v4l2_wrapper.cpp
@@ -225,6 +225,8 @@ int32_t YamiV4L2_SetParameter(int32_t fd, const char* key, const char* value)
     V4l2CodecPtr v4l2Codec = _findCodecFromFd(fd);
     ASSERT(v4l2Codec);
 
+    // FIXME, usually, it can be detected by v4l2_requestbuffers.memory
+    // however, chrome always set it to MMAP even for egl/texture usage
     if (!strcmp(key, "frame-memory-type")) {
         VideoDataMemoryType memoryType;
         if (!strcmp(value, "raw-data")) {

--- a/v4l2/v4l2codec_device_ops.h
+++ b/v4l2/v4l2codec_device_ops.h
@@ -31,11 +31,18 @@
  */
 #ifndef v4l2codec_device_ops_h
 #define v4l2codec_device_ops_h
+#include <linux/videodev2.h>
 #include <EGL/egl.h>
 #include <stdint.h>
 
 #ifndef V4L2_EVENT_RESOLUTION_CHANGE
     #define V4L2_EVENT_RESOLUTION_CHANGE 5
+#endif
+#ifndef V4L2_MEMORY_DMABUF
+    #define V4L2_MEMORY_DMABUF      4
+#endif
+#ifndef V4L2_MEMORY_ANDROID_NATIVE_BUFFER
+    #define V4L2_MEMORY_ANDROID_NATIVE_BUFFER   (V4L2_MEMORY_DMABUF+1)
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
- in order to adopt all the buffer provided by client before decoding,
  we start capture device node after all output buffer has been enqued.
  then v4l2codec can setup hw related context(VASurface/VAContext etc)
  upon this STREAMON ioctl
- decode input (OUTPUT node) starts as early as possible to parser codec_data
  but frame decoding waits until the above is done.
- add buffer memory type for dma_buf and android native buffer