### PR TITLE
v4l2-test: variables not used when compiling in X11 mode and disabling docs by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -283,8 +283,8 @@ AM_CONDITIONAL(BUILD_GET_MV,
 # dnl Doxygen
 AC_ARG_ENABLE(docs,
     [AC_HELP_STRING([--enable-docs],
-        [build Doxygen docs @<:@default=yes@:>@])],
-    [], [enable_docs="yes"])
+        [build Doxygen docs @<:@default=no@:>@])],
+    [], [enable_docs="no"])
 
 if test "$enable_docs" = "yes"; then
     AC_CHECK_TOOL([DOXYGEN], [doxygen], [no])

--- a/tests/v4l2decode.cpp
+++ b/tests/v4l2decode.cpp
@@ -125,6 +125,7 @@ uint32_t k_extraOutputFrameCount = 2;
 static std::vector<uint8_t*> inputFrames;
 static std::vector<struct RawFrameData> rawOutputFrames;
 
+#if !__ENABLE_V4L2_GLX__
 static VideoDataMemoryType memoryType = VIDEO_DATA_MEMORY_TYPE_DRM_NAME;
 static const char* typeStrDrmName = "drm-name";
 static const char* typeStrDmaBuf = "dma-buf";
@@ -135,6 +136,7 @@ static const char* memoryTypeStr = typeStrDrmName;
 #define IS_DMA_BUF()   (!strcmp(memoryTypeStr, typeStrDmaBuf))
 #define IS_RAW_DATA()   (!strcmp(memoryTypeStr, typeStrRawData))
 // #define IS_ANDROID_NATIVE_BUFFER()   (!strcmp(memoryTypeStr, typeStrAndroidNativeBuffer))
+#endif
 
 static FILE* outfp = NULL;
 static Display * x11Display = NULL;
@@ -405,7 +407,7 @@ int main(int argc, char** argv)
     // set output frame memory type
 #if __ENABLE_V4L2_OPS__
     SIMULATE_V4L2_OP(SetParameter)(fd, "frame-memory-type", memoryTypeStr);
-#else
+#elif !__ENABLE_V4L2_GLX__
     SIMULATE_V4L2_OP(FrameMemoryType)(fd, memoryType);
 #endif
 


### PR DESCRIPTION
Build was broken due to memory type variables that were not properly
isolated when V4L2_GLX is not enabled. Isolating the code with
this patch

Signed-off-by: Daniel Charles <daniel.charles@intel.com>