### PR TITLE
libtool: workaround ubuntu libtool issue

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -417,6 +417,9 @@ AC_OUTPUT([
          pkgconfig/libyami_vpp.pc
 ])
 
+dnl Hack to workaround Ubuntu libtool bug
+sed -i "s/link_all_deplibs=no/link_all_deplibs=yes/g" libtool
+
 # Print a configuration summary
 DECODERS=""
 AS_IF([test x$enable_h265dec = xyes], [DECODERS="$DECODERS h265"])


### PR DESCRIPTION
Ubuntu and Debian patched libtool to set link_all_deplibs=no.
Apparently this goes against what the libtool documentation
states/recommends.

Setting link_all_deplibs causes libtool to not properly track
down all the inter-dependencies for you.  That is, if A depends
on B and B depends on C, then libtool will not link A to C
automatically, even though it is required.  Oddly, this only
happens when both static and shared libraries are compiled
at the same time.

To workaround this, sed replace link_all_deplibs=no to
link_all_deplibs=yes in the configure generated libtool
wrapper.

Fixes #377

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>