### PR TITLE
yamiinfo

### DIFF
--- a/common/factory.h
+++ b/common/factory.h
@@ -23,6 +23,7 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
 template < class T >
 class Factory {
@@ -30,6 +31,7 @@ public:
     typedef T* Type;
     typedef Type (*Creator) (void);
     typedef std::string KeyType;
+    typedef std::vector<KeyType> Keys;
     typedef std::map<KeyType, Creator> Creators;
     typedef typename Creators::iterator iterator;
     typedef typename Creators::const_iterator const_iterator;
@@ -60,6 +62,16 @@ public:
         if (creator != creators.end())
             return creator->second();
         return NULL;
+    }
+
+    static Keys keys()
+    {
+        Keys result;
+        const Creators& creators = getCreators();
+        const const_iterator endIt(creators.end());
+        for (const_iterator it(creators.begin()); it != endIt; ++it)
+            result.push_back(it->first);
+        return result;
     }
 
 private:

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -177,3 +177,16 @@ yamivpp_SOURCES  = vppinputdecode.cpp vppinputoutput.cpp vppoutputencode.cpp  vp
 yamitranscode_LDADD    = $(YAMI_VPP_LIBS)
 yamitranscode_LDFLAGS  = -pthread $(YAMI_VPP_LDFLAGS)
 yamitranscode_SOURCES  = vppinputdecode.cpp vppinputoutput.cpp vppoutputencode.cpp  yamitranscode.cpp encodeinput.cpp encodeInputCamera.cpp encodeInputDecoder.cpp $(DECODE_INPUT_SOURCES) vppinputasync.cpp 
+
+bin_PROGRAMS += yamiinfo
+yamiinfo_SOURCES = yamiinfo.cpp
+yamiinfo_LDADD = \
+	$(top_builddir)/decoder/libyami_decoder.la \
+	$(top_builddir)/encoder/libyami_encoder.la \
+	$(top_builddir)/vpp/libyami_vpp.la \
+	$(NULL)
+yamiinfo_LDFLAGS = -Wl,--no-as-needed \
+	$(YAMI_DECODE_LDFLAGS) \
+	$(YAMI_ENCODE_LDFLAGS) \
+	$(YAMI_VPP_LDFLAGS) \
+	$(NULL)

--- a/tests/yamiinfo.cpp
+++ b/tests/yamiinfo.cpp
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (C) 2011-2015 Intel Corporation
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2.1
+ *  of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <iostream>
+#include "decoder/vaapidecoder_factory.h"
+#include "encoder/vaapiencoder_factory.h"
+#include "vpp/vaapipostprocess_factory.h"
+
+using namespace YamiMediaCodec;
+
+template<class Factory>
+void printFactoryInfo(const char* name)
+{
+    std::cout << std::endl << name << ":" << std::endl;
+    typename Factory::Keys keys(Factory::keys());
+    for (size_t i(0); i < keys.size(); ++i) {
+        std::cout << "\t" << keys[i] << std::endl;
+    }
+}
+
+int main(int argc, const char** argv)
+{
+    std::cout << PACKAGE_STRING << " - " << PACKAGE_URL << std::endl;
+
+    printFactoryInfo<VaapiDecoderFactory>("decoders");
+    printFactoryInfo<VaapiEncoderFactory>("encoders");
+    printFactoryInfo<VaapiPostProcessFactory>("post processors");
+
+    return 0;
+}


### PR DESCRIPTION
Add yamiinfo binary to tests.  This is useful for getting yami version and supported codec mime type class info.