### PR TITLE
decoder/jpeg: stop decoding after EOI

### DIFF
--- a/decoder/vaapidecoder_jpeg.cpp
+++ b/decoder/vaapidecoder_jpeg.cpp
@@ -439,6 +439,9 @@ Decode_Status VaapiDecoderJpeg::decode(VideoDecodeBuffer * buffer)
         case JPEG_MARKER_EOI:
             /* Get out of the loop, trailing data is not needed */
             status = decodePictureEnd();
+            if (ofs < bufSize)
+                WARNING("%d bytes of trailing data skipped", bufSize - ofs);
+            return status;
             break;
         case JPEG_MARKER_DHT:
             status = parseHuffmanTable(buf + seg.offset, seg.size);


### PR DESCRIPTION
Based on the comment in the EOI case, it appears the intention,
and rightfully so, is to break out of the decode loop after
encountering the EOI in the JPEG data stream.  However, the break
statement only breaks out of the case block.  This causes the
decode loop to continue parsing trailing data and can result
in erroneous behavior if the trailing data is malformed.

To fix this, return immediately when the EOI is encountered so
that we don't attempt to parse invalid trailing data.

The decoder is only intended to decode/parse a single JPEG image.
If the user wants to decode multiple JPEG's (e.g. an MJPEG file)
then they can call decode() multiple times with each distinct sequence
of JPEG data (i.e. user is responsible for splitting an MJPEG into
separate JPEG's and should not send the entire MJPEG stream to a
single call to decode()).

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>