### PR TITLE
enc: add multi-reference-frame support.

### DIFF
--- a/encoder/vaapiencoder_base.cpp
+++ b/encoder/vaapiencoder_base.cpp
@@ -52,6 +52,7 @@ VaapiEncoderBase::VaapiEncoderBase():
     m_videoParamCommon.frameRate.frameRateDenom = 1;
     m_videoParamCommon.intraPeriod = 15;
     m_videoParamCommon.ipPeriod = 1;
+    m_videoParamCommon.numRefFrames = 1;
     m_videoParamCommon.rcMode = RATE_CONTROL_CQP;
     m_videoParamCommon.rcParams.initQP = 26;
     m_videoParamCommon.rcParams.minQP = 1;

--- a/encoder/vaapiencoder_base.h
+++ b/encoder/vaapiencoder_base.h
@@ -125,6 +125,11 @@ protected:
     uint32_t ipPeriod() const {
         return m_videoParamCommon.ipPeriod;
     }
+
+    uint32_t numRefFrames() const {
+        return m_videoParamCommon.numRefFrames;
+    }
+
     uint32_t frameRateDenom() const {
         return m_videoParamCommon.frameRate.frameRateDenom;
     }

--- a/encoder/vaapiencoder_h264.cpp
+++ b/encoder/vaapiencoder_h264.cpp
@@ -788,11 +788,15 @@ void VaapiEncoderH264::resetParams ()
     m_log2MaxPicOrderCnt = m_log2MaxFrameNum + 1;
     m_maxPicOrderCnt = (1 << m_log2MaxPicOrderCnt);
 
-    m_maxRefList0Count = 1;
-    m_maxRefList1Count = m_numBFrames > 0;
+    m_maxRefList1Count = m_numBFrames > 0;//m_maxRefList1Count <=1, because of currenent order mechanism
+    m_maxRefList0Count = numRefFrames();
+    if (m_maxRefList0Count >= m_maxOutputBuffer -1)
+        m_maxRefList0Count = m_maxOutputBuffer -1;
+
     m_maxRefFrames =
         m_maxRefList0Count + m_maxRefList1Count;
 
+    assert(m_maxRefFrames <= m_maxOutputBuffer);
     INFO("m_maxRefFrames: %d", m_maxRefFrames);
 
 

--- a/encoder/vaapiencoder_hevc.cpp
+++ b/encoder/vaapiencoder_hevc.cpp
@@ -957,9 +957,15 @@ void VaapiEncoderHEVC::resetParams ()
     m_log2MaxPicOrderCnt = m_log2MaxFrameNum + 1;
     m_maxPicOrderCnt = (1 << m_log2MaxPicOrderCnt);
 
-    m_maxRefList0Count = 1;
-    m_maxRefList1Count = m_numBFrames > 0;
-    m_maxRefFrames = m_maxRefList0Count + m_maxRefList1Count;
+    m_maxRefList1Count = m_numBFrames > 0;//m_maxRefList1Count <=1, because of currenent order mechanism
+    m_maxRefList0Count = numRefFrames();
+    if (m_maxRefList0Count >= m_maxOutputBuffer -1)
+        m_maxRefList0Count = m_maxOutputBuffer -1;
+
+    m_maxRefFrames =
+        m_maxRefList0Count + m_maxRefList1Count;
+
+    assert(m_maxRefFrames <= m_maxOutputBuffer);
 
     INFO("m_maxRefFrames: %d", m_maxRefFrames);
 

--- a/interface/VideoEncoderDefs.h
+++ b/interface/VideoEncoderDefs.h
@@ -337,8 +337,9 @@ typedef struct VideoParamsCommon {
     VideoRawFormat rawFormat;
     VideoResolution resolution;
     VideoFrameRate frameRate;
-    int32_t intraPeriod;
-    int32_t ipPeriod;
+    uint32_t intraPeriod;
+    uint32_t ipPeriod;
+    uint32_t numRefFrames;
     VideoRateControl rcMode;
     VideoRateControlParams rcParams;
     VideoIntraRefreshType refreshType;

--- a/tests/encodehelp.h
+++ b/tests/encodehelp.h
@@ -37,6 +37,8 @@ static int videoWidth = 0, videoHeight = 0, bitRate = 0, fps = 30;
 static int initQp=26;
 static VideoRateControl rcMode = RATE_CONTROL_CQP;
 static int frameCount = 0;
+static int numRefFrames = 1;
+
 #ifdef __BUILD_GET_MV__
 static FILE *MVFp;
 #endif
@@ -70,6 +72,7 @@ static void print_help(const char* app)
     printf("   --rcmode <CBR|CQP> optional\n");
     printf("   --ipbmode <0(I frame only ) | 1 (I and P frames) | 2 (I,P,B frames)> optional\n");
     printf("   --keyperiod <key frame period(default 30)> optional\n");
+    printf("   --refnum <number of referece frames(default 1)> optional\n");
 }
 
 static VideoRateControl string_to_rc_mode(char *str)
@@ -96,6 +99,7 @@ static bool process_cmdline(int argc, char *argv[])
         {"rcmode", required_argument, NULL, 0 },
         {"ipbmode", required_argument, NULL, 0 },
         {"keyperiod", required_argument, NULL, 0 },
+        {"refnum", required_argument, NULL, 0 },
         {NULL, no_argument, NULL, 0 }};
     int option_index;
 
@@ -152,6 +156,9 @@ static bool process_cmdline(int argc, char *argv[])
                     break;
                 case 4:
                     kIPeriod = atoi(optarg);
+                    break;
+                case 5:
+                    numRefFrames= atoi(optarg);
                     break;
             }
         }
@@ -210,6 +217,7 @@ void setEncoderParameters(VideoParamsCommon * encVideoParams)
     encVideoParams->rcParams.bitRate = bitRate;
     encVideoParams->rcParams.initQP = initQp;
     encVideoParams->rcMode = rcMode;
+    encVideoParams->numRefFrames = numRefFrames;
     //encVideoParams->rcParams.minQP = 1;
 
     //encVideoParams->profile = VAProfileH264Main;

--- a/tests/vppoutputencode.cpp
+++ b/tests/vppoutputencode.cpp
@@ -33,6 +33,7 @@ EncodeParams::EncodeParams()
     , ipPeriod(1)
     , ipbMode(1)
     , kIPeriod(30)
+    , numRefFrames(1)
     , codec("AVC")
 {
     /*nothing to do*/
@@ -93,6 +94,7 @@ static void setEncodeParam(const SharedPtr<IVideoEncoder>& encoder,
     encVideoParams.rcParams.bitRate = encParam->bitRate;
     encVideoParams.rcParams.initQP = encParam->initQp;
     encVideoParams.rcMode = encParam->rcMode;
+    encVideoParams.numRefFrames = encParam->numRefFrames;
 
     encVideoParams.size = sizeof(VideoParamsCommon);
     encoder->setParameters(VideoParamsTypeCommon, &encVideoParams);

--- a/tests/vppoutputencode.h
+++ b/tests/vppoutputencode.h
@@ -42,6 +42,7 @@ public:
     int32_t ipPeriod;
     int32_t ipbMode;
     int32_t kIPeriod;
+    int32_t numRefFrames;
     string codec;
 };
 

--- a/tests/yamitranscode.cpp
+++ b/tests/yamitranscode.cpp
@@ -42,7 +42,7 @@ using namespace YamiMediaCodec;
 static void print_help(const char* app)
 {
     printf("%s <options>\n", app);
-    printf("   -i <source yuv filename> load YUV from a file or container\n");
+    printf("   -i <source filename> load a raw yuv file or a compressed video file\n");
     printf("   -W <width> -H <height>\n");
     printf("   -o <coded file> optional\n");
     printf("   -b <bitrate: kbps> optional\n");
@@ -52,6 +52,7 @@ static void print_help(const char* app)
     printf("   -N <number of frames to encode(camera default 50), useful for camera>\n");
     printf("   --qp <initial qp> optional\n");
     printf("   --rcmode <CBR|CQP> optional\n");
+    printf("   --refnum <number of referece frames(default 1)> optional\n");
 }
 
 static VideoRateControl string_to_rc_mode(char *str)
@@ -76,6 +77,7 @@ static bool processCmdLine(int argc, char *argv[], TranscodeParams& para)
         {"help", no_argument, NULL, 'h' },
         {"qp", required_argument, NULL, 0 },
         {"rcmode", required_argument, NULL, 0 },
+        {"refnum", required_argument, NULL, 0 },
         {NULL, no_argument, NULL, 0 }};
     int option_index;
 
@@ -126,6 +128,9 @@ static bool processCmdLine(int argc, char *argv[], TranscodeParams& para)
                     break;
                 case 2:
                     para.m_encParams.rcMode = string_to_rc_mode(optarg);
+                    break;
+                case 3:
+                    para.m_encParams.numRefFrames= atoi(optarg);
                     break;
             }
         }


### PR DESCRIPTION
1. Add multi-reference frames interface and test cases
2. Add multi-reference frames support for h264 and hevc.
   Because of current reoder mechanism, multi-reference is only used
   for forward reference. The max value of back referece frames is still
   one.

Signed-off-by: Zhong Li <zhong.li@intel.com>