### PR TITLE
tests: remove needless statements

### DIFF
--- a/tests/decodehelp.h
+++ b/tests/decodehelp.h
@@ -103,6 +103,7 @@ static bool process_cmdline(int argc, char *argv[])
                     dumpFourcc = VA_FOURCC(optarg[0], optarg[1], optarg[2], optarg[3]);
                 } else {
                     fprintf(stderr, "invalid fourcc: %s\n", optarg);
+                    return false;
                 }
             }
             break;
@@ -117,7 +118,7 @@ static bool process_cmdline(int argc, char *argv[])
     }
     if (!inputFileName) {
         fprintf(stderr, "no input media file specified\n");
-        return -1;
+        return false;
     }
     fprintf(stderr, "input file: %s, renderMode: %d\n", inputFileName, renderMode);
 

--- a/tests/v4l2decode.cpp
+++ b/tests/v4l2decode.cpp
@@ -462,15 +462,6 @@ int main(int argc, char** argv)
     if (!process_cmdline(argc, argv))
         return -1;
 
-    if (!inputFileName) {
-        ERROR("no input media file specified\n");
-        return -1;
-    }
-    INFO("input file: %s, renderMode: %d", inputFileName, renderMode);
-
-    if (!dumpOutputName)
-        dumpOutputName = strdup ("./");
-
 #if !__ENABLE_V4L2_GLX__
     switch (renderMode) {
     case 0:


### PR DESCRIPTION
decodehelp.h: return false instead -1 when parse failed.
v4l2decode: remove needless statements which has been done in the function process_cmdline()