### PR TITLE
v4l2: add back texture render mode

### DIFF
--- a/egl/egl_vaapi_image.cpp
+++ b/egl/egl_vaapi_image.cpp
@@ -78,6 +78,7 @@ EGLImageKHR EglVaapiImage::createEglImage(EGLDisplay eglDisplay, EGLContext eglC
         return m_eglImage;
     if (!acquireBufferHandle(memoryType))
         return EGL_NO_IMAGE_KHR;
+    //FIXME, it doesn't support planar video frame yet
     m_eglImage = createEglImageFromHandle(eglDisplay, eglContext, memoryType, m_bufferInfo.handle,
         m_width, m_height, m_image.pitches[0]);
     if (m_eglImage == EGL_NO_IMAGE_KHR) {

--- a/egl/egl_vaapi_image.h
+++ b/egl/egl_vaapi_image.h
@@ -39,6 +39,7 @@ public:
     bool init();
     EGLImageKHR createEglImage(EGLDisplay, EGLContext, VideoDataMemoryType);
     bool blt(const VideoFrameRawData& src);
+    bool exportFrame(VideoDataMemoryType memoryType, VideoFrameRawData &frame);
     ~EglVaapiImage();
 private:
     bool acquireBufferHandle(VideoDataMemoryType);
@@ -50,6 +51,8 @@ private:
     int             m_width;
     int             m_height;
     bool            m_inited;
+    bool            m_acquired; // acquired buffer handle
+    VideoFrameRawData   m_frameInfo;
 
     EGLImageKHR     m_eglImage;
 };

--- a/tests/v4l2decode.cpp
+++ b/tests/v4l2decode.cpp
@@ -32,6 +32,8 @@
 #include <errno.h>
 #include  <sys/mman.h>
 #include <vector>
+#include <stdint.h>
+#include <inttypes.h>
 
 #include "common/log.h"
 #include "common/utils.h"
@@ -502,10 +504,14 @@ int main(int argc, char** argv)
 #if __ENABLE_X11__ || __ENABLE_V4L2_GLX__
     x11Display = XOpenDisplay(NULL);
     ASSERT(x11Display);
-#endif
-#if __ENABLE_V4L2_GLX__
-    // FIXME, setXDisplay for GLX only
+    DEBUG("x11display: %p", x11Display);
+    #if __ENABLE_V4L2_OPS__
+    char displayStr[32];
+    sprintf(displayStr, "%" PRIu64 "", (uint64_t)x11Display);
+    ioctlRet = SIMULATE_V4L2_OP(SetParameter)(fd, "x11-display", displayStr);
+    #else
     ioctlRet = SIMULATE_V4L2_OP(SetXDisplay)(fd, x11Display);
+    #endif
 #endif
     // set output frame memory type
 #if __ENABLE_V4L2_OPS__

--- a/tests/v4l2encode.cpp
+++ b/tests/v4l2encode.cpp
@@ -167,7 +167,7 @@ bool takeOneOutputFrame(int fd, int index = -1/* if index is not -1, simple enqu
     int ioctlRet = -1;
 
     memset(&buf, 0, sizeof(buf));
-    memset(&planes, 0, sizeof(planes));
+    memset(planes, 0, sizeof(planes));
     buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE; //it indicates output buffer type
     buf.memory = V4L2_MEMORY_MMAP; // chromeos v4l2vea uses this mode only
     buf.m.planes = planes;

--- a/v4l2/v4l2_codecbase.cpp
+++ b/v4l2/v4l2_codecbase.cpp
@@ -83,7 +83,7 @@ V4l2CodecBase::V4l2CodecBase()
     : m_memoryType(VIDEO_DATA_MEMORY_TYPE_RAW_COPY)
     , m_started(false)
 #if ANDROID
-#elif __ENABLE_V4L2_GLX__
+#elif __ENABLE_X11__ || __ENABLE_V4L2_GLX__
     , m_x11Display(NULL)
 #else
     , m_drmfd(0)

--- a/v4l2/v4l2_codecbase.h
+++ b/v4l2/v4l2_codecbase.h
@@ -29,12 +29,15 @@
 #if ANDROID
 #include "VideoPostProcessHost.h"
 #include "interface/VideoDecoderInterface.h"
-#elif __ENABLE_V4L2_GLX__
-#include <X11/Xlib.h>
 #else
-#include <EGL/egl.h>
-#define EGL_EGLEXT_PROTOTYPES
-#include "EGL/eglext.h"
+    #if __ENABLE_X11__ || __ENABLE_V4L2_GLX__
+    #include <X11/Xlib.h>
+    #endif
+    #if !__ENABLE_V4L2_GLX__
+    #include <EGL/egl.h>
+    #define EGL_EGLEXT_PROTOTYPES
+    #include "EGL/eglext.h"
+    #endif
 #endif
 #include "interface/VideoCommonDefs.h"
 
@@ -70,12 +73,15 @@ class V4l2CodecBase {
 #if ANDROID
     inline bool setVaDisplay();
     inline bool createVpp();
-#elif __ENABLE_V4L2_GLX__
+#else
+    #if __ENABLE_X11__ || __ENABLE_V4L2_GLX__
     bool setXDisplay(Display *x11Display) { m_x11Display = x11Display; return true; };
     virtual int32_t usePixmap(uint32_t bufferIndex, Pixmap pixmap) {return 0;};
-#else
+    #endif
+    #if !__ENABLE_V4L2_GLX__
     virtual int32_t useEglImage(EGLDisplay eglDisplay, EGLContext eglContext, uint32_t buffer_index, void* egl_image) {return 0;};
     bool setDrmFd(int drm_fd) {m_drmfd = drm_fd; return true;};
+    #endif
 
 #endif
     void workerThread();
@@ -106,10 +112,13 @@ class V4l2CodecBase {
 #if ANDROID
     VADisplay m_vaDisplay;
     SharedPtr<IVideoPostProcess> m_vpp;
-#elif __ENABLE_V4L2_GLX__
-    Display *m_x11Display;
 #else
+    #if __ENABLE_X11__ || __ENABLE_V4L2_GLX__
+    Display *m_x11Display;
+    #endif
+    #if !__ENABLE_V4L2_GLX__
     int m_drmfd;
+    #endif
 #endif
 
     enum EosState{

--- a/v4l2/v4l2_decode.cpp
+++ b/v4l2/v4l2_decode.cpp
@@ -240,6 +240,7 @@ bool V4l2Decoder::outputPulse(uint32_t &index)
     m_outputRawFrames[index].timeStamp = timeStamp;
 #else
     if (m_memoryType == VIDEO_DATA_MEMORY_TYPE_DRM_NAME || m_memoryType == VIDEO_DATA_MEMORY_TYPE_DMA_BUF) {
+        // FIXME, it introduce one GPU copy; which is not necessary in major case and should be avoided in most case
         m_eglVaapiImages[index]->blt(*frame);
         m_decoder->renderDone(frame);
     }

--- a/v4l2/v4l2_decode.cpp
+++ b/v4l2/v4l2_decode.cpp
@@ -109,10 +109,18 @@ bool V4l2Decoder::start()
 #if ANDROID
     nativeDisplay.type = NATIVE_DISPLAY_VA;
     nativeDisplay.handle = (intptr_t)m_vaDisplay;
-#elif __ENABLE_V4L2_GLX__
+#elif __ENABLE_X11__ || __ENABLE_V4L2_GLX__
+    DEBUG("m_x11Display: %p", m_x11Display);
+    #if __ENABLE_V4L2_GLX__
     ASSERT(m_x11Display);
-    nativeDisplay.type = NATIVE_DISPLAY_X11;
-    nativeDisplay.handle = (intptr_t)m_x11Display;
+    #endif
+    if (m_x11Display) {
+        nativeDisplay.type = NATIVE_DISPLAY_X11;
+        nativeDisplay.handle = (intptr_t)m_x11Display;
+    } else {
+        nativeDisplay.type = NATIVE_DISPLAY_DRM;
+        nativeDisplay.handle = m_drmfd;
+    }
 #else
     nativeDisplay.type = NATIVE_DISPLAY_DRM;
     nativeDisplay.handle = m_drmfd;

--- a/v4l2/v4l2_decode.h
+++ b/v4l2/v4l2_decode.h
@@ -69,6 +69,7 @@ class V4l2Decoder : public V4l2CodecBase
   private:
     DecoderPtr m_decoder;
     std::vector<uint8_t> m_codecData;
+    bool m_bindEglImage;
     // VideoFormatInfo m_videoFormatInfo;
     // chrome requires m_maxBufferCount[OUTPUT] to be big enough (dpb size + some extra ones), it is correct when we export YUV buffer direcly
     // however, we convert YUV frame to temporary RGBX frame; so the RGBX frame pool is not necessary to be that big.

--- a/v4l2/v4l2_wrapper.h
+++ b/v4l2/v4l2_wrapper.h
@@ -23,10 +23,13 @@
 #include <stdint.h>
 #include <stddef.h>
 #if ANDROID
-#elif __ENABLE_V4L2_GLX__
-#include <X11/Xlib.h>
 #else
-#include <EGL/egl.h>
+    #if __ENABLE_X11__ || __ENABLE_V4L2_GLX__
+    #include <X11/Xlib.h>
+    #endif
+    #if !__ENABLE_V4L2_GLX__
+    #include <EGL/egl.h>
+    #endif
 #endif
 #include "VideoCommonDefs.h"
 
@@ -50,18 +53,21 @@ void* YamiV4L2_Mmap(void* addr, size_t length,
                      int prot, int flags, int fd, unsigned int offset);
 int32_t YamiV4L2_Munmap(void* addr, size_t length);
 #if ANDROID
-#elif __ENABLE_V4L2_GLX__
-/// it should be called before driver initialization (immediate after _Open()).
-int32_t YamiV4L2_SetXDisplay(int32_t fd, Display *x11Display);
-/// pixmap=0 means the previous set rendering target becomes invalid, stop rendering to it.
-int32_t YamiV4L2_UsePixmap(int fd, uint32_t bufferIndex, Pixmap pixmap);
-/// terminate vaapi before XFreePixmap work around a strange X11 exception; otherwise there is "BadDrawable" exception though the Pixmap is valid.
-int32_t YamiV4L2_Stop(int32_t fd);
 #else
-int32_t YamiV4L2_UseEglImage(int fd, EGLDisplay eglDisplay, EGLContext eglContext, unsigned int buffer_index, void* egl_image);
-int32_t YamiV4L2_SetDrmFd(int32_t fd, int drm_fd);
+    #if __ENABLE_X11__ || __ENABLE_V4L2_GLX__
+    /// it should be called before driver initialization (immediate after _Open()).
+    int32_t YamiV4L2_SetXDisplay(int32_t fd, Display *x11Display);
+    #endif
+    #if __ENABLE_V4L2_GLX__
+    /// pixmap=0 means the previous set rendering target becomes invalid, stop rendering to it.
+    int32_t YamiV4L2_UsePixmap(int fd, uint32_t bufferIndex, Pixmap pixmap);
+    /// terminate vaapi before XFreePixmap work around a strange X11 exception; otherwise there is "BadDrawable" exception though the Pixmap is valid.
+    int32_t YamiV4L2_Stop(int32_t fd);
+    #else
+    int32_t YamiV4L2_UseEglImage(int fd, EGLDisplay eglDisplay, EGLContext eglContext, unsigned int buffer_index, void* egl_image);
+    int32_t YamiV4L2_SetDrmFd(int32_t fd, int drm_fd);
+    #endif
 #endif
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/vaapi/vaapipicture.h
+++ b/vaapi/vaapipicture.h
@@ -109,7 +109,7 @@ bool VaapiPicture::render(std::vector<O>& objects)
 {
     bool ret = true;
 
-    for (int i = 0; i < objects.size(); i++)
+    for (uint32_t i = 0; i < objects.size(); i++)
         ret &= render(objects[i]);
 
     objects.clear(); // slient work around for psb drv to delete VABuffer


### PR DESCRIPTION
- add texture render mode of x11 init
- though gcc treat &arrary as array, it's better use array
- fix for IOCTL_COMMAND_STRING_MAP, force to use int for ioctl command

however, video frame doesn't show because drm_intel_bo_flink() fails in driver.