### PR TITLE
make: modify comparison between int and uint

### DIFF
--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -46,7 +46,7 @@ uint32_t guessFourcc(const char* fileName)
     const char* extension = strrchr(fileName, '.');
     if (extension) {
         extension++;
-        for (int i = 0; i < N_ELEMENTS(possibleFourcc); i++) {
+        for (size_t i = 0; i < N_ELEMENTS(possibleFourcc); i++) {
             const char* fourcc = possibleFourcc[i];
             if (!strcasecmp(fourcc, extension)) {
                 uint32_t ret = VA_FOURCC(fourcc[0], fourcc[1], fourcc[2], fourcc[3]);
@@ -244,7 +244,7 @@ bool fillFrameRawData(VideoFrameRawData* frame, uint32_t fourcc, uint32_t width,
     frame->memoryType = VIDEO_DATA_MEMORY_TYPE_RAW_POINTER;
 
     uint32_t offset = 0;
-    for (int i = 0; i < planes; i++) {
+    for (uint32_t i = 0; i < planes; i++) {
         frame->pitch[i] = w[i];
         frame->offset[i] = offset;
         offset += w[i] * h[i];

--- a/configure.ac
+++ b/configure.ac
@@ -305,8 +305,8 @@ fi
 AM_CONDITIONAL(ENABLE_DOCS,
     [test "$enable_docs" = "yes"])
 
-: ${CFLAGS="-g -O2 -Wno-unused-function -Wno-sign-compare -Wno-cpp -Wall -Werror"}
-: ${CXXFLAGS="-g -O2 -Wno-unused-function -Wno-sign-compare -Wno-cpp -Wall -Werror"}
+: ${CFLAGS="-g -O2 -Wno-unused-function  -Wno-cpp -Wall -Werror"}
+: ${CXXFLAGS="-g -O2 -Wno-unused-function -Wno-cpp -Wall -Werror"}
 
 # Checks for programs.
 AC_DISABLE_STATIC

--- a/decoder/vaapidecoder_fake.cpp
+++ b/decoder/vaapidecoder_fake.cpp
@@ -45,7 +45,6 @@ Decode_Status VaapiDecoderFake::start(VideoConfigBuffer * buffer)
 {
     DEBUG("VP9: start() buffer size: %d x %d", buffer->width,
           buffer->height);
-    Decode_Status status;
 
     VideoConfigBuffer config;
     config = *buffer;

--- a/decoder/vaapidecoder_h264.h
+++ b/decoder/vaapidecoder_h264.h
@@ -128,11 +128,11 @@ class VaapiDecPictureH264 : public VaapiDecPicture
     uint32_t m_structure;
     uint32_t m_picStructure; // XXX, seems duplicate with m_structure. since the macro in vaapipicture.h uses it, add it back temporarily
     int32_t m_fieldPoc[2];
-    int32_t m_frameNum;
+    uint32_t m_frameNum;
     int32_t m_frameNumWrap;
     uint32_t m_longTermFrameIdx;
-    int32_t m_picNum;
-    int32_t m_longTermPicNum;
+    uint32_t m_picNum;
+    uint32_t m_longTermPicNum;
     uint32_t m_outputFlag;
     uint32_t m_outputNeeded;
     PictureWeakPtr m_otherField;
@@ -248,7 +248,7 @@ class VaapiDPBManager {
                                 uint32_t refListCount);
 
     void initPictureRefsPicNum(const PicturePtr& pic,
-                               const SliceHeaderPtr& sliceHdr, int32_t frameNum);
+                               const SliceHeaderPtr& sliceHdr, uint32_t frameNum);
 
     void execPictureRefsModification(const PicturePtr& picture,
                                      const SliceHeaderPtr& sliceHdr);

--- a/decoder/vaapidecoder_h264_dpb.cpp
+++ b/decoder/vaapidecoder_h264_dpb.cpp
@@ -55,7 +55,8 @@ static uint32_t roundLog2(uint32_t value)
 {
     uint32_t ret = 0;
     uint32_t valueSquare = value * value;
-    while ((1 << (ret + 1)) <= valueSquare)
+    uint32_t one = 1;
+    while ((one << (ret + 1)) <= valueSquare)
         ++ret;
 
     ret = (ret + 1) >> 1;
@@ -331,7 +332,7 @@ void VaapiDPBManager::drainDPB()
 
 void VaapiDPBManager::debugDPBStatus()
 {
-    int i;
+    uint32_t i;
     VaapiFrameStore::Ptr frameStore;
 
     for (i = 0; i < DPBLayer->DPBCount; i++) {
@@ -443,7 +444,7 @@ void VaapiDPBManager::resetDPB(H264SPS * sps)
 */
 bool VaapiDPBManager::outputImmediateBFrame()
 {
-    int i;
+    uint32_t i;
     int ret = true;
 
     if (m_prevFrameStore.get()) {
@@ -871,11 +872,11 @@ initPictureRefsFields1(uint32_t pictureStructure,
 
 void VaapiDPBManager::initPictureRefsPicNum(const PicturePtr& picture,
                                             const SliceHeaderPtr& sliceHdr,
-                                            int32_t frameNum)
+                                            uint32_t frameNum)
 {
     H264PPS *const pps = sliceHdr->pps;
     H264SPS *const sps = pps->sequence;
-    const int32_t maxFrameNum = 1 << (sps->log2_max_frame_num_minus4 + 4);
+    const uint32_t maxFrameNum = 1 << (sps->log2_max_frame_num_minus4 + 4);
     uint32_t i;
 
     for (i = 0; i < DPBLayer->shortRefCount; i++) {
@@ -959,7 +960,7 @@ void VaapiDPBManager::execPictureRefsModification1(const PicturePtr& picture,
 
     //FIXME: without this we will crash in MR3_TANDBERG_B.264
     //shold review this after we fix it
-    for (int j = refListCount; j < numRefs; j++)
+    for (uint32_t j = refListCount; j < numRefs; j++)
         refList[j] = NULL;
     //end
 

--- a/decoder/vaapidecoder_h265.cpp
+++ b/decoder/vaapidecoder_h265.cpp
@@ -366,7 +366,7 @@ bool VaapiDecoderH265::DPB::checkLatency(const H265SPS* const sps)
 bool VaapiDecoderH265::DPB::checkDpbSize(const H265SPS* const sps)
 {
     uint8_t highestTid = sps->max_sub_layers_minus1;
-    return m_pictures.size() >= (sps->max_dec_pic_buffering_minus1[highestTid] + 1);
+    return m_pictures.size() >= (size_t)(sps->max_dec_pic_buffering_minus1[highestTid] + 1);
 }
 
 //C.5.2.2
@@ -509,7 +509,7 @@ Decode_Status VaapiDecoderH265::decodeCurrent()
 #define FILL_SCALING_LIST(mxm) \
 void fillScalingList##mxm(VAIQMatrixBufferHEVC* iqMatrix, const H265ScalingList* const scalingList) \
 { \
-    for (int i = 0; i < N_ELEMENTS(iqMatrix->ScalingList##mxm); i++) { \
+    for (size_t i = 0; i < N_ELEMENTS(iqMatrix->ScalingList##mxm); i++) { \
         h265_quant_matrix_##mxm##_get_raster_from_uprightdiagonal(iqMatrix->ScalingList##mxm[i], \
             scalingList->scaling_lists_##mxm[i]); \
     } \
@@ -523,7 +523,7 @@ FILL_SCALING_LIST(32x32)
 #define FILL_SCALING_LIST_DC(mxm) \
 void fillScalingListDc##mxm(VAIQMatrixBufferHEVC* iqMatrix, const H265ScalingList* const scalingList) \
 { \
-    for (int i = 0; i < N_ELEMENTS(iqMatrix->ScalingListDC##mxm); i++) { \
+    for (size_t i = 0; i < N_ELEMENTS(iqMatrix->ScalingListDC##mxm); i++) { \
         iqMatrix->ScalingListDC##mxm[i] = \
             scalingList->scaling_list_dc_coef_minus8_##mxm[i] + 8; \
     } \
@@ -565,7 +565,7 @@ void VaapiDecoderH265::fillReference(VAPictureHEVC* refs, int32_t& n,
     const RefSet& refset, uint32_t flags)
 {
   //ERROR("fill ref(%x):", flags);
-    for (int32_t i = 0; i < refset.size(); i++) {
+    for (size_t i = 0; i < refset.size(); i++) {
         VAPictureHEVC* r = refs + n;
         const VaapiDecPictureH265* pic = refset[i];
 

--- a/decoder/vaapidecoder_vp9.cpp
+++ b/decoder/vaapidecoder_vp9.cpp
@@ -152,7 +152,7 @@ bool VaapiDecoderVP9::fillReference(VADecPictureParameterBufferVP9* param, const
         FILL_REFERENCE(golden_ref_frame, VP9_GOLDEN_FRAME);
         FILL_REFERENCE(alt_ref_frame, VP9_ALTREF_FRAME);
     }
-    for (int i = 0; i < m_reference.size(); i++) {
+    for (size_t i = 0; i < m_reference.size(); i++) {
         SurfacePtr& surface = m_reference[i];
         param->reference_frames[i] = surface.get() ? surface->getID():VA_INVALID_SURFACE;
     }
@@ -293,7 +293,7 @@ Decode_Status VaapiDecoderVP9::decode(const Vp9FrameHdr* hdr, const uint8_t* dat
     return DECODE_SUCCESS;
 }
 
-static bool parse_super_frame(std::vector<uint32_t>& frameSize, const uint8_t* data, const int32_t size)
+static bool parse_super_frame(std::vector<uint32_t>& frameSize, const uint8_t* data, const size_t size)
 {
     if (!data || !size)
         return false;
@@ -312,9 +312,9 @@ static bool parse_super_frame(std::vector<uint32_t>& frameSize, const uint8_t* d
     const uint8_t marker2 = *data++;
     if (marker != marker2)
         return false;
-    for (int i = 0; i < frames; i++) {
+    for (uint32_t i = 0; i < frames; i++) {
         uint32_t sz = 0;
-        for (int j = 0; j < mag; j++) {
+        for (uint32_t j = 0; j < mag; j++) {
             sz |= (*data++) << (j * 8);
         }
         frameSize.push_back(sz);
@@ -328,12 +328,12 @@ Decode_Status VaapiDecoderVP9::decode(VideoDecodeBuffer * buffer)
     if (!buffer)
         return DECODE_INVALID_DATA;
     uint8_t* data = buffer->data;
-    int32_t  size = buffer->size;
+    size_t  size = buffer->size;
     uint8_t* end = data + size;
     std::vector<uint32_t> frameSize;
     if (!parse_super_frame(frameSize, data, size))
         return DECODE_INVALID_DATA;
-    for (int i = 0; i < frameSize.size(); i++) {
+    for (size_t i = 0; i < frameSize.size(); i++) {
         uint32_t sz = frameSize[i];
         if (data + sz > end)
             return DECODE_INVALID_DATA;

--- a/decoder/vaapidecsurfacepool.cpp
+++ b/decoder/vaapidecsurfacepool.cpp
@@ -281,7 +281,7 @@ bool VaapiDecSurfacePool::getOutput(VideoFrameRawData* frame)
 
 bool VaapiDecSurfacePool::populateOutputHandles(VideoFrameRawData *frames, uint32_t &frameCount)
 {
-    int i;
+    uint32_t i;
     if (!frameCount) { // output frame count negotiation
         ASSERT(frames);
         if (frames[0].fourcc && frames[0].fourcc != VA_FOURCC_NV12)

--- a/egl/egl_vaapi_image.cpp
+++ b/egl/egl_vaapi_image.cpp
@@ -123,7 +123,7 @@ bool getVaFormat(VADisplay display, VAImageFormat& format)
         return false;
     }
     vaFormats.resize(num);
-    for (int i = 0; i < vaFormats.size(); i++)
+    for (size_t i = 0; i < vaFormats.size(); i++)
     {
         const VAImageFormat& fmt = vaFormats[i];
         if (fmt.fourcc == VA_FOURCC_BGRX) {

--- a/encoder/vaapiencoder_base.cpp
+++ b/encoder/vaapiencoder_base.cpp
@@ -410,7 +410,7 @@ const ProfileMapItem g_profileMap[] =
 
 VaapiProfile VaapiEncoderBase::profile() const
 {
-    for (int i = 0; i < N_ELEMENTS(g_profileMap); i++) {
+    for (size_t i = 0; i < N_ELEMENTS(g_profileMap); i++) {
         if (m_videoParamCommon.profile == g_profileMap[i].vaProfile)
             return g_profileMap[i].vaapiProfile;
     }

--- a/encoder/vaapiencoder_h264.cpp
+++ b/encoder/vaapiencoder_h264.cpp
@@ -563,7 +563,7 @@ private:
         headers.push_back(&m_sps);
         headers.push_back(&m_pps);
         uint8_t sync[] = {0, 0, 0, 1};
-        for (int i = 0; i < headers.size(); i++) {
+        for (size_t i = 0; i < headers.size(); i++) {
             m_headers.insert(m_headers.end(), sync, sync + N_ELEMENTS(sync));
             appendHeaderWithEmulation(*headers[i]);
         }
@@ -672,7 +672,7 @@ private:
         outBuffer->dataSize = 0;
 
         Encode_Status ret;
-        for (int i = 0; i < functions.size(); i++) {
+        for (size_t i = 0; i < functions.size(); i++) {
             ret = functions[i]();
             if (ret != ENCODE_SUCCESS)
                 return ret;
@@ -1278,7 +1278,7 @@ bool VaapiEncoderH264::addSliceHeaders (const PicturePtr& picture) const
     sliceOfMbs = mbSize / m_numSlices;
     sliceModMbs = mbSize % m_numSlices;
     lastMbIndex = 0;
-    for (int i = 0; i < m_numSlices; ++i) {
+    for (uint32_t i = 0; i < m_numSlices; ++i) {
         curSliceMbs = sliceOfMbs;
         if (sliceModMbs) {
             ++curSliceMbs;

--- a/encoder/vaapiencoder_hevc.cpp
+++ b/encoder/vaapiencoder_hevc.cpp
@@ -128,7 +128,8 @@ static uint32_t log2 (uint32_t num)
     uint32_t ret = 0;
     assert(num);
 
-    while (num > (1 << ret))
+    uint32_t one = 1;
+    while (num > (one << ret))
         ++ret;
 
     return ret;
@@ -349,7 +350,7 @@ public:
         headers.push_back(&m_sps);
         headers.push_back(&m_pps);
         uint8_t sync[] = {0, 0, 0, 1};
-        for (int i = 0; i < headers.size(); i++) {
+        for (size_t i = 0; i < headers.size(); i++) {
             m_headers.insert(m_headers.end(), sync, sync + N_ELEMENTS(sync));
             appendHeaderWithEmulation(*headers[i]);
         }
@@ -832,7 +833,7 @@ private:
         outBuffer->dataSize = 0;
 
         Encode_Status ret;
-        for (int i = 0; i < functions.size(); i++) {
+        for (size_t i = 0; i < functions.size(); i++) {
             ret = functions[i]();
             if (ret != ENCODE_SUCCESS)
                 return ret;
@@ -1268,6 +1269,7 @@ void VaapiEncoderHEVC::shortRfsUpdate(const PicturePtr& picture)
             m_shortRFS.num_positive_pics      = 1;
             m_shortRFS.delta_poc_s1_minus1[0]  = m_refList1[0]->m_poc - picture->m_poc - 1;
             m_shortRFS.used_by_curr_pic_s1_flag[0]            = 1;
+			
             DEBUG("m_refList1_size is %zu\n", m_refList1.size());
         }
     }
@@ -1602,7 +1604,7 @@ bool VaapiEncoderHEVC::addSliceHeaders (const PicturePtr& picture) const
     sliceOfCtus = numCtus / m_numSlices;
     sliceModCtus = numCtus % m_numSlices;
     lastCtuIndex = 0;
-    for (int i = 0; i < m_numSlices; ++i) {
+    for (uint32_t i = 0; i < m_numSlices; ++i) {
         curSliceCtus = sliceOfCtus;
         if (sliceModCtus) {
             ++curSliceCtus;

--- a/encoder/vaapiencoder_vp8.cpp
+++ b/encoder/vaapiencoder_vp8.cpp
@@ -208,7 +208,7 @@ bool VaapiEncoderVP8::fill(VAEncPictureParameterBufferVP8* picParam, const Pictu
 
 bool VaapiEncoderVP8::fill(VAQMatrixBufferVP8* qMatrix) const
 {
-    int i;
+    size_t i;
 
     for (i = 0; i < N_ELEMENTS(qMatrix->quantization_index); i++) {
         qMatrix->quantization_index[i] = m_qIndex;

--- a/examples/grid.cpp
+++ b/examples/grid.cpp
@@ -187,7 +187,7 @@ DrmFrame::~DrmFrame()
     if (id != VA_INVALID_ID) {
         checkVaapiStatus(vaDestroySurfaces(m_display, &id, 1), "vaDestroySurfaces");
     }
-    if (m_handle != -1) {
+    if (m_handle != (uint32_t)-1) {
         ret = drmModeRmFB(m_fd, m_handle);
         checkDrmRet(ret, "drmModeRmFB");
     }
@@ -305,7 +305,7 @@ DrmRenderer::Flipper::~Flipper()
         m_quit = true;
         m_cond.signal();
     }
-    if (m_thread != -1)
+    if (m_thread != (uint32_t)-1)
         pthread_join(m_thread, NULL);
 }
 
@@ -594,7 +594,7 @@ class Grid
         }
         ~Arg()
         {
-            for (int i = 0; i < m_argv.size(); i++)
+            for (size_t i = 0; i < m_argv.size(); i++)
                 free(m_argv[i]);
         }
         void init (const string& args)
@@ -646,7 +646,7 @@ public:
 
     ~Grid()
     {
-        if (m_vppThread != -1)
+        if (m_vppThread != (unsigned long)-1)
             pthread_join(m_vppThread, NULL);
         m_renderer.reset();
         m_vpp.reset();
@@ -814,7 +814,7 @@ public:
             fprintf(stderr, "init display failed");
             return false;
         }
-        for (int i = 0; i < m_args.size(); i++) {
+        for (size_t i = 0; i < m_args.size(); i++) {
             string& arg = m_args[i];
             SharedPtr<Grid> grid(new Grid(m_fd, m_nativeDisplay));
             if (!grid->init(arg)) {
@@ -826,10 +826,10 @@ public:
     }
     bool run()
     {
-        for (int i = 0; i < m_grids.size(); i++) {
+        for (size_t i = 0; i < m_grids.size(); i++) {
             SharedPtr<Grid>& grid = m_grids[i];
             if (!grid->run()) {
-                ERROR("run grid %d failed", i);
+                ERROR("run grid %lu failed", i);
                 return false;
             }
         }

--- a/interface/VideoDecoderDefs.h
+++ b/interface/VideoDecoderDefs.h
@@ -103,7 +103,7 @@ typedef enum {
 
 typedef struct {
     uint8_t *data;
-    int32_t size;
+    size_t size;
     int64_t timeStamp;
     uint32_t flag;
     VideoExtensionBuffer *ext;
@@ -116,8 +116,8 @@ typedef struct {
     uint8_t *data;
     int32_t size;
     /// it is the actual frame size, height is 1080 for h264 1080p stream
-    int32_t width;
-    int32_t height;
+    uint32_t width;
+    uint32_t height;
     /// surfaceWidth and surfaceHeight are the resolution to config output buffer (dirver surface size or client buffer like in sw decode mode)
     /// take h264 1080p as example, it is enlarged to 1088
     int32_t surfaceWidth;
@@ -157,8 +157,8 @@ typedef struct SurfaceBuffer{
 typedef struct {
     bool valid;                 // indicates whether format info is valid. MimeType is always valid.
     char *mimeType;
-    int32_t width;
-    int32_t height;
+    uint32_t width;
+    uint32_t height;
     int32_t surfaceWidth;
     int32_t surfaceHeight;
     int32_t surfaceNumber;

--- a/interface/VideoEncoderDefs.h
+++ b/interface/VideoEncoderDefs.h
@@ -347,7 +347,7 @@ typedef struct VideoParamsCommon {
     AirParams airParams;
     uint32_t disableDeblocking;
     bool syncEncMode;
-    int32_t leastInputCount;
+    uint32_t leastInputCount;
 }VideoParamsCommon;
 
 typedef struct VideoParamsAVC {

--- a/tests/decode.cpp
+++ b/tests/decode.cpp
@@ -51,7 +51,7 @@ int main(int argc, char** argv)
     const VideoFormatInfo *formatInfo = NULL;
     Decode_Status status;
     class CalcFps calcFpsGross, calcFpsNet;
-    int skipFrameCount4NetFps = 0;
+    uint32_t skipFrameCount4NetFps = 0;
 #ifdef __ENABLE_X11__
     // XInitThreads();
 #endif

--- a/tests/decodeinput.cpp
+++ b/tests/decodeinput.cpp
@@ -37,8 +37,8 @@ using namespace YamiMediaCodec;
 
 class MyDecodeInput : public DecodeInput{
 public:
-    static const int MaxNaluSize = 1024*1024*4; // assume max nalu size is 4M
-    static const int CacheBufferSize = 8 * MaxNaluSize;
+    static const size_t MaxNaluSize = 1024*1024*4; // assume max nalu size is 4M
+    static const size_t CacheBufferSize = 8 * MaxNaluSize;
     MyDecodeInput();
     virtual ~MyDecodeInput();
     bool initInput(const char* fileName);
@@ -63,8 +63,8 @@ public:
     bool init();
     virtual bool getNextDecodeUnit(VideoDecodeBuffer &inputBuffer);
 private:
-    const int m_ivfFrmHdrSize;
-    const int m_maxFrameSize;
+    const size_t m_ivfFrmHdrSize;
+    const size_t m_maxFrameSize;
     const char* m_mimeType;
 };
 
@@ -248,10 +248,10 @@ bool DecodeInputVPX::init()
 bool DecodeInputVPX::getNextDecodeUnit(VideoDecodeBuffer &inputBuffer)
 {
     if(m_ivfFrmHdrSize == fread (m_buffer, 1, m_ivfFrmHdrSize, m_fp)) {
-        int framesize = 0;
+        size_t framesize = 0;
         framesize = (uint32_t)(m_buffer[0]) + ((uint32_t)(m_buffer[1])<<8) + ((uint32_t)(m_buffer[2])<<16);
-        assert (framesize < (uint32_t) m_maxFrameSize);
-        assert (framesize <= (uint32_t) CacheBufferSize);
+        assert (framesize < m_maxFrameSize);
+        assert (framesize <= CacheBufferSize);
 
         if (framesize != fread (m_buffer, 1, framesize, m_fp)) {
             fprintf (stderr, "fail to read frame data, quit\n");
@@ -292,7 +292,7 @@ bool DecodeInputRaw::init()
 
 bool DecodeInputRaw::ensureBufferData()
 {
-    int readCount = 0;
+    size_t readCount = 0;
 
     if (m_readToEOS)
         return true;
@@ -359,7 +359,7 @@ bool DecodeInputRaw::getNextDecodeUnit(VideoDecodeBuffer &inputBuffer)
     if (!m_parseToEOS)
        inputBuffer.size += StartCodeSize; // one inputBuffer is start and end with start code
 
-    DEBUG("offset=%d, NALU data=%p, size=%d\n", offset, inputBuffer.data, inputBuffer.size);
+    DEBUG("offset=%d, NALU data=%p, size=%lu\n", offset, inputBuffer.data, inputBuffer.size);
     m_lastReadOffset += offset + StartCodeSize;
     return true;
 }

--- a/tests/decodeinputavformat.cpp
+++ b/tests/decodeinputavformat.cpp
@@ -42,7 +42,7 @@ bool DecodeInputAvFormat::initInput(const char* fileName)
     int ret = avformat_open_input(&m_format, fileName, NULL, NULL);
     if (ret)
         goto error;
-    int i;
+    uint32_t i;
     for (i = 0; i < m_format->nb_streams; ++i) {
         AVCodecContext* ctx = m_format->streams[i]->codec;
         //VP9: width and height of the IVF header,VP8: width and height is zero
@@ -105,7 +105,7 @@ static const MimeEntry MimeEntrys[] = {
 
 const char * DecodeInputAvFormat::getMimeType()
 {
-    for (int i = 0; i < N_ELEMENTS(MimeEntrys); i++) {
+    for (size_t i = 0; i < N_ELEMENTS(MimeEntrys); i++) {
         if (MimeEntrys[i].id == m_codecId)
             return MimeEntrys[i].mime;
     }

--- a/tests/decodeoutput.cpp
+++ b/tests/decodeoutput.cpp
@@ -124,7 +124,7 @@ private:
         uint32_t height, uint32_t pitch)
     {
         data += offset;
-        for (int h = 0; h < height; h++) {
+        for (uint32_t h = 0; h < height; h++) {
             v.insert(v.end(), data, data + width);
             data += pitch;
         }
@@ -134,7 +134,7 @@ private:
         uint32_t height, uint32_t pitch)
     {
         data += offset;
-        for (int h = 0; h < height; h++) {
+        for (uint32_t h = 0; h < height; h++) {
             uint8_t* start = data;
             uint8_t* end = data + width;
             while (start < end) {
@@ -247,10 +247,10 @@ bool DecodeOutputFileDump::render(VideoFrameRawData* frame)
     //ASSERT(m_width == frame->width && m_height == frame->height);
     if (!getPlaneResolution(frame->fourcc, frame->width, frame->height, width, height, planes))
         return false;
-    for (int i = 0; i < planes; i++) {
+    for (uint32_t i = 0; i < planes; i++) {
         uint8_t* data = reinterpret_cast<uint8_t*>(frame->handle);
         data += frame->offset[i];
-        for (int h = 0; h < height[i]; h++) {
+        for (uint32_t h = 0; h < height[i]; h++) {
             fwrite(data, 1, width[i], m_fp);
             data += frame->pitch[i];
         }

--- a/tests/decodeoutput.h
+++ b/tests/decodeoutput.h
@@ -52,8 +52,8 @@ public:
 protected:
     DecodeOutput(IVideoDecoder* decoder);
     IVideoDecoder* m_decoder;
-    int m_width;
-    int m_height;
+    uint32_t m_width;
+    uint32_t m_height;
     uint32_t m_renderFrames;
     VideoFrameRawData m_frame;
 };

--- a/tests/encodeInputCamera.cpp
+++ b/tests/encodeInputCamera.cpp
@@ -116,7 +116,7 @@ bool EncodeInputCamera::initDevice(const char *cameraDevicePath)
 bool EncodeInputCamera::initMmap(void)
 {
     struct v4l2_requestbuffers rqbufs;
-    int index;
+    uint32_t index;
 
     INFO();
     memset(&rqbufs, 0, sizeof(rqbufs));
@@ -274,7 +274,7 @@ int32_t EncodeInputCamera::dequeFrame(void)
 
 bool EncodeInputCamera::enqueFrame(int32_t index)
 {
-    assert(index >=0 && index < m_frameBufferCount);
+    assert(index >=0 && (uint32_t)index < m_frameBufferCount);
     struct v4l2_buffer buf;
     memset(&buf, 0, sizeof(buf));
 
@@ -298,7 +298,7 @@ bool EncodeInputCamera::enqueFrame(int32_t index)
 bool EncodeInputCamera::getOneFrameInput(VideoFrameRawData &inputBuffer)
 {
     int frameIndex = dequeFrame();
-    ASSERT(frameIndex>=0 && frameIndex<m_frameBufferCount);
+    ASSERT((frameIndex >= 0) && ((uint32_t)frameIndex < m_frameBufferCount));
 
     memset(&inputBuffer, 0, sizeof(inputBuffer));
     bool ret = fillFrameRawData(&inputBuffer, m_fourcc, m_width, m_height, m_frameBuffers[frameIndex]);

--- a/tests/encodeinput.cpp
+++ b/tests/encodeinput.cpp
@@ -128,7 +128,7 @@ bool EncodeInputFile::getOneFrameInput(VideoFrameRawData &inputBuffer)
     if (inputBuffer.handle)
         buffer = reinterpret_cast<uint8_t*>(inputBuffer.handle);
 
-    int ret = fread(buffer, sizeof(uint8_t), m_frameSize, m_fp);
+    size_t ret = fread(buffer, sizeof(uint8_t), m_frameSize, m_fp);
 
     if (ret <= 0) {
         m_readToEOS = true;
@@ -214,7 +214,7 @@ bool EncodeOutput::init(const char* outputFileName, int width , int height)
 
 bool EncodeOutput::write(void* data, int size)
 {
-    return fwrite(data, 1, size, m_fp) == size;
+    return fwrite(data, 1, size, m_fp) == (size_t)size;
 }
 
 const char* EncodeOutputH264::getMimeType()

--- a/tests/encodeinput.h
+++ b/tests/encodeinput.h
@@ -50,9 +50,9 @@ public:
 
 protected:
     uint32_t m_fourcc;
-    int m_width;
-    int m_height;
-    int m_frameSize;
+    uint32_t m_width;
+    uint32_t m_height;
+    size_t m_frameSize;
 };
 
 class EncodeInputFile : public EncodeInput {

--- a/tests/v4l2decode.cpp
+++ b/tests/v4l2decode.cpp
@@ -266,7 +266,7 @@ bool feedOneInputFrame(DecodeInput * input, int fd, int index = -1 /* if index i
 
 bool dumpOneVideoFrame(int32_t index)
 {
-    int row;
+    uint32_t row;
 
     if (!outfp) {
         char outFileName[256];
@@ -332,10 +332,10 @@ static bool displayOneVideoFrameAndroid(int32_t fd, int32_t index)
     return true;
 }
 #elif __ENABLE_V4L2_GLX__
-static bool displayOneVideoFrameGLX(int32_t fd, int32_t index)
+static bool displayOneVideoFrameGLX(int32_t fd, uint32_t index)
 {
     ASSERT(glxContext && textureIds.size());
-    ASSERT(index>=0 && index<textureIds.size());
+    ASSERT(index<textureIds.size());
     DEBUG("textureIds[%d] = 0x%x", index, textureIds[index]);
 
     int ret = drawTexture(glxContext, textureIds[index]);
@@ -440,7 +440,7 @@ int main(int argc, char** argv)
 {
     DecodeInput *input;
     int32_t fd = -1;
-    int32_t i = 0;
+    uint32_t i = 0;
     int32_t ioctlRet = -1;
     YamiMediaCodec::CalcFps calcFps;
 
@@ -805,7 +805,7 @@ int main(int argc, char** argv)
     ASSERT(ioctlRet != -1);
 
     bool event_pending=true; // try to get video resolution.
-    int dqCountAfterEOS = 0;
+    uint32_t dqCountAfterEOS = 0;
     do {
         if (event_pending) {
             handleResolutionChange(fd);

--- a/tests/v4l2encode.cpp
+++ b/tests/v4l2encode.cpp
@@ -51,7 +51,7 @@ bool isOutputEOS = false;
 
 static EncodeInput* streamInput;
 
-bool readOneFrameData(int index)
+bool readOneFrameData(uint32_t index)
 {
     static int encodeFrameCount = 0;
 
@@ -60,7 +60,7 @@ bool readOneFrameData(int index)
     if (isReadEOS)
         return false;
 
-    ASSERT(index>=0 && index<inputQueueCapacity);
+    ASSERT(index<inputQueueCapacity);
 
     bool ret = streamInput->getOneFrameInput(inputFrames[index]);
     if (!ret || (frameCount && encodeFrameCount++>=frameCount)) {
@@ -81,7 +81,7 @@ void fillV4L2Buffer(struct v4l2_buffer& buf, const VideoFrameRawData& frame)
     ret = getPlaneResolution(frame.fourcc, frame.width, frame.height, width, height,  planes);
     ASSERT(ret && "get planes resolution failed");
     unsigned long data = (unsigned long)frame.handle;
-    for (int i = 0; i < planes; i++) {
+    for (uint32_t i = 0; i < planes; i++) {
         buf.m.planes[i].bytesused = width[i] * height[i];
         buf.m.planes[i].m.userptr = data + frame.offset[i];
     }
@@ -92,7 +92,7 @@ bool feedOneInputFrame(int fd, int index = -1 /* if index is not -1, simple enqu
     struct v4l2_buffer buf;
     struct v4l2_plane planes[VIDEO_MAX_PLANES];
     int ioctlRet = -1;
-    static int32_t dqCountAfterEOS = 0;
+    static uint32_t dqCountAfterEOS = 0;
 
     memset(&buf, 0, sizeof(buf));
     memset(&planes, 0, sizeof(planes));
@@ -203,7 +203,7 @@ bool takeOneOutputFrame(int fd, int index = -1/* if index is not -1, simple enqu
 int main(int argc, char** argv)
 {
     int32_t fd = -1;
-    int32_t i = 0;
+    uint32_t i = 0;
     int32_t ioctlRet = -1;
 
     yamiTraceInit();

--- a/tests/vppinputoutput.h
+++ b/tests/vppinputoutput.h
@@ -83,7 +83,7 @@ public:
 class PooledFrameAllocator : public FrameAllocator
 {
 public:
-    PooledFrameAllocator(const SharedPtr<VADisplay>& display, int poolsize):
+    PooledFrameAllocator(const SharedPtr<VADisplay>& display, size_t poolsize):
         m_display(display), m_poolsize(poolsize)
     {
     }
@@ -111,7 +111,7 @@ public:
             return false;
         }
         std::deque<SharedPtr<VideoFrame> > buffers;
-        for (int i = 0;  i < m_surfaces.size(); i++) {
+        for (size_t i = 0;  i < m_surfaces.size(); i++) {
             SharedPtr<VideoFrame> f(new VideoFrame);
             memset(f.get(), 0, sizeof(VideoFrame));
             //we need fill dest crop to work around libva's bug.
@@ -137,7 +137,7 @@ private:
     SharedPtr<VADisplay> m_display;
     std::vector<VASurfaceID> m_surfaces;
     SharedPtr<VideoPool<VideoFrame> > m_pool;
-    int m_poolsize;
+    size_t m_poolsize;
 };
 
 class VaapiFrameIO
@@ -176,10 +176,10 @@ public:
             return false;
         }
         bool ret = true;
-        for (int i = 0; i < planes; i++) {
+        for (uint32_t i = 0; i < planes; i++) {
             char* ptr = buf + image.offsets[i];
             int w = byteWidth[i];
-            for (int j = 0; j < byteHeight[i]; j++) {
+            for (uint32_t j = 0; j < byteHeight[i]; j++) {
                 ret = m_io(ptr, w, fp);
                 if (!ret)
                     goto out;
@@ -213,7 +213,7 @@ private:
     SharedPtr<VaapiFrameIO> m_frameio;
     static bool readFromFile(char* ptr, int size, FILE* fp)
     {
-        return fread(ptr, 1, size, fp) == size;
+        return fread(ptr, 1, size, fp) == (size_t)size;
     }
 };
 
@@ -232,7 +232,7 @@ private:
     SharedPtr<VaapiFrameIO> m_frameio;
     static bool writeToFile(char* ptr, int size, FILE* fp)
     {
-        return fwrite(ptr, 1, size, fp) == size;
+        return fwrite(ptr, 1, size, fp) == (size_t)size;
     }
 };
 //vaapi related operation end

--- a/tests/yamitranscode.cpp
+++ b/tests/yamitranscode.cpp
@@ -257,7 +257,7 @@ public:
 
         SharedPtr<VideoFrame> src;
         FpsCalc fps;
-        int count = 0;
+        uint32_t count = 0;
         while (m_input->read(src)) {
             SharedPtr<VideoFrame> dest = m_allocator->alloc();
             if (!dest) {

--- a/v4l2/v4l2_codecbase.cpp
+++ b/v4l2/v4l2_codecbase.cpp
@@ -144,7 +144,7 @@ bool V4l2CodecBase::close()
         timeOut--;
     }
 
-    for (int i=0; i<m_maxBufferCount[OUTPUT]; i++)
+    for (uint32_t i=0; i<m_maxBufferCount[OUTPUT]; i++)
         recycleOutputBuffer(i);
 
     ASSERT(!m_threadOn[INPUT]);
@@ -187,7 +187,7 @@ void V4l2CodecBase::workerThread()
             }
         }
 
-        int index = m_framesTodo[thread].front();
+        uint32_t index = (uint32_t)(m_framesTodo[thread].front());
 
         // for decode, outputPulse may update index
         ret = thread == INPUT ? inputPulse(index) : outputPulse(index);
@@ -257,7 +257,7 @@ static void* _workerThread(void *arg)
 }
 
 #if __ENABLE_DEBUG__
-const char* V4l2CodecBase::IoctlCommandString(int command)
+const char* V4l2CodecBase::IoctlCommandString(long unsigned int command)
 {
     static const char* unknown = "Unkonwn command";
 #define IOCTL_COMMAND_STRING_MAP(cmd)   {cmd, #cmd}
@@ -282,7 +282,7 @@ const char* V4l2CodecBase::IoctlCommandString(int command)
             IOCTL_COMMAND_STRING_MAP(VIDIOC_G_CTRL)
         };
 
-    int i;
+    size_t i;
     for (i=0; i<sizeof(ioctlCommandMap)/sizeof(IoctlCommanMap); i++)
         if (ioctlCommandMap[i].command == command)
             return ioctlCommandMap[i].cmdStr;
@@ -579,7 +579,7 @@ static const FormatEntry FormatEntrys[] = {
 uint32_t v4l2PixelFormatFromMime(const char* mime)
 {
     uint32_t format = 0;
-    for (int i = 0; i < N_ELEMENTS(FormatEntrys); i++) {
+    for (uint32_t i = 0; i < N_ELEMENTS(FormatEntrys); i++) {
         const FormatEntry* entry = FormatEntrys + i;
         if (strcmp(mime, entry->mime) == 0) {
             format = entry->format;
@@ -592,7 +592,7 @@ uint32_t v4l2PixelFormatFromMime(const char* mime)
 const char* mimeFromV4l2PixelFormat(uint32_t pixelFormat)
 {
     const char* mime = NULL;
-    for (int i = 0; i < N_ELEMENTS(FormatEntrys); i++) {
+    for (size_t i = 0; i < N_ELEMENTS(FormatEntrys); i++) {
         const FormatEntry* entry = FormatEntrys + i;
         if (entry->format == pixelFormat) {
             mime = entry->mime;

--- a/v4l2/v4l2_codecbase.h
+++ b/v4l2/v4l2_codecbase.h
@@ -72,7 +72,7 @@ class V4l2CodecBase {
     inline bool createVpp();
 #elif __ENABLE_V4L2_GLX__
     bool setXDisplay(Display *x11Display) { m_x11Display = x11Display; return true; };
-    virtual int32_t usePixmap(int bufferIndex, Pixmap pixmap) {return 0;};
+    virtual int32_t usePixmap(uint32_t bufferIndex, Pixmap pixmap) {return 0;};
 #else
     virtual int32_t useEglImage(EGLDisplay eglDisplay, EGLContext eglContext, uint32_t buffer_index, void* egl_image) {return 0;};
     bool setDrmFd(int drm_fd) {m_drmfd = drm_fd; return true;};
@@ -85,8 +85,8 @@ class V4l2CodecBase {
     virtual bool start() = 0;
     virtual bool acceptInputBuffer(struct v4l2_buffer *qbuf) = 0;
     virtual bool giveOutputBuffer(struct v4l2_buffer *dqbuf) = 0;
-    virtual bool inputPulse(int32_t index) = 0;
-    virtual bool outputPulse(int32_t &index) = 0; // index of decode output is decided by libyami, not FIFO of m_framesTodo[OUTPUT]
+    virtual bool inputPulse(uint32_t index) = 0;
+    virtual bool outputPulse(uint32_t &index) = 0; // index of decode output is decided by libyami, not FIFO of m_framesTodo[OUTPUT]
     virtual bool recycleOutputBuffer(int32_t index) {return true;};
     virtual bool hasCodecEvent() {return m_hasEvent;}
     virtual void setCodecEvent();
@@ -95,7 +95,7 @@ class V4l2CodecBase {
     virtual void flush() {}
 
     VideoDataMemoryType m_memoryType;
-    int m_maxBufferCount[2];
+    uint32_t m_maxBufferCount[2];
     uint32_t m_bufferPlaneCount[2];
     uint32_t m_memoryMode[2];
     uint32_t m_pixelFormat[2]; // (it should be a set)
@@ -151,7 +151,7 @@ class V4l2CodecBase {
 
 #ifdef __ENABLE_DEBUG__
   protected:
-    const char* IoctlCommandString(int command);
+    const char* IoctlCommandString(long unsigned int command);
 
     uint32_t m_frameCount[2];
 #endif

--- a/v4l2/v4l2_decode.cpp
+++ b/v4l2/v4l2_decode.cpp
@@ -47,7 +47,7 @@ V4l2Decoder::V4l2Decoder()
     , m_reqBuffCnt(0)
 #endif
 {
-    int i;
+    uint32_t i;
     m_memoryMode[INPUT] = V4L2_MEMORY_MMAP; // dma_buf hasn't been supported yet
     m_pixelFormat[INPUT] = V4L2_PIX_FMT_H264;
     m_bufferPlaneCount[INPUT] = 1; // decided by m_pixelFormat[INPUT]
@@ -143,7 +143,7 @@ bool V4l2Decoder::stop()
     return true;
 }
 
-bool V4l2Decoder::inputPulse(int32_t index)
+bool V4l2Decoder::inputPulse(uint32_t index)
 {
     Decode_Status status = DECODE_SUCCESS;
 
@@ -171,7 +171,7 @@ bool V4l2Decoder::inputPulse(int32_t index)
 }
 
 #if ANDROID
-bool V4l2Decoder::outputPulse(int32_t &index)
+bool V4l2Decoder::outputPulse(uint32_t &index)
 {
     SharedPtr<VideoFrame> output = m_decoder->getOutput();
 
@@ -188,7 +188,7 @@ bool V4l2Decoder::outputPulse(int32_t &index)
     return true;
 }
 #else
-bool V4l2Decoder::outputPulse(int32_t &index)
+bool V4l2Decoder::outputPulse(uint32_t &index)
 {
     Decode_Status status = DECODE_SUCCESS;
 
@@ -339,7 +339,7 @@ int32_t V4l2Decoder::ioctl(int command, void* arg)
                 const VideoFormatInfo* outFormat = m_decoder->getFormatInfo();
                 ASSERT(outFormat && outFormat->width && outFormat->height);
                 ASSERT(m_eglVaapiImages.empty());
-                for (int i = 0; i < reqbufs->count; i++) {
+                for (uint32_t i = 0; i < reqbufs->count; i++) {
                     SharedPtr<EglVaapiImage> image(
                                                    new EglVaapiImage(m_decoder->getDisplayID(), outFormat->width, outFormat->height));
                     if (!image->init()) {
@@ -529,7 +529,7 @@ int32_t V4l2Decoder::ioctl(int command, void* arg)
 void* V4l2Decoder::mmap (void* addr, size_t length,
                       int prot, int flags, unsigned int offset)
 {
-    int i;
+    uint32_t i;
     ASSERT((prot == PROT_READ) | PROT_WRITE);
     ASSERT(flags == MAP_SHARED);
 
@@ -642,14 +642,14 @@ bool V4l2Decoder::mapVideoFrames()
     return true;
 }
 #elif __ENABLE_V4L2_GLX__
-int32_t V4l2Decoder::usePixmap(int bufferIndex, Pixmap pixmap)
+int32_t V4l2Decoder::usePixmap(uint32_t bufferIndex, Pixmap pixmap)
 {
     if (m_pixmaps.empty()) {
         m_pixmaps.resize(m_maxBufferCount[OUTPUT]);
         memset(&m_pixmaps[0], 0, sizeof(Pixmap)*m_pixmaps.size());
     }
 
-    ASSERT(bufferIndex>=-1 && bufferIndex<m_maxBufferCount[OUTPUT]);
+    ASSERT(bufferIndex<m_maxBufferCount[OUTPUT]);
     m_pixmaps[bufferIndex] = pixmap;
 
     return 0;

--- a/v4l2/v4l2_decode.h
+++ b/v4l2/v4l2_decode.h
@@ -50,7 +50,7 @@ class V4l2Decoder : public V4l2CodecBase
     SharedPtr<VideoFrame> createVaSurface(const ANativeWindowBuffer* buf);
     bool mapVideoFrames();
 #elif __ENABLE_V4L2_GLX__
-    virtual int32_t usePixmap(int buffer_index, Pixmap pixmap);
+    virtual int32_t usePixmap(uint32_t buffer_index, Pixmap pixmap);
 #else
     virtual int32_t useEglImage(EGLDisplay eglDisplay, EGLContext eglContext, uint32_t buffer_index, void* egl_image);
 #endif
@@ -60,8 +60,8 @@ class V4l2Decoder : public V4l2CodecBase
     virtual bool stop();
     virtual bool acceptInputBuffer(struct v4l2_buffer *qbuf);
     virtual bool giveOutputBuffer(struct v4l2_buffer *dqbuf);
-    virtual bool inputPulse(int32_t index);
-    virtual bool outputPulse(int32_t &index);
+    virtual bool inputPulse(uint32_t index);
+    virtual bool outputPulse(uint32_t &index);
     virtual bool recycleOutputBuffer(int32_t index);
     virtual void releaseCodecLock(bool lockable);
     virtual void flush();

--- a/v4l2/v4l2_encode.cpp
+++ b/v4l2/v4l2_encode.cpp
@@ -105,7 +105,7 @@ bool V4l2Encoder::UpdateVideoParameters(bool isInputThread)
 
     return status == ENCODE_SUCCESS;
 }
-bool V4l2Encoder::inputPulse(int32_t index)
+bool V4l2Encoder::inputPulse(uint32_t index)
 {
     Encode_Status status = ENCODE_SUCCESS;
 
@@ -121,7 +121,7 @@ bool V4l2Encoder::inputPulse(int32_t index)
     return true;
 }
 
-bool V4l2Encoder::outputPulse(int32_t &index)
+bool V4l2Encoder::outputPulse(uint32_t &index)
 {
     Encode_Status status = ENCODE_SUCCESS;
 
@@ -153,7 +153,7 @@ bool V4l2Encoder::outputPulse(int32_t &index)
 
 bool V4l2Encoder::acceptInputBuffer(struct v4l2_buffer *qbuf)
 {
-    int i;
+    uint32_t i;
     VideoEncRawBuffer *inputBuffer = &(m_inputFrames[qbuf->index]);
     // XXX todo: add multiple planes support for yami
     inputBuffer->data = reinterpret_cast<uint8_t*>(qbuf->m.planes[0].m.userptr);
@@ -226,7 +226,7 @@ int32_t V4l2Encoder::ioctl(int command, void* arg)
     }
     break;
     case VIDIOC_S_EXT_CTRLS: {
-        int i;
+        uint32_t i;
         struct v4l2_ext_controls *control = static_cast<struct v4l2_ext_controls *>(arg);
         DEBUG("V4L2_CTRL_CLASS_MPEG: %d, control->ctrl_class: %d", V4L2_CTRL_CLASS_MPEG, control->ctrl_class);
         if (control->ctrl_class == V4L2_CTRL_CLASS_MPEG) {
@@ -281,7 +281,7 @@ int32_t V4l2Encoder::ioctl(int command, void* arg)
             // ::RequestEncodingParametersChangeTask
             m_videoParams.frameRate.frameRateNum = parms->parm.output.timeperframe.numerator;
             m_videoParams.frameRate.frameRateDenom = parms->parm.output.timeperframe.denominator;
-            int framerate = m_videoParams.frameRate.frameRateNum/m_videoParams.frameRate.frameRateDenom;
+            uint32_t framerate = m_videoParams.frameRate.frameRateNum/m_videoParams.frameRate.frameRateDenom;
             if (framerate * 2 < m_videoParams.intraPeriod) {
                 m_videoParams.intraPeriod = framerate * 2;
             }
@@ -376,7 +376,7 @@ int32_t V4l2Encoder::ioctl(int command, void* arg)
 void* V4l2Encoder::mmap (void* addr, size_t length,
                       int prot, int flags, unsigned int offset)
 {
-    int i;
+    uint32_t i;
     ASSERT((prot == PROT_READ) | PROT_WRITE);
     ASSERT(flags == MAP_SHARED);
 

--- a/v4l2/v4l2_encode.h
+++ b/v4l2/v4l2_encode.h
@@ -45,8 +45,8 @@ class V4l2Encoder : public V4l2CodecBase
     virtual bool stop();
     virtual bool acceptInputBuffer(struct v4l2_buffer *qbuf);
     virtual bool giveOutputBuffer(struct v4l2_buffer *dqbuf);
-    virtual bool inputPulse(int32_t index);
-    virtual bool outputPulse(int32_t &index);
+    virtual bool inputPulse(uint32_t index);
+    virtual bool outputPulse(uint32_t &index);
 
   private:
     bool UpdateVideoParameters(bool isInputThread=false);

--- a/v4l2/v4l2_wrapper.cpp
+++ b/v4l2/v4l2_wrapper.cpp
@@ -168,7 +168,7 @@ int32_t YamiV4L2_SetXDisplay(int32_t fd, Display *x11Display)
      return ret;
 }
 
-int32_t YamiV4L2_UsePixmap(int fd, int bufferIndex, Pixmap pixmap)
+int32_t YamiV4L2_UsePixmap(int fd, uint32_t bufferIndex, Pixmap pixmap)
 {
     V4l2CodecPtr v4l2Codec = _findCodecFromFd(fd);
      bool ret = true;

--- a/v4l2/v4l2_wrapper.h
+++ b/v4l2/v4l2_wrapper.h
@@ -54,7 +54,7 @@ int32_t YamiV4L2_Munmap(void* addr, size_t length);
 /// it should be called before driver initialization (immediate after _Open()).
 int32_t YamiV4L2_SetXDisplay(int32_t fd, Display *x11Display);
 /// pixmap=0 means the previous set rendering target becomes invalid, stop rendering to it.
-int32_t YamiV4L2_UsePixmap(int fd, int bufferIndex, Pixmap pixmap);
+int32_t YamiV4L2_UsePixmap(int fd, uint32_t bufferIndex, Pixmap pixmap);
 /// terminate vaapi before XFreePixmap work around a strange X11 exception; otherwise there is "BadDrawable" exception though the Pixmap is valid.
 int32_t YamiV4L2_Stop(int32_t fd);
 #else

--- a/vaapi/vaapidisplay.cpp
+++ b/vaapi/vaapidisplay.cpp
@@ -213,7 +213,7 @@ const VAImageFormat *
 VaapiDisplay::getVaFormat(uint32_t fourcc)
 {
     AutoLock locker(m_lock);
-    int i;
+    size_t i;
 
     if (m_vaImageFormats.empty()) {
         VAStatus vaStatus;

--- a/vaapi/vaapiimage.cpp
+++ b/vaapi/vaapiimage.cpp
@@ -121,7 +121,7 @@ bool VaapiImageRaw::copyFrom(const uint8_t* src, uint32_t size)
     uint32_t off = 0;
     uint32_t planes;
     getPlaneResolution(width, height, planes);
-    for (int i = 0; i < planes; i++) {
+    for (uint32_t i = 0; i < planes; i++) {
         offset[i] = off;
         off += width[i] * height[i];
     }
@@ -146,7 +146,7 @@ bool VaapiImageRaw::copy(uint8_t* destBase,
               const uint32_t srcOffsets[3], const uint32_t srcPitches[3],
               const uint32_t width[3], const uint32_t height[3], uint32_t planes)
 {
-    for (int i = 0; i < planes; i++) {
+    for (uint32_t i = 0; i < planes; i++) {
         uint32_t w = width[i];
         uint32_t h = height[i];
         if (w > destPitches[i] || w > srcPitches[i]) {
@@ -158,7 +158,7 @@ bool VaapiImageRaw::copy(uint8_t* destBase,
         uint8_t* dest = destBase + destOffsets[i];
 
 
-        for (int j = 0; j < h; j++) {
+        for (uint32_t j = 0; j < h; j++) {
             memcpy(dest, src, w);
             src += srcPitches[i];
             dest += destPitches[i];

--- a/vaapi/vaapiimagepool.cpp
+++ b/vaapi/vaapiimagepool.cpp
@@ -32,7 +32,7 @@
 
 namespace YamiMediaCodec{
 
-ImagePoolPtr VaapiImagePool::create(const DisplayPtr& display, uint32_t format, int32_t width, int32_t height, int32_t count)
+ImagePoolPtr VaapiImagePool::create(const DisplayPtr& display, uint32_t format, int32_t width, int32_t height, size_t count)
 {
     ImagePoolPtr pool;
     std::vector<ImagePtr> images;
@@ -54,11 +54,11 @@ VaapiImagePool::VaapiImagePool(std::vector<ImagePtr> images):
 {
     m_poolSize = images.size();
     m_images.swap(images);
-    DEBUG("m_poolSize: %d", m_poolSize);
-    for (int32_t i = 0; i < m_poolSize; ++i) {
+    DEBUG("m_poolSize: %lu", m_poolSize);
+    for (size_t i = 0; i < m_poolSize; ++i) {
         m_freeIndex.push_back(i);
         m_indexMap[m_images[i]->getID()] = i;
-        DEBUG("image pool index: %d, image ID: 0x%x", i, m_images[i]->getID());
+        DEBUG("image pool index: %lu, image ID: 0x%x", i, m_images[i]->getID());
     }
 }
 
@@ -102,7 +102,7 @@ ImagePtr VaapiImagePool::acquireWithWait()
     ASSERT(!m_freeIndex.empty());
 
     int32_t index = m_freeIndex.front();
-    ASSERT(index >=0 && index < m_poolSize);
+    ASSERT(index >= 0 && (size_t)index < m_poolSize);
     m_freeIndex.pop_front();
 
     image.reset(m_images[index].get(), ImageRecycler(shared_from_this()));
@@ -126,7 +126,7 @@ void VaapiImagePool::recycleID(VAImageID imageID)
         return;
 
     index = it->second;
-    ASSERT(index >=0 && index < m_poolSize);
+    ASSERT(index >= 0 && (size_t)index < m_poolSize);
     m_freeIndex.push_back(index);
 
     if (m_flushing && m_freeIndex.size() == m_poolSize)

--- a/vaapi/vaapiimagepool.h
+++ b/vaapi/vaapiimagepool.h
@@ -49,7 +49,7 @@ namespace YamiMediaCodec{
 class VaapiImagePool : public EnableSharedFromThis<VaapiImagePool>
 {
 public:
-    static ImagePoolPtr create(const DisplayPtr&, uint32_t format, int32_t width, int32_t height, int32_t count);
+    static ImagePoolPtr create(const DisplayPtr&, uint32_t format, int32_t width, int32_t height, size_t count);
     /// get a free image,
     ImagePtr acquireWithWait();
 
@@ -66,7 +66,7 @@ private:
     void recycleID(VAImageID imageID);    // usually recycle from client after rendering
 
     std::vector<ImagePtr> m_images;
-    int32_t m_poolSize;
+    size_t m_poolSize;
     std::deque<int32_t> m_freeIndex;
     typedef std::map<VAImageID, int32_t> MapImageIDIndex; // map between VAImageID and index (of m_images)
     MapImageIDIndex m_indexMap;

--- a/vaapi/vaapisurface.cpp
+++ b/vaapi/vaapisurface.cpp
@@ -48,7 +48,7 @@ static uint32_t vaapiChromaToVaChroma(VaapiChromaType chroma)
         {VAAPI_CHROMA_TYPE_YUV422, VA_RT_FORMAT_YUV422},
         {VAAPI_CHROMA_TYPE_YUV444, VA_RT_FORMAT_YUV444}
     };
-    for (int i = 0; i < N_ELEMENTS(chromaMap); i++) {
+    for (size_t i = 0; i < N_ELEMENTS(chromaMap); i++) {
         if (chromaMap[i].vaapiChroma == chroma)
             return chromaMap[i].vaChroma;
     }

--- a/vaapi/vaapisurfaceallocator.cpp
+++ b/vaapi/vaapisurfaceallocator.cpp
@@ -59,7 +59,7 @@ YamiStatus VaapiSurfaceAllocator::doAlloc(SurfaceAllocParams* params)
     if (!checkVaapiStatus(status, "vaCreateSurfaces"))
         return YAMI_OUT_MEMORY;
     params->surfaces = new intptr_t[size];
-    for (int i = 0; i < size; i++) {
+    for (uint32_t i = 0; i < size; i++) {
         params->surfaces[i] = (intptr_t)v[i];
     }
     params->size = size;
@@ -72,7 +72,7 @@ YamiStatus VaapiSurfaceAllocator::doFree(SurfaceAllocParams* params)
         return YAMI_INVALID_PARAM;
     uint32_t size = params->size;
     std::vector<VASurfaceID> v(size);
-    for (int i = 0; i < size; i++) {
+    for (uint32_t i = 0; i < size; i++) {
         v[i] = (VASurfaceID)params->surfaces[i];
     }
     checkVaapiStatus(vaDestroySurfaces(m_display, &v[0], size), "vaDestroySurfaces");


### PR DESCRIPTION
Delete flag '-Wno-sign-compare' from both CFLAGS and CXXFLAGS,
and work out the compiling error in comparison between int and uint.
In case of some type int variables involved in too many functions,
it is difficult for me to change its type to uint in declaration.
There are still some cast expressions,
such as casting int to uint.
So I appreciate advices to reduce the use of cast expression honestly.

This vession has passed through the regression testing by the testing script.