### PR TITLE
enc: remove surface validity check

### DIFF
--- a/encoder/vaapiencoder_base.cpp
+++ b/encoder/vaapiencoder_base.cpp
@@ -153,7 +153,7 @@ Encode_Status VaapiEncoderBase::encode(VideoFrameRawData* frame)
 
 Encode_Status VaapiEncoderBase::encode(const SharedPtr<VideoFrame>& frame)
 {
-    if (!frame || !frame->surface)
+    if (!frame)
         return ENCODE_INVALID_PARAMS;
     if (isBusy())
         return ENCODE_IS_BUSY;


### PR DESCRIPTION
Since in some cases(like android libva) surface id 0 is valid,
and may support windows in future, remove surface validity check
to make yami general. Driver will decide it.

Signed-off-by: Leilei Shang <leilei.shang@intel.com>