### PR TITLE
compile: fix sign compare compiler error

### DIFF
--- a/examples/blend.cpp
+++ b/examples/blend.cpp
@@ -112,7 +112,7 @@ public:
 
             PERF_START(blend);
             //blend it
-            for (int i = 0; i < m_blendSurfaces.size(); i++) {
+            for (uint32_t i = 0; i < m_blendSurfaces.size(); i++) {
                 m_bumpBoxes[i]->getPos(m_dest->crop.x, m_dest->crop.y, m_dest->crop.width, m_dest->crop.height);
                 //printf("(%d, %d, %d, %d)\r\n", m_dest->crop.x, m_dest->crop.y, m_dest->crop.width, m_dest->crop.height);
 

--- a/examples/bumpbox.h
+++ b/examples/bumpbox.h
@@ -12,7 +12,7 @@ class BumpBox
 {
 public:
 
-    BumpBox(int outerWidth, int outerHeight, uint32_t width, uint32_t height, uint32_t step = 5)
+    BumpBox(uint32_t outerWidth, uint32_t outerHeight, uint32_t width, uint32_t height, uint32_t step = 5)
         :m_width(width), m_height(height)
     {
         assert(outerWidth > width && outerHeight > height);

--- a/ocl/oclcontext.cpp
+++ b/ocl/oclcontext.cpp
@@ -164,7 +164,7 @@ bool OclDevice::loadFile(const char* path, vector<char>& dest)
     if (!fp)
         return false;
     fseek(fp,0L,SEEK_END);
-    long len = ftell(fp);
+    size_t len = ftell(fp);
     if (len > 0) {
         dest.resize(len + 1);
         fseek(fp,0L,SEEK_SET);


### PR DESCRIPTION
clean up compile erros in ocl related code without "-Wno-sign-compare"