### PR TITLE
create YamiVersion.h for api version track.

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -5,6 +5,11 @@ libyami_common_source_c = \
 	utils.cpp \
 	nalreader.cpp \
 	surfacepool.cpp \
+	YamiVersion.cpp \
+	$(NULL)
+
+libyami_common_source_h = \
+	YamiVersion.h \
 	$(NULL)
 
 libyami_common_source_h_priv = \
@@ -34,6 +39,8 @@ libyami_common_la_LDFLAGS     = $(libyami_common_ldflags)
 libyami_common_la_CPPFLAGS    = $(libyami_common_cppflags)
 
 DISTCLEANFILES = \
-	Makefile.in 
+	Makefile.in\
+	YamiVersion.h.in \
+	$(NULL)
 
 

--- a/common/YamiVersion.cpp
+++ b/common/YamiVersion.cpp
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (C) 2013-2014 Intel Corporation
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2.1
+ *  of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA
+ */
+
+#include "YamiVersion.h"
+
+void yamiGetApiVersion(uint32_t *apiVersion)
+{
+	*apiVersion = YAMI_API_VERSION;
+}

--- a/common/YamiVersion.h.in
+++ b/common/YamiVersion.h.in
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (C) 2013-2014 Intel Corporation
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2.1
+ *  of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA
+ */
+
+#ifndef YAMI_VERSION_H
+#define YAMI_VERSION_H
+
+#include <stdint.h>
+
+/**
+ * YAMI_API_MAJOR_VERSION
+ * The major version of yami api
+ */
+#define YAMI_API_MAJOR_VERSION    @YAMI_API_MAJOR_VERSION@
+
+/**
+ * YAMI_API_MINOR_VERSION
+ * The minor version of yami api
+ */
+#define YAMI_API_MINOR_VERSION    @YAMI_API_MINOR_VERSION@
+
+/**
+ * YAMI_API_MICRO_VERSION
+ * The micro version of yami api
+ */
+#define YAMI_API_MICRO_VERSION    @YAMI_API_MICRO_VERSION@
+
+/**
+ * YAMI_API_VERSION_STRING
+ * The string version of yami api
+ */
+#define YAMI_API_VERSION_STRING    "@YAMI_API_VERSION@"
+
+
+#define YAMI_API_VERSION_INT(major, minor, micro)    ((major << 24) | (minor << 16) | (micro << 8))
+
+/**
+ * YAMI_API_VERSION
+ * The int version of yami api
+ */
+#define YAMI_API_VERSION    YAMI_API_VERSION_INT(YAMI_API_MAJOR_VERSION, YAMI_API_MINOR_VERSION, YAMI_API_MICRO_VERSION)
+
+/**
+ * YAMI_CHECK_API_VERSION
+ * Result is 1 if YAMI_API_VERSION is greater than
+ * YAMI_API_VERSION_INT(major, minor, micro)
+ */
+#define YAMI_CHECK_API_VERSION(major, minor, micro) (YAMI_API_VERSION >= YAMI_API_VERSION_INT(major, minor, micro))
+
+/**
+* yamiGetApiVersion
+* return YAMI_API_VERSION;
+*/
+void yamiGetApiVersion(uint32_t *apiVersion);
+
+#endif /* YAMI_VERSION_H */

--- a/configure.ac
+++ b/configure.ac
@@ -2,11 +2,13 @@
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.68])
 
-## it is interface version for libtool, only change it if you are sure to do so
-m4_define([libyami_lt_current], 0)
-m4_define([libyami_lt_revision], 3)
-m4_define([libyami_lt_age], 0)
-m4_define([libyami_lt_version], [libyami_lt_current.libyami_lt_revision.libyami_lt_age])
+# YAMI-API version
+# YAMI-API version for api headers, only change it when the api interface is changed.
+m4_define([yami_api_major_version], 0)
+m4_define([yami_api_minor_version], 1)
+m4_define([yami_api_micro_version], 0)
+m4_define([yami_api_version],
+    [yami_api_major_version.yami_api_minor_version.yami_api_micro_version])
 
 # package version (lib name suffix), usually sync with git tag
 m4_define([libyami_major_version], 0)
@@ -37,6 +39,15 @@ LIBYAMI_LT_LDFLAGS="-version-number $LIBYAMI_LT_VERSION"
 # "-release" option should be avoid, that create lib name like libyami-1.s0.xxx
 AC_SUBST(LIBYAMI_LT_VERSION)
 AC_SUBST(LIBYAMI_LT_LDFLAGS)
+
+YAMI_API_MAJOR_VERSION=yami_api_major_version
+YAMI_API_MINOR_VERSION=yami_api_minor_version
+YAMI_API_MICRO_VERSION=yami_api_micro_version
+YAMI_API_VERSION=yami_api_version
+AC_SUBST(YAMI_API_MAJOR_VERSION)
+AC_SUBST(YAMI_API_MINOR_VERSION)
+AC_SUBST(YAMI_API_MICRO_VERSION)
+AC_SUBST(YAMI_API_VERSION)
 
 AM_CONDITIONAL(BUILD_STATIC,
     [test "x$enable_static" = "xyes"])
@@ -405,6 +416,7 @@ AC_CONFIG_FILES([Makefile
 AC_OUTPUT([
          pkgconfig/libyami.pc
          pkgconfig/libyami_v4l2.pc
+         common/YamiVersion.h
 ])
 
 # Print a configuration summary
@@ -426,7 +438,7 @@ VPPS=" scaler"
 AS_IF([test x$enable_oclblender = xyes], [VPPS="$VPPS oclblender"])
 
 AC_MSG_RESULT([
-    libyami - libyami_version
+    libyami - libyami_version (API: yami_api_version)
 
     Build decoders ................... :$DECODERS
     Build encoders ....................:$ENCODERS

--- a/pkgconfig/libyami.pc.in
+++ b/pkgconfig/libyami.pc.in
@@ -4,9 +4,8 @@ libdir=@libdir@
 includedir=@includedir@
 
 Name: libyami
-Description: Intel Open source encoder based on libva. \
-	Including encoder, decoder, capi, vpp(Video post process) and codeparser.
-Version: @LIBYAMI_LT_VERSION@
+Description: Intel open source media infrastructure base on libva.
+Version: @YAMI_API_VERSION@
 Requires: @LIBVA_PKG_REQ@ \
           @LIBVA_DRM_PKG_REQ@ \
           @LIBVA_X11_PKG_REQ@ \

--- a/pkgconfig/libyami_v4l2.pc.in
+++ b/pkgconfig/libyami_v4l2.pc.in
@@ -3,9 +3,9 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 
-Name: libyami v4l2 wrapper
-Description: Intel Open source video post process based on libva
-Version: @LIBYAMI_LT_VERSION@
+Name: libyami_v4l2
+Description: yami based v4l2 plugin
+Version: @YAMI_API_VERSION@
 Requires: libyami
 Libs: -L${libdir} -lyami_v4l2
 Cflags: -I${includedir}/libyami

--- a/tests/yamiinfo.cpp
+++ b/tests/yamiinfo.cpp
@@ -22,6 +22,7 @@
 #endif
 
 #include <iostream>
+#include "common/YamiVersion.h"
 #include "decoder/vaapidecoder_factory.h"
 #include "encoder/vaapiencoder_factory.h"
 #include "vpp/vaapipostprocess_factory.h"
@@ -38,9 +39,26 @@ void printFactoryInfo(const char* name)
     }
 }
 
+void printApiVersion()
+{
+   uint32_t api;
+   yamiGetApiVersion(&api);
+
+   //uint32 just for print format
+   uint32_t major = api >> 24;
+   uint32_t minor = (api >> 16) & 0xff;
+   uint32_t micro = (api >> 8) & 0xff;
+
+   std::cout << "API: " << major << "." << minor << "." << micro << std::endl;
+}
+
 int main(int argc, const char** argv)
 {
+
     std::cout << PACKAGE_STRING << " - " << PACKAGE_URL << std::endl;
+
+    std::cout<<std::endl;
+    printApiVersion();
 
     printFactoryInfo<VaapiDecoderFactory>("decoders");
     printFactoryInfo<VaapiEncoderFactory>("encoders");


### PR DESCRIPTION
Create YamiVersion.h for api version, we should update it
when the interface between yami and user changed.
this fix #318 

