### PR TITLE
h264enc and hevcenc: Modify IDR interval and key period parameters se…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AC_PREREQ([2.68])
 # YAMI-API version for api headers, only change it when the api interface is changed.
 m4_define([yami_api_major_version], 0)
 m4_define([yami_api_minor_version], 1)
-m4_define([yami_api_micro_version], 0)
+m4_define([yami_api_micro_version], 1)
 m4_define([yami_api_version],
     [yami_api_major_version.yami_api_minor_version.yami_api_micro_version])
 

--- a/encoder/vaapiencoder_h264.h
+++ b/encoder/vaapiencoder_h264.h
@@ -87,9 +87,6 @@ private:
     void referenceListFree();
     //template end
 
-    uint32_t& keyFramePeriod() {
-        return m_videoParamAVC.idrInterval;
-    }
     void resetGopStart();
     void setBFrame(const PicturePtr&);
     void setPFrame(const PicturePtr&);
@@ -114,6 +111,7 @@ private:
     AVCStreamFormat m_streamFormat;
     uint32_t m_frameIndex;
     uint32_t m_curFrameNum;
+    uint32_t m_keyPeriod;
 
     /* reference list */
     std::deque<ReferencePtr> m_refList;

--- a/encoder/vaapiencoder_hevc.h
+++ b/encoder/vaapiencoder_hevc.h
@@ -105,9 +105,6 @@ private:
     void referenceListFree();
     //template end
 
-    uint32_t& keyFramePeriod() {
-        return m_videoParamAVC.idrInterval;
-    }
     void resetGopStart();
     void setBFrame(const PicturePtr&);
     void setPFrame(const PicturePtr&);
@@ -138,6 +135,7 @@ private:
     std::list<PicturePtr> m_reorderFrameList;
     VaapiEncReorderState m_reorderState;
     uint32_t m_frameIndex;
+    uint32_t m_keyPeriod;
     
     /* reference list */
     std::deque<ReferencePtr> m_refList;

--- a/interface/VideoEncoderDefs.h
+++ b/interface/VideoEncoderDefs.h
@@ -315,7 +315,6 @@ typedef enum {
     VideoConfigTypeIntraRefreshType,
     VideoConfigTypeAIR,
     VideoConfigTypeCyclicFrameInterval,
-    VideoConfigTypeAVCIntraPeriod,
     VideoConfigTypeNALSize,
     VideoConfigTypeIDRRequest,
     VideoConfigTypeSliceNum,
@@ -355,7 +354,7 @@ typedef struct VideoParamsAVC {
     uint32_t basicUnitSize;     //for rate control
     uint8_t VUIFlag;
     int32_t maxSliceSize;
-    uint32_t idrInterval;
+    uint32_t idrInterval;    //How many Intra frames will have an IDR frame
     SliceNum sliceNum;
     AVCDelimiterType delimiterType;
     Cropping crop;
@@ -406,12 +405,6 @@ typedef struct VideoConfigBitRate {
     uint32_t size;
     VideoRateControlParams rcParams;
 }VideoConfigBitRate;
-
-typedef struct VideoConfigAVCIntraPeriod {
-    uint32_t size;
-    uint32_t idrInterval;       //How many Intra frame will have a IDR frame
-    uint32_t intraPeriod;
-}VideoConfigAVCIntraPeriod;
 
 typedef struct VideoConfigNALSize {
     uint32_t size;

--- a/tests/encode.cpp
+++ b/tests/encode.cpp
@@ -87,6 +87,14 @@ int main(int argc, char** argv)
     encVideoParams.size = sizeof(VideoParamsCommon);
     encoder->setParameters(VideoParamsTypeCommon, &encVideoParams);
 
+    // configure AVC encoding parameters
+    VideoParamsAVC encVideoParamsAVC;
+    encVideoParamsAVC.size = sizeof(VideoParamsAVC);
+    encoder->getParameters(VideoParamsTypeAVC, &encVideoParamsAVC);
+    encVideoParamsAVC.idrInterval = idrInterval;
+    encVideoParamsAVC.size = sizeof(VideoParamsAVC);
+    encoder->setParameters(VideoParamsTypeAVC, &encVideoParamsAVC);
+
     VideoConfigAVCStreamFormat streamFormat;
     streamFormat.size = sizeof(VideoConfigAVCStreamFormat);
     streamFormat.streamFormat = AVC_STREAM_FORMAT_ANNEXB;

--- a/tests/encodehelp.h
+++ b/tests/encodehelp.h
@@ -25,7 +25,8 @@
 #include "interface/VideoEncoderDefs.h"
 #include <getopt.h>
 
-static int kIPeriod = 30;
+static int idrInterval = 0;
+static int intraPeriod = 30;
 static int ipPeriod = 1;
 static int ipbMode = 1;
 static char *inputFileName = NULL;
@@ -71,8 +72,9 @@ static void print_help(const char* app)
     printf("   --qp <initial qp> optional\n");
     printf("   --rcmode <CBR|CQP> optional\n");
     printf("   --ipbmode <0(I frame only ) | 1 (I and P frames) | 2 (I,P,B frames)> optional\n");
-    printf("   --keyperiod <key frame period(default 30)> optional\n");
+    printf("   --intraperiod <Intra frame period (default 30)> optional\n");
     printf("   --refnum <number of referece frames(default 1)> optional\n");
+    printf("   --idrinterval <AVC/HEVC IDR frame interval (default 0)> optional\n");
 }
 
 static VideoRateControl string_to_rc_mode(char *str)
@@ -98,8 +100,9 @@ static bool process_cmdline(int argc, char *argv[])
         {"qp", required_argument, NULL, 0 },
         {"rcmode", required_argument, NULL, 0 },
         {"ipbmode", required_argument, NULL, 0 },
-        {"keyperiod", required_argument, NULL, 0 },
+        {"intraperiod", required_argument, NULL, 0 },
         {"refnum", required_argument, NULL, 0 },
+        {"idrinterval", required_argument, NULL, 0 },
         {NULL, no_argument, NULL, 0 }};
     int option_index;
 
@@ -155,10 +158,13 @@ static bool process_cmdline(int argc, char *argv[])
                     ipbMode= atoi(optarg);
                     break;
                 case 4:
-                    kIPeriod = atoi(optarg);
+                    intraPeriod = atoi(optarg);
                     break;
                 case 5:
                     numRefFrames= atoi(optarg);
+                    break;
+                case 6:
+                    idrInterval = atoi(optarg);
                     break;
             }
         }
@@ -212,7 +218,7 @@ void setEncoderParameters(VideoParamsCommon * encVideoParams)
     encVideoParams->frameRate.frameRateNum = fps;
 
     //picture type and bitrate
-    encVideoParams->intraPeriod = kIPeriod;
+    encVideoParams->intraPeriod = intraPeriod;
     encVideoParams->ipPeriod = ipPeriod;
     encVideoParams->rcParams.bitRate = bitRate;
     encVideoParams->rcParams.initQP = initQp;


### PR DESCRIPTION
…tting.

tests: Add "idrinterval" setting for encoder to indicate how many I frames between two IDRs.
tests: Change "keyperiod" option name to "intraperiod" to be consistent with its feature.