### PR TITLE
remove all getOutputs in decoder except "SharedPtr<VideoFrame> getOutput".

### DIFF
--- a/capi/VideoDecoderCapi.cpp
+++ b/capi/VideoDecoderCapi.cpp
@@ -118,47 +118,6 @@ void releaseDecoder(DecodeHandler p)
         releaseVideoDecoder((IVideoDecoder*)p);
 }
 
-void renderDone(DecodeHandler p, const VideoRenderBuffer* buffer)
-{
-    if(p)
-        ((IVideoDecoder*)p)->renderDone(buffer);
-}
-
-void renderDoneRawData(DecodeHandler p, VideoFrameRawData* buffer)
-{
-    if(p)
-        ((IVideoDecoder*)p)->renderDone(buffer);
-}
-
-
-void flushOutport(DecodeHandler p)
-{
-    if(p)
-        ((IVideoDecoder*)p)->flushOutport();
-}
-
-void enableNativeBuffers(DecodeHandler p)
-{
-    if(p)
-        ((IVideoDecoder*)p)->enableNativeBuffers();
-}
-
-Decode_Status getClientNativeWindowBuffer(DecodeHandler p, void *bufferHeader, void *nativeBufferHandle)
-{
-    if(p)
-        return ((IVideoDecoder*)p)->getClientNativeWindowBuffer(bufferHeader, nativeBufferHandle);
-    else
-        return DECODE_FAIL;
-}
-
-Decode_Status flagNativeBuffer(DecodeHandler p, void * pBuffer)
-{
-    if(p)
-        return ((IVideoDecoder*)p)->flagNativeBuffer(pBuffer);
-    else
-        return DECODE_FAIL;
-}
-
 void releaseLock(DecodeHandler p)
 {
     if(p)

--- a/capi/VideoDecoderCapi.h
+++ b/capi/VideoDecoderCapi.h
@@ -26,9 +26,7 @@
 #define __ENABLE_CAPI__ 1
 #endif
 #include "VideoDecoderDefs.h"
-#ifdef __ENABLE_X11__
-#include <X11/Xlib.h>
-#endif
+#include "VideoCommonDefs.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -38,6 +36,8 @@ typedef void* DecodeHandler;
 
 DecodeHandler createDecoder(const char *mimeType);
 
+void decodeSetNativeDisplay(DecodeHandler p, NativeDisplay* display);
+
 Decode_Status decodeStart(DecodeHandler p, VideoConfigBuffer *buffer);
 
 Decode_Status decodeReset(DecodeHandler p, VideoConfigBuffer *buffer);
@@ -46,37 +46,34 @@ void decodeStop(DecodeHandler p);
 
 void decodeFlush(DecodeHandler p);
 
-Decode_Status decode(DecodeHandler p, VideoDecodeBuffer *buffer);
+Decode_Status decodeDecode(DecodeHandler p, VideoDecodeBuffer* buffer);
 
-const VideoRenderBuffer* decodeGetOutput(DecodeHandler p, bool draining);
+VideoFrame* decodeGetOutput(DecodeHandler p);
 
-#ifdef __ENABLE_X11__
-Decode_Status decodeGetOutput_x11(DecodeHandler p, Drawable draw, int64_t *timeStamp
-        , int drawX, int drawY, int drawWidth, int drawHeight, bool draining
-        , int frameX, int frameY, int frameWidth, int frameHeight);
-#endif
-
-Decode_Status decodeGetOutputRawData(DecodeHandler p, VideoFrameRawData* frame, bool draining);
-
-const VideoFormatInfo* getFormatInfo(DecodeHandler p);
-
-void renderDone(DecodeHandler p, const VideoRenderBuffer* buffer);
-
-void renderDoneRawData(DecodeHandler p, VideoFrameRawData* buffer);
-
-void decodeSetNativeDisplay(DecodeHandler p, NativeDisplay * display);
-
-void flushOutport(DecodeHandler p);
-
-void enableNativeBuffers(DecodeHandler p);
-
-Decode_Status getClientNativeWindowBuffer(DecodeHandler p, void *bufferHeader, void *nativeBufferHandle);
-
-Decode_Status flagNativeBuffer(DecodeHandler p, void * pBuffer);
-
-void releaseLock(DecodeHandler p);
+const VideoFormatInfo* decodeGetFormatInfo(DecodeHandler p);
 
 void releaseDecoder(DecodeHandler p);
+
+/*deprecated*/
+void renderDone(DecodeHandler p, const VideoRenderBuffer* buffer);
+
+/*deprecated*/
+void renderDoneRawData(DecodeHandler p, VideoFrameRawData* buffer);
+
+/*deprecated*/
+void flushOutport(DecodeHandler p);
+
+/*deprecated*/
+void enableNativeBuffers(DecodeHandler p);
+
+/*deprecated*/
+Decode_Status getClientNativeWindowBuffer(DecodeHandler p, void *bufferHeader, void *nativeBufferHandle);
+
+/*deprecated*/
+Decode_Status flagNativeBuffer(DecodeHandler p, void * pBuffer);
+
+/*deprecated*/
+void releaseLock(DecodeHandler p);
 
 #ifdef __cplusplus
 };

--- a/capi/VideoDecoderCapi.h
+++ b/capi/VideoDecoderCapi.h
@@ -55,24 +55,6 @@ const VideoFormatInfo* decodeGetFormatInfo(DecodeHandler p);
 void releaseDecoder(DecodeHandler p);
 
 /*deprecated*/
-void renderDone(DecodeHandler p, const VideoRenderBuffer* buffer);
-
-/*deprecated*/
-void renderDoneRawData(DecodeHandler p, VideoFrameRawData* buffer);
-
-/*deprecated*/
-void flushOutport(DecodeHandler p);
-
-/*deprecated*/
-void enableNativeBuffers(DecodeHandler p);
-
-/*deprecated*/
-Decode_Status getClientNativeWindowBuffer(DecodeHandler p, void *bufferHeader, void *nativeBufferHandle);
-
-/*deprecated*/
-Decode_Status flagNativeBuffer(DecodeHandler p, void * pBuffer);
-
-/*deprecated*/
 void releaseLock(DecodeHandler p);
 
 #ifdef __cplusplus

--- a/capi/VideoEncoderCapi.cpp
+++ b/capi/VideoEncoderCapi.cpp
@@ -53,6 +53,21 @@ void encodeStop(EncodeHandler p)
         ((IVideoEncoder*)p)->stop();
 }
 
+static void freeFrame(VideoFrame* frame)
+{
+    if (frame && frame->free) {
+        frame->free(frame);
+    }
+}
+
+Encode_Status encodeEncode(EncodeHandler p, VideoFrame* frame)
+{
+    if (!p)
+        return ENCODE_INVALID_PARAMS;
+    SharedPtr<VideoFrame> f(frame, freeFrame);
+    return ((IVideoEncoder*)p)->encode(f);
+}
+
 Encode_Status encodeEncodeRawData(EncodeHandler p, VideoFrameRawData* inBuffer)
 {
     if(p)

--- a/capi/VideoEncoderCapi.cpp
+++ b/capi/VideoEncoderCapi.cpp
@@ -53,7 +53,7 @@ void encodeStop(EncodeHandler p)
         ((IVideoEncoder*)p)->stop();
 }
 
-Encode_Status encode(EncodeHandler p, VideoFrameRawData * inBuffer)
+Encode_Status encodeEncodeRawData(EncodeHandler p, VideoFrameRawData* inBuffer)
 {
     if(p)
         return ((IVideoEncoder*)p)->encode(inBuffer);
@@ -69,7 +69,7 @@ Encode_Status encodeGetOutput(EncodeHandler p, VideoEncOutputBuffer * outBuffer,
         return ENCODE_FAIL;
 }
 
-Encode_Status getParameters(EncodeHandler p, VideoParamConfigType type, Yami_PTR videoEncParams)
+Encode_Status encodeGetParameters(EncodeHandler p, VideoParamConfigType type, Yami_PTR videoEncParams)
 {
     if(p)
         return ((IVideoEncoder*)p)->getParameters(type, videoEncParams);
@@ -77,7 +77,7 @@ Encode_Status getParameters(EncodeHandler p, VideoParamConfigType type, Yami_PTR
         return ENCODE_FAIL;
 }
 
-Encode_Status setParameters(EncodeHandler p, VideoParamConfigType type, Yami_PTR videoEncParams)
+Encode_Status encodeSetParameters(EncodeHandler p, VideoParamConfigType type, Yami_PTR videoEncParams)
 {
     if(p)
         return ((IVideoEncoder*)p)->setParameters(type, videoEncParams);
@@ -85,12 +85,18 @@ Encode_Status setParameters(EncodeHandler p, VideoParamConfigType type, Yami_PTR
         return ENCODE_FAIL;
 }
 
-Encode_Status getMaxOutSize(EncodeHandler p, uint32_t * maxSize)
+Encode_Status encodeGetMaxOutSize(EncodeHandler p, uint32_t* maxSize)
 {
     if(p)
         return ((IVideoEncoder*)p)->getMaxOutSize(maxSize);
     else
         return ENCODE_FAIL;
+}
+
+void releaseEncoder(EncodeHandler p)
+{
+    if (p)
+        releaseVideoEncoder((IVideoEncoder*)p);
 }
 
 Encode_Status getStatistics(EncodeHandler p, VideoStatistics * videoStat)
@@ -115,10 +121,4 @@ Encode_Status setConfig(EncodeHandler p, VideoParamConfigType type, Yami_PTR vid
         return ((IVideoEncoder*)p)->setConfig(type, videoEncConfig);
     else
         return ENCODE_FAIL;
-}
-
-void releaseEncoder(EncodeHandler p)
-{
-    if(p)
-        releaseVideoEncoder((IVideoEncoder*)p);
 }

--- a/capi/VideoEncoderCapi.h
+++ b/capi/VideoEncoderCapi.h
@@ -41,23 +41,26 @@ Encode_Status encodeStart(EncodeHandler p);
 
 void encodeStop(EncodeHandler p);
 
-Encode_Status encode(EncodeHandler p, VideoFrameRawData * inBuffer);
+Encode_Status encodeEncodeRawData(EncodeHandler p, VideoFrameRawData* inBuffer);
 
 Encode_Status encodeGetOutput(EncodeHandler p, VideoEncOutputBuffer * outBuffer, bool withWait);
 
-Encode_Status getParameters(EncodeHandler p, VideoParamConfigType type, Yami_PTR videoEncParams);
+Encode_Status encodeGetParameters(EncodeHandler p, VideoParamConfigType type, Yami_PTR videoEncParams);
 
-Encode_Status setParameters(EncodeHandler p, VideoParamConfigType type, Yami_PTR videoEncParams);
+Encode_Status encodeSetParameters(EncodeHandler p, VideoParamConfigType type, Yami_PTR videoEncParams);
 
-Encode_Status getMaxOutSize(EncodeHandler p, uint32_t * maxSize);
-
-Encode_Status getStatistics(EncodeHandler p, VideoStatistics * videoStat);
-
-Encode_Status getConfig(EncodeHandler p, VideoParamConfigType type, Yami_PTR videoEncConfig);
-
-Encode_Status setConfig(EncodeHandler p, VideoParamConfigType type, Yami_PTR videoEncConfig);
+Encode_Status encodeGetMaxOutSize(EncodeHandler p, uint32_t* maxSize);
 
 void releaseEncoder(EncodeHandler p);
+
+/*deprecated*/
+Encode_Status getStatistics(EncodeHandler p, VideoStatistics * videoStat);
+
+/*deprecated*/
+Encode_Status getConfig(EncodeHandler p, VideoParamConfigType type, Yami_PTR videoEncConfig);
+
+/*deprecated*/
+Encode_Status setConfig(EncodeHandler p, VideoParamConfigType type, Yami_PTR videoEncConfig);
 
 #ifdef __cplusplus
 };

--- a/capi/VideoEncoderCapi.h
+++ b/capi/VideoEncoderCapi.h
@@ -41,7 +41,8 @@ Encode_Status encodeStart(EncodeHandler p);
 
 void encodeStop(EncodeHandler p);
 
-Encode_Status encodeEncodeRawData(EncodeHandler p, VideoFrameRawData* inBuffer);
+/* encoder will can frame->free, no matter it return fail or not*/
+Encode_Status encodeEncode(EncodeHandler p, VideoFrame* frame);
 
 Encode_Status encodeGetOutput(EncodeHandler p, VideoEncOutputBuffer * outBuffer, bool withWait);
 
@@ -52,6 +53,9 @@ Encode_Status encodeSetParameters(EncodeHandler p, VideoParamConfigType type, Ya
 Encode_Status encodeGetMaxOutSize(EncodeHandler p, uint32_t* maxSize);
 
 void releaseEncoder(EncodeHandler p);
+
+/*deprecated*/
+Encode_Status encodeEncodeRawData(EncodeHandler p, VideoFrameRawData* inBuffer);
 
 /*deprecated*/
 Encode_Status getStatistics(EncodeHandler p, VideoStatistics * videoStat);

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ m4_define([yami_api_major_version], 0)
 # update this for every release when micro version large than zero
 m4_define([yami_api_minor_version], 1)
 # change this for any api change
-m4_define([yami_api_micro_version], 4)
+m4_define([yami_api_micro_version], 5)
 m4_define([yami_api_version],
     [yami_api_major_version.yami_api_minor_version.yami_api_micro_version])
 

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ m4_define([yami_api_major_version], 0)
 # update this for every release when micro version large than zero
 m4_define([yami_api_minor_version], 1)
 # change this for any api change
-m4_define([yami_api_micro_version], 6)
+m4_define([yami_api_micro_version], 7)
 m4_define([yami_api_version],
     [yami_api_major_version.yami_api_minor_version.yami_api_micro_version])
 

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ m4_define([yami_api_major_version], 0)
 # update this for every release when micro version large than zero
 m4_define([yami_api_minor_version], 1)
 # change this for any api change
-m4_define([yami_api_micro_version], 5)
+m4_define([yami_api_micro_version], 6)
 m4_define([yami_api_version],
     [yami_api_major_version.yami_api_minor_version.yami_api_micro_version])
 

--- a/configure.ac
+++ b/configure.ac
@@ -5,8 +5,10 @@ AC_PREREQ([2.68])
 # YAMI-API version
 # YAMI-API version for api headers, only change it when the api interface is changed.
 m4_define([yami_api_major_version], 0)
+# update this for every release when micro version large than zero
 m4_define([yami_api_minor_version], 1)
-m4_define([yami_api_micro_version], 3)
+# change this for any api change
+m4_define([yami_api_micro_version], 4)
 m4_define([yami_api_version],
     [yami_api_major_version.yami_api_minor_version.yami_api_micro_version])
 

--- a/decoder/vaapidecoder_base.cpp
+++ b/decoder/vaapidecoder_base.cpp
@@ -170,10 +170,6 @@ void VaapiDecoderBase::flush(void)
     m_forwardReference = NULL;
 }
 
-void VaapiDecoderBase::flushOutport(void)
-{
-}
-
 struct BufferRecycler
 {
     BufferRecycler(const DecSurfacePoolPtr&  pool, VideoRenderBuffer* buffer)

--- a/decoder/vaapidecoder_base.cpp
+++ b/decoder/vaapidecoder_base.cpp
@@ -42,12 +42,9 @@ inline void unrefAllocator(SurfaceAllocator* allocator)
     allocator->unref(allocator);
 }
 
-VaapiDecoderBase::VaapiDecoderBase():
-m_renderTarget(NULL),
-m_lastReference(NULL),
-m_forwardReference(NULL),
-m_VAStarted(false),
-m_currentPTS(INVALID_PTS), m_enableNativeBuffersFlag(false)
+VaapiDecoderBase::VaapiDecoderBase()
+    : m_VAStarted(false)
+    , m_currentPTS(INVALID_PTS)
 {
     INFO("base: construct()");
     m_externalDisplay.handle = 0,
@@ -146,9 +143,6 @@ void VaapiDecoderBase::stop(void)
     terminateVA();
 
     m_currentPTS = INVALID_PTS;
-    m_renderTarget = NULL;
-    m_lastReference = NULL;
-    m_forwardReference = NULL;
 
     m_lowDelay = false;
     m_rawOutput = false;
@@ -165,9 +159,6 @@ void VaapiDecoderBase::flush(void)
     }
 
     m_currentPTS = INVALID_PTS;
-    m_renderTarget = NULL;
-    m_lastReference = NULL;
-    m_forwardReference = NULL;
 }
 
 struct BufferRecycler
@@ -219,34 +210,10 @@ const VideoFormatInfo *VaapiDecoderBase::getFormatInfo(void)
     return &m_videoFormatInfo;
 }
 
-Decode_Status VaapiDecoderBase::updateReference(void)
-{
-    // update reference frames
-    if (m_renderTarget->referenceFrame) {
-        // managing reference for MPEG4/H.263/WMV.
-        // AVC should manage reference frame in a different way
-        if (m_forwardReference != NULL) {
-            // this foward reference is no longer needed
-            m_forwardReference->asReferernce = false;
-        }
-        // Forware reference for either P or B frame prediction
-        m_forwardReference = m_lastReference;
-        m_renderTarget->asReferernce = true;
-
-        // the last reference frame.
-        m_lastReference = m_renderTarget;
-    }
-    return DECODE_SUCCESS;
-}
-
 Decode_Status
     VaapiDecoderBase::setupVA(uint32_t numSurface, VAProfile profile)
 {
     INFO("base: setup VA");
-
-    if (m_enableNativeBuffersFlag == true) {
-        numSurface = 20;        //NATIVE_WINDOW_COUNT;
-    }
 
     if (m_VAStarted) {
         return DECODE_SUCCESS;

--- a/decoder/vaapidecoder_base.h
+++ b/decoder/vaapidecoder_base.h
@@ -89,14 +89,6 @@ class VaapiDecoderBase:public IVideoDecoder {
     DecSurfacePoolPtr m_surfacePool;
     SharedPtr<SurfaceAllocator> m_allocator;
     SharedPtr<SurfaceAllocator> m_externalAllocator;
-    /* the current render target for decoder */
-    // XXX, not useful. decoding bases on VaapiPicture, rendering bases on IVideoDecoder->getOutput()
-    VideoSurfaceBuffer *m_renderTarget;
-
-    /* reference picture, h264 will not use */
-    // XXX, not used. reference frame management base on VaapiPicture
-    VideoSurfaceBuffer *m_lastReference;
-    VideoSurfaceBuffer *m_forwardReference;
 
     bool m_VAStarted;
 
@@ -110,7 +102,6 @@ class VaapiDecoderBase:public IVideoDecoder {
   private:
     bool m_lowDelay;
     bool m_rawOutput;
-    bool m_enableNativeBuffersFlag;
 #ifdef __ENABLE_DEBUG__
     int renderPictureCount;
 #endif

--- a/decoder/vaapidecoder_base.h
+++ b/decoder/vaapidecoder_base.h
@@ -57,23 +57,11 @@ class VaapiDecoderBase:public IVideoDecoder {
     //virtual Decode_Status decode(VideoDecodeBuffer *buffer);
     virtual void flush(void);
     virtual void flushOutport(void);
-    virtual const VideoRenderBuffer *getOutput(bool draining);
-    virtual Decode_Status getOutput(unsigned long draw, int64_t *timeStamp
-        , int drawX, int drawY, int drawWidth, int drawHeight, bool draining = false
-        , int frameX = -1, int frameY = -1, int frameWidth = -1, int frameHeight = -1);
-    virtual Decode_Status getOutput(VideoFrameRawData* frame, bool draining = false);
-    virtual Decode_Status populateOutputHandles(VideoFrameRawData *frames, uint32_t &frameCount);
     virtual const VideoFormatInfo *getFormatInfo(void);
-    virtual void renderDone(const VideoRenderBuffer * renderBuf);
-    virtual void renderDone(VideoFrameRawData* frame);
     virtual SharedPtr<VideoFrame> getOutput();
 
     /* native window related functions */
     void setNativeDisplay(NativeDisplay * nativeDisplay);
-    void enableNativeBuffers(void);
-    Decode_Status getClientNativeWindowBuffer(void *bufferHeader,
-                                              void *nativeBufferHandle);
-    Decode_Status flagNativeBuffer(void *pBuffer);
     void releaseLock(bool lockable=false);
 
     void  setAllocator(SurfaceAllocator* allocator);

--- a/decoder/vaapidecoder_base.h
+++ b/decoder/vaapidecoder_base.h
@@ -56,7 +56,6 @@ class VaapiDecoderBase:public IVideoDecoder {
     virtual void stop(void);
     //virtual Decode_Status decode(VideoDecodeBuffer *buffer);
     virtual void flush(void);
-    virtual void flushOutport(void);
     virtual const VideoFormatInfo *getFormatInfo(void);
     virtual SharedPtr<VideoFrame> getOutput();
 

--- a/egl/egl_vaapi_image.cpp
+++ b/egl/egl_vaapi_image.cpp
@@ -117,7 +117,7 @@ EGLImageKHR EglVaapiImage::createEglImage(EGLDisplay eglDisplay, EGLContext eglC
     return m_eglImage;
 }
 
-bool EglVaapiImage::blt(const VideoFrameRawData& src)
+bool EglVaapiImage::blt(const SharedPtr<VideoFrame>& src)
 {
     if (!m_inited) {
         ERROR("call init before blt!");
@@ -126,11 +126,11 @@ bool EglVaapiImage::blt(const VideoFrameRawData& src)
     if (m_acquired)
         vaReleaseBufferHandle(m_display, m_image.buf);
 
-    VAStatus vaStatus = vaGetImage(m_display, src.internalID, 0, 0, src.width, src.height, m_image.image_id);
+    VAStatus vaStatus = vaGetImage(m_display, (VASurfaceID)src->surface, src->crop.x, src->crop.y, src->crop.width, src->crop.height, m_image.image_id);
 
     // incomplete data yet
-    m_frameInfo.timeStamp = src.timeStamp;
-    m_frameInfo.flags = src.flags;
+    m_frameInfo.timeStamp = src->timeStamp;
+    m_frameInfo.flags = src->flags;
     return checkVaapiStatus(vaStatus, "vaGetImage");
 }
 

--- a/egl/egl_vaapi_image.h
+++ b/egl/egl_vaapi_image.h
@@ -38,7 +38,7 @@ public:
     EglVaapiImage(VADisplay, int width, int height);
     bool init();
     EGLImageKHR createEglImage(EGLDisplay, EGLContext, VideoDataMemoryType);
-    bool blt(const VideoFrameRawData& src);
+    bool blt(const SharedPtr<VideoFrame>& src);
     bool exportFrame(VideoDataMemoryType memoryType, VideoFrameRawData &frame);
     ~EglVaapiImage();
 private:

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -33,7 +33,6 @@ endif
 
 VPP_INPUT_SOURCES = \
 	$(DECODE_INPUT_SOURCES) \
-	$(top_builddir)/tests/vppinputoutput.cpp \
 	$(top_builddir)/tests/vppinputdecode.cpp \
 	$(top_builddir)/tests/vppinputasync.cpp \
 	$(top_builddir)/tests/vppoutputencode.cpp \

--- a/interface/VideoCommonDefs.h
+++ b/interface/VideoCommonDefs.h
@@ -85,6 +85,8 @@ extern "C" {
 #define YAMI_FOURCC_NV12 YAMI_FOURCC('N','V','1','2')
 #define YAMI_FOURCC_RGBX YAMI_FOURCC('R','G','B','X')
 #define YAMI_FOURCC_RGBA YAMI_FOURCC('R','G','B','A')
+#define YAMI_FOURCC_BGRX YAMI_FOURCC('B','G','R','X')
+#define YAMI_FOURCC_BGRA YAMI_FOURCC('B','G','R','A')
 
 typedef enum {
     NATIVE_DISPLAY_AUTO,    // decided by yami

--- a/interface/VideoDecoderInterface.h
+++ b/interface/VideoDecoderInterface.h
@@ -55,91 +55,24 @@ public:
 
     ///get decoded frame from decoder.
     virtual SharedPtr<VideoFrame> getOutput() = 0;
-    /**
-     * \brief return one frame to client for display; obsolete API. please use getOutput(XID, ...) or getOutput(VideoFrameRawData, ...) instead.
-     * NULL will be returned if no available frame for rendering
-     * @param[in] draining drain out all possible frames or not. it is set to true upon EOS.
-     * @return a #VideoRenderBuffer to be rendered by client
-     */
-    virtual const VideoRenderBuffer* getOutput(bool draining) = 0;
-    /**
-     * \brief  render one available video frame to draw
-     * @param[in] draw a X11 drawable, Pixmap or Window ID. we do not use Drawable/XID type from X11/X.h because interface should be unique unconditionally
-     * @param[in/out] timeStamp, time stamp of current rendering frame (it is passed from client before)
-     * @param[in] drawX/drawY/drawWidth/drawHeight specify a rect to render on the draw
-     * @param[in] drawX horizontal offset to render on the draw
-     * @param[in] drawY vertical offset to render on the draw
-     * @param[in] width rendering rect width on the draw
-     * @param[in] height render rect height on the draw
-     * @param[in] frameX/frameY/frameWidth/frameHeight specify a portion rect for rendering, default means the whole surface to render
-     * @param[in] frameX horizontal offset of the video frame to render
-     * @param[in] frameY vertical offset of the video frame to render
-     * @param[in] frameWidth rect width of the video frame to render
-     * @param[in] frameHeight rect height of the video frame to render
-     *
-     * default value of frameX/frameY/frameWidth/frameHeight means rendering the whole video frame(surface)
-     *
-     * @return DECODE_SUCCESS for success
-     * @return RENDER_NO_AVAILABLE_FRAME when no available frame to render
-     * @return RENDER_FAIL when driver fail to do vaPutSurface
-     * @return RENDER_INVALID_PARAMETER
-     */
-    virtual Decode_Status getOutput(unsigned long draw, int64_t *timeStamp
-        , int drawX, int drawY, int drawWidth, int drawHeight, bool draining = false
-        , int frameX = -1, int frameY = -1, int frameWidth = -1, int frameHeight = -1) = 0;
-    /**
-     * \brief export one frame to client buffer;
-     * there are four type to export one frame (VideoDataMemoryType); after rendering, client return the buffer back by renderDone(VideoFrameRawData*);
-     * RENDER_NO_AVAILABLE_FRAME will be returned if no available frame for rendering.
-     * if frame->fourcc or/and frame->width/height are set, color conversion or/and resize is done as well.
-     * @param[in] draining drain out all possible frames or not. it is set to true upon EOS.
-     */
-    virtual Decode_Status getOutput(VideoFrameRawData* frame, bool draining = false) = 0;
 
-    /**
-    * in chromeos v4l2vda, it creates all EGLImage from output frames at initialization time, not create/destroy each frame texture on the fly.
-    * @param[in] frames the exported handles (and attributes) for all output frames.
-    * @param[in/out] frameCount. the size of input frames when it is not zero. return the internal output pool size when it is zero.
-    * make sure to recycle (renderDone()) these frames.
-    */
-    virtual Decode_Status populateOutputHandles(VideoFrameRawData *frames, unsigned int &frameCount) = 0;
-
-    /** \brief retrieve updated stream information after decoder has parsed the video stream.
+   /** \brief retrieve updated stream information after decoder has parsed the video stream.
     * client usually calls it when libyami return DECODE_FORMAT_CHANGE in decode().
     */
     virtual const VideoFormatInfo* getFormatInfo(void) = 0;
-    /** \brief client recycles buffer back to libyami after the buffer has been rendered.
-    *
-    * <pre>
-    * it is used by current omx client in async rendering mode.
-    * if rendering target is passed in getOutput(), then yami can does the rendering directly; this function becomes unnecessary.
-    * however, this API is still useful when we export video frame directly for EGLImage (dma_buf).
-    * </pre>
-    */
-    virtual void renderDone(const VideoRenderBuffer* buffer) = 0;
-
-    /** \brief client recycles video frame (retrieve by getOutput) back to libyami after the buffer has been rendered.
-    */
-    virtual void renderDone(VideoFrameRawData* frame) = 0;
 
     /// set native display
     virtual void  setNativeDisplay( NativeDisplay * display = NULL) = 0;
     virtual void  setAllocator(SurfaceAllocator* allocator) = 0;
 
+    /*deprecated*/
     /// lockable is set to false when seek begins and reset to true after seek is done
     /// EOS also set lockable to false
     virtual void releaseLock(bool lockable=false) = 0;
 
+    /*deprecated*/
     ///do not use this, we will remove this in near future
     virtual VADisplay getDisplayID() = 0;
-    /// obsolete, make all cached video frame output-able, it can be done by getOutput(draining=true) as well
-    virtual void flushOutport(void) = 0;
-    /// not interest for now, may be used by Android to accept external video frame memory from gralloc
-    virtual void  enableNativeBuffers(void) = 0;
-    /// not interest for now, may be used by Android to accept external video frame memory from gralloc
-    virtual Decode_Status  getClientNativeWindowBuffer(void *bufferHeader, void *nativeBufferHandle) = 0;
-    /// not interest for now, may be used by Android to accept external video frame memory from gralloc
-    virtual Decode_Status flagNativeBuffer(void * pBuffer) = 0;
 };
 }
 #endif                          /* VIDEO_DECODER_INTERFACE_H_ */

--- a/tests/Android.mk
+++ b/tests/Android.mk
@@ -5,6 +5,7 @@ include $(CLEAR_VARS)
 include $(LOCAL_PATH)/../common.mk
 
 LOCAL_SRC_FILES := \
+        decodehelp.cpp \
         decodeinput.cpp \
         vppinputoutput.cpp \
         v4l2decode.cpp

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -117,7 +117,7 @@ YAMI_VPP_CFLAGS = \
 if ENABLE_CAPI
 decodecapi_LDADD    = $(CAPI_DECODE_LIBS)
 decodecapi_LDFLAGS  = $(YAMI_STATIC_LDFLAGS)
-decodecapi_SOURCES  = decodecapi.c decodehelp.h  decodeInputCapi.cpp decodeOutputCapi.cpp $(DECODE_INPUT_SOURCES) decodeoutput.cpp
+decodecapi_SOURCES  = decodecapi.c decodehelp.cpp  decodeInputCapi.cpp decodeOutputCapi.cpp $(DECODE_INPUT_SOURCES) decodeoutput.cpp
 if ENABLE_TESTS_GLES
 decodecapi_SOURCES += ../egl/egl_util.c ./egl/gles2_help.c
 endif
@@ -126,9 +126,9 @@ encodecapi_LDADD    = $(CAPI_ENCODE_LIBS)
 encodecapi_LDFLAGS  = $(YAMI_STATIC_LDFLAGS)
 encodecapi_SOURCES  = encodecapi.c encodehelp.h encodeinput.cpp encodeInputCamera.cpp encodeInputDecoder.cpp encodeInputCapi.cpp $(DECODE_INPUT_SOURCES)
 else
-yamidecode_LDADD    = $(YAMI_DECODE_LIBS)
-yamidecode_LDFLAGS  = $(YAMI_DECODE_LDFLAGS)
-yamidecode_SOURCES  = decode.cpp decodehelp.h $(DECODE_INPUT_SOURCES) decodeoutput.cpp
+yamidecode_LDADD    = $(YAMI_VPP_LIBS)
+yamidecode_LDFLAGS  = $(YAMI_VPP_LDFLAGS)
+yamidecode_SOURCES  = decode.cpp decodehelp.cpp $(DECODE_INPUT_SOURCES) decodeoutput.cpp vppinputoutput.cpp vppinputdecode.cpp vppoutputencode.cpp encodeinput.cpp encodeInputCamera.cpp encodeInputDecoder.cpp
 if ENABLE_TESTS_GLES
 yamidecode_SOURCES += ../egl/egl_util.c ./egl/gles2_help.c
 endif
@@ -139,7 +139,7 @@ yamiencode_SOURCES  = encode.cpp encodeinput.cpp encodeInputCamera.cpp encodeInp
 
 v4l2decode_LDADD   = $(V4L2_DECODE_LIBS)
 v4l2decode_LDFLAGS = $(V4L2_DECODE_LDFLAGS)
-v4l2decode_SOURCES = v4l2decode.cpp decodehelp.h $(DECODE_INPUT_SOURCES)
+v4l2decode_SOURCES = v4l2decode.cpp decodehelp.cpp $(DECODE_INPUT_SOURCES)
 
 v4l2decode_SOURCES += ./egl/gles2_help.c
 v4l2decode_LDADD += -ldl

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -115,9 +115,10 @@ YAMI_VPP_CFLAGS = \
 	$(NULL)
 
 if ENABLE_CAPI
+CAPI_DECODE_LIBS += $(YAMI_VPP_LIBS)
 decodecapi_LDADD    = $(CAPI_DECODE_LIBS)
 decodecapi_LDFLAGS  = $(YAMI_STATIC_LDFLAGS)
-decodecapi_SOURCES  = decodecapi.c decodehelp.cpp  decodeInputCapi.cpp decodeOutputCapi.cpp $(DECODE_INPUT_SOURCES) decodeoutput.cpp
+decodecapi_SOURCES  = decode.cpp decodehelp.cpp $(DECODE_INPUT_SOURCES) decodeoutput.cpp vppinputoutput.cpp vppinputdecode.cpp vppoutputencode.cpp encodeinput.cpp encodeInputCamera.cpp encodeInputDecoder.cpp vppinputdecodecapi.cpp
 if ENABLE_TESTS_GLES
 decodecapi_SOURCES += ../egl/egl_util.c ./egl/gles2_help.c
 endif

--- a/tests/decode.cpp
+++ b/tests/decode.cpp
@@ -22,6 +22,11 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
+#ifdef __ENABLE_CAPI__
+#include "vppinputdecodecapi.h"
+#endif
+
 #include "vppinputdecode.h"
 #include "decodeoutput.h"
 #include "common/utils.h"
@@ -40,7 +45,11 @@ SharedPtr<VppInput> createInput(DecodeParameter& para, SharedPtr<NativeDisplay>&
         fprintf(stderr, "VppInput create failed.\n");
         return input;
     }
+#ifdef __ENABLE_CAPI__
+    SharedPtr<VppInputDecodeCapi> inputDecode = std::tr1::dynamic_pointer_cast<VppInputDecodeCapi>(input);
+#else
     SharedPtr<VppInputDecode> inputDecode = std::tr1::dynamic_pointer_cast<VppInputDecode>(input);
+#endif
     if (!inputDecode) {
         input.reset();
         fprintf(stderr, "createInput failed, cannot convert VppInput to VppInputDecode\n");

--- a/tests/decode.cpp
+++ b/tests/decode.cpp
@@ -1,8 +1,8 @@
 /*
- *  decode.cpp - h264 decode test
+ *  decode.cpp - decode test
  *
  *  Copyright (C) 2011-2014 Intel Corporation
- *    Author: Halley Zhao<halley.zhao@intel.com>
+ *    Author: Lin Hai<hai1.lin@intel.com>
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public License
@@ -22,148 +22,89 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include "vppinputdecode.h"
+#include "decodeoutput.h"
+#include "common/utils.h"
+#include "decodehelp.h"
 
 #include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
+#include <fcntl.h>
 #include <unistd.h>
-#include <assert.h>
+#include <limits.h>
 
-#include "common/log.h"
-#include "common/utils.h"
-#include "VideoDecoderHost.h"
-#include "decodeinput.h"
-#include "decodeoutput.h"
-#include "decodehelp.h"
-#ifdef __ENABLE_X11__
-// #include <X11/Xlib.h>
-#endif
-
-using namespace YamiMediaCodec;
-
-int main(int argc, char** argv)
+SharedPtr<VppInput> createInput(DecodeParameter& para, SharedPtr<NativeDisplay>& display)
 {
-    IVideoDecoder *decoder = NULL;
-    DecodeInput *input;
-    DecodeOutput *output;
-    VideoDecodeBuffer inputBuffer;
-    VideoConfigBuffer configBuffer;
-    const VideoFormatInfo *formatInfo = NULL;
-    Decode_Status status;
-    class CalcFps calcFpsGross, calcFpsNet;
-    uint32_t skipFrameCount4NetFps = 0;
-#ifdef __ENABLE_X11__
-    // XInitThreads();
-#endif
-    calcFpsGross.setAnchor();
-    yamiTraceInit();
-    if (!process_cmdline(argc, argv))
-        return -1;
-#if !__ENABLE_TESTS_GLES__
-    if (renderMode > 1) {
-        fprintf(stderr, "renderMode=%d is not supported, please rebuild with --enable-tests-gles option\n", renderMode);
-        return -1;
+    SharedPtr<VppInput> input(VppInput::create(para.inputFile, para.renderFourcc, para.width, para.height));
+    if (!input) {
+        fprintf(stderr, "VppInput create failed.\n");
+        return input;
     }
-#endif
-#if !__ENABLE_MD5__
-    if (renderMode == -2) {
-        fprintf(stderr, "renderMode=%d is not supported, you must compile libyami without --disable-md5 option "
-                "and package libssl-dev should be installed\n", renderMode);
-        return -1;
+    SharedPtr<VppInputDecode> inputDecode = std::tr1::dynamic_pointer_cast<VppInputDecode>(input);
+    if (!inputDecode) {
+        input.reset();
+        fprintf(stderr, "createInput failed, cannot convert VppInput to VppInputDecode\n");
+        return input;
     }
-#endif
-    input = DecodeInput::create(inputFileName);
-
-    if (input==NULL) {
-        fprintf(stderr, "fail to init input stream\n");
-        return -1;
+    if (!inputDecode->config(*display)) {
+        input.reset();
+        fprintf(stderr, "VppInputDecode config failed.\n");
+        return input;
     }
+    return input;
+}
 
-    decoder = createVideoDecoder(input->getMimeType());
-    assert(decoder != NULL);
-
-    output = DecodeOutput::create(decoder, renderMode);
-    if (!output || !configDecodeOutput(output)) {
-        fprintf(stderr, "failed to config decode output of mode: %d\n", renderMode);
-        delete input;
-        delete output;
-        return -1;
-    }
-
-    memset(&configBuffer,0,sizeof(VideoConfigBuffer));
-    configBuffer.profile = VAProfileNone;
-    const string codecData = input->getCodecData();
-    if (codecData.size()) {
-        configBuffer.data = (uint8_t*)codecData.data();
-        configBuffer.size = codecData.size();
-    }
-
-    if (input->getWidth() && input->getHeight()) {
-        configBuffer.width = input->getWidth();
-        configBuffer.height = input->getHeight();
-        if (!output->setVideoSize(input->getWidth(), input->getHeight()))
-            assert(0 && "set video size failed");
-    }
-
-    status = decoder->start(&configBuffer);
-    assert(status == DECODE_SUCCESS);
-
-    while (!input->isEOS())
+class DecodeTest {
+public:
+    bool init(int argc, char** argv)
     {
-        if (input->getNextDecodeUnit(inputBuffer)){
-            status = decoder->decode(&inputBuffer);
-        } else
-            break;
-        if (status == DECODE_INVALID_DATA)
-            break;
+        if (!processCmdLine(argc, argv, &m_params)) {
+            fprintf(stderr, "process arguments failed.\n");
+            return false;
+        }
+        m_output.reset(DecodeOutput::create(m_params.renderMode, m_params.renderFourcc, m_params.inputFile, m_params.outputFile.c_str()));
+        if (!m_output) {
+            fprintf(stderr, "DecodeOutput::create failed.\n");
+            return false;
+        }
+        m_nativeDisplay = m_output->nativeDisplay();
+        m_vppInput = createInput(m_params, m_nativeDisplay);
 
-        if (DECODE_FORMAT_CHANGE == status) {
-            formatInfo = decoder->getFormatInfo();
-            if (!output->setVideoSize(formatInfo->width, formatInfo->height)) {
-                assert(0 && "set video size failed");
+        if (!m_nativeDisplay || !m_vppInput) {
+            fprintf(stderr, "DecodeTest init failed.\n");
+            return false;
+        }
+        return true;
+    }
+    bool run()
+    {
+        FpsCalc fps;
+        SharedPtr<VideoFrame> src;
+        uint32_t count = 0;
+        while (m_vppInput->read(src)) {
+            if (!m_output->output(src))
                 break;
-            }
-            // resend the buffer
-            status = decoder->decode(&inputBuffer);
+            count++;
+            fps.addFrame();
+            if (count == m_params.renderFrames)
+                break;
         }
-        if(status != DECODE_SUCCESS) {
-            break;
-        }
-
-        renderOutputFrames(output, frameCount);
-        if (output->renderFrameCount() >= 5 && !skipFrameCount4NetFps) {
-            skipFrameCount4NetFps = output->renderFrameCount();
-            calcFpsNet.setAnchor();
-        }
-
-        if(output->renderFrameCount() == frameCount)
-            break;
+        fps.log();
+        return true;
     }
 
-#if 1
-    // send EOS to decoder
-    inputBuffer.data = NULL;
-    inputBuffer.size = 0;
-    status = decoder->decode(&inputBuffer);
-#endif
+private:
+    SharedPtr<DecodeOutput> m_output;
+    SharedPtr<NativeDisplay> m_nativeDisplay;
+    SharedPtr<VppInput> m_vppInput;
+    DecodeParameter m_params;
+};
 
-    // drain the output buffer
-    renderOutputFrames(output, frameCount, true);
-
-    calcFpsGross.fps(output->renderFrameCount());
-    if (output->renderFrameCount() > skipFrameCount4NetFps)
-        calcFpsNet.fps(output->renderFrameCount()-skipFrameCount4NetFps);
-
-    possibleWait(input->getMimeType());
-
-    decoder->stop();
-    releaseVideoDecoder(decoder);
-
-    delete input;
-    delete output;
-
-    if (dumpOutputName)
-        free(dumpOutputName);
-    fprintf(stderr, "decode done\n");
+int main(int argc, char* argv[])
+{
+    DecodeTest decode;
+    if (!decode.init(argc, argv))
+        return 1;
+    decode.run();
     return 0;
 }

--- a/tests/decodehelp.cpp
+++ b/tests/decodehelp.cpp
@@ -1,0 +1,143 @@
+/*
+ *  decodehelp.h - decode test help
+ *
+ *  Copyright (C) 2011-2014 Intel Corporation
+ *    Author: Halley Zhao<halley.zhao@intel.com>
+ *            Xin Tang<xin.t.tang@intel.com>
+ *            Lin Hai<hai1.lin@intel.com>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2.1
+ *  of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include "decodehelp.h"
+
+#include "common/utils.h"
+#include "interface/VideoCommonDefs.h"
+
+#include <ctype.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+
+using namespace YamiMediaCodec;
+
+static void printHelp(const char* app)
+{
+    printf("%s <options>\n", app);
+    printf("   -i media file to decode\n");
+    printf("   -w wait before quit: 0:no-wait, 1:auto(jpeg wait), 2:wait\n");
+    printf("   -f dumped fourcc [*]\n");
+    printf("   -o dumped output dir\n");
+    printf("   -n specifiy how many frames to be decoded\n");
+    printf("   -m <render mode>\n");
+    printf("     -2: print MD5 by per frame and the whole decoded file MD5\n");
+    printf("     -1: skip video rendering [*]\n");
+    printf("      0: dump video frame to file\n");
+    printf("      1: render to X window [*]\n");
+    printf("      2: texture: render to Pixmap + texture from Pixmap [*]\n");
+    printf("      3: texture: export video frame as drm name (RGBX) + texture from drm name\n");
+    printf("      4: texture: export video frame as dma_buf(RGBX) + texutre from dma_buf\n");
+    printf("      5: texture: export video frame as dma_buf(NV12) + texture from dma_buf. not implement yet\n");
+    printf(" [*] v4l2decode doesn't support the option\n");
+}
+
+bool processCmdLine(int argc, char** argv, DecodeParameter* parameters)
+{
+    bool isSetFourcc = false;
+    std::string outputFile;
+    parameters->renderFrames = UINT_MAX;
+    parameters->waitBeforeQuit = 1;
+    parameters->renderMode = 1;
+    parameters->inputFile = NULL;
+
+    char opt;
+    while ((opt = getopt(argc, argv, "h:m:n:i:f:o:w:?")) != -1) {
+        switch (opt) {
+        case 'h':
+        case '?':
+            printHelp(argv[0]);
+            return false;
+        case 'i':
+            parameters->inputFile = optarg;
+            break;
+        case 'w':
+            parameters->waitBeforeQuit = atoi(optarg);
+            break;
+        case 'm':
+            parameters->renderMode = atoi(optarg);
+            break;
+        case 'n':
+            parameters->renderFrames = atoi(optarg);
+            break;
+        case 'f':
+            if (strlen(optarg) == 4) {
+                parameters->renderFourcc = YAMI_FOURCC(toupper(optarg[0]), toupper(optarg[1]), toupper(optarg[2]), toupper(optarg[3]));
+                isSetFourcc = true;
+            }
+            else {
+                fprintf(stderr, "invalid fourcc: %s\n", optarg);
+                return false;
+            }
+            break;
+        case 'o':
+            outputFile = optarg;
+            break;
+        default:
+            printHelp(argv[0]);
+            break;
+        }
+    }
+    if (!parameters->inputFile) {
+        fprintf(stderr, "no input media file specified.\n");
+        return false;
+    }
+    if (outputFile.empty())
+        outputFile = "./";
+    parameters->outputFile = outputFile;
+    if (!isSetFourcc)
+        parameters->renderFourcc = guessFourcc(parameters->outputFile.c_str());
+    int width, height;
+    if (guessResolution(parameters->inputFile, width, height)) {
+        parameters->width = width;
+        parameters->height = height;
+    }
+    return true;
+}
+
+bool possibleWait(const char* mimeType, const DecodeParameter* parameters)
+{
+    // waitBeforeQuit 0:nowait, 1:auto(jpeg wait), 2:wait
+    switch (parameters->waitBeforeQuit) {
+    case 0:
+        break;
+    case 1:
+        if (parameters->renderMode == 0 || strcmp(mimeType, YAMI_MIME_JPEG))
+            break;
+    case 2:
+        fprintf(stdout, "press any key to continue ...");
+        getchar();
+        break;
+    default:
+        break;
+    }
+
+    return true;
+}

--- a/tests/decodehelp.h
+++ b/tests/decodehelp.h
@@ -3,7 +3,8 @@
  *
  *  Copyright (C) 2011-2014 Intel Corporation
  *    Author: Halley Zhao<halley.zhao@intel.com>
- *             Xin Tang<xin.t.tang@intel.com>
+ *            Xin Tang<xin.t.tang@intel.com>
+ *            Lin Hai<hai1.lin@intel.com>
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public License
@@ -20,132 +21,25 @@
  *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  *  Boston, MA 02110-1301 USA
  */
-#ifndef __DECODE_HELP__
-#define __DECODE_HELP__
+#ifndef decodehelp_h
+#define decodehelp_h
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
+#include <stdint.h>
+#include <string>
 
-#ifdef __cpluscplus
-extern "C" {
-#endif
+typedef struct DecodeParameter {
+    char* inputFile;
+    int width;
+    int height;
+    short renderMode;
+    short waitBeforeQuit;
+    uint32_t renderFrames;
+    uint32_t renderFourcc;
+    std::string outputFile;
+} DecodeParameter;
 
-#include "interface/VideoDecoderDefs.h"
-#ifdef __ENABLE_CAPI__
-#include "capi/VideoDecoderCapi.h"
-#else
-#include "interface/VideoDecoderHost.h"
-#endif
-#include "common/log.h"
-#include <unistd.h>
-#include <limits.h>
+bool processCmdLine(int argc, char** argv, DecodeParameter* parameters);
 
-#ifndef VA_FOURCC_I420
-#define VA_FOURCC_I420 VA_FOURCC('I','4','2','0')
-#endif
-char *dumpOutputName = NULL;
-uint32_t dumpFourcc = VA_FOURCC_I420;
-char *inputFileName = NULL;
-int renderMode = 1;
-static int32_t waitBeforeQuit = 1;
-static uint32_t frameCount = UINT_MAX;
+bool possibleWait(const char* mimeType, const DecodeParameter* parameters);
 
-static void print_help(const char* app)
-{
-    printf("%s <options>\n", app);
-    printf("   -i media file to decode\n");
-    printf("   -w wait before quit: 0:no-wait, 1:auto(jpeg wait), 2:wait\n");
-    printf("   -f dumped fourcc [*]\n");
-    printf("   -o dumped output dir\n");
-    printf("   -n specifiy how many frames to be decoded\n");
-    printf("   -m <render mode>\n");
-    printf("     -2: print MD5 by per frame and the whole decoded file MD5\n");
-    printf("     -1: skip video rendering [*]\n");
-    printf("      0: dump video frame to file\n");
-    printf("      1: render to X window [*]\n");
-    printf("      2: texture: render to Pixmap + texture from Pixmap [*]\n");
-    printf("      3: texture: export video frame as drm name (RGBX) + texture from drm name\n");
-    printf("      4: texture: export video frame as dma_buf(RGBX) + texutre from dma_buf\n");
-    printf("      5: texture: export video frame as dma_buf(NV12) + texture from dma_buf. not implement yet\n");
-    printf(" [*] v4l2decode doesn't support the option\n");
-}
-
-static bool process_cmdline(int argc, char *argv[])
-{
-    char opt;
-
-    while ((opt = getopt(argc, argv, "h:m:n:i:f:o:w:?")) != -1)
-    {
-        switch (opt) {
-        case 'h':
-        case '?':
-            print_help (argv[0]);
-            return false;
-        case 'i':
-            inputFileName = optarg;
-            break;
-        case 'w':
-            if (optarg)
-                waitBeforeQuit = atoi(optarg);
-            break;
-        case 'm':
-            if (optarg)
-                renderMode = atoi(optarg);
-            break;
-        case 'n':
-            if (optarg)
-                frameCount = atoi(optarg);
-            break;
-        case 'f':
-            if (optarg) {
-                if (strlen(optarg) == 4) {
-                    dumpFourcc = VA_FOURCC(optarg[0], optarg[1], optarg[2], optarg[3]);
-                } else {
-                    fprintf(stderr, "invalid fourcc: %s\n", optarg);
-                    return false;
-                }
-            }
-            break;
-        case 'o':
-            if (optarg)
-                dumpOutputName = strdup(optarg);
-            break;
-        default:
-            print_help(argv[0]);
-            break;
-        }
-    }
-    if (!inputFileName) {
-        fprintf(stderr, "no input media file specified\n");
-        return false;
-    }
-    fprintf(stderr, "input file: %s, renderMode: %d\n", inputFileName, renderMode);
-
-    if (!dumpOutputName)
-        dumpOutputName = strdup ("./");
-
-    return true;
-}
-
-static bool possibleWait(const char* mimeType)
-{
-    // waitBeforeQuit 0:no-wait, 1:auto(jpeg wait), 2:wait
-    switch(waitBeforeQuit) {
-    case 0:
-        break;
-    case 1:
-        if (renderMode == 0 || strcmp(mimeType, YAMI_MIME_JPEG))
-            break;
-    case 2:
-        fprintf(stdout, "press any key to continue ...");
-        getchar();
-        break;
-    default:
-        break;
-    }
-
-    return true;
-}
-
-#endif
+#endif //decodehelp_h

--- a/tests/decodeoutput.h
+++ b/tests/decodeoutput.h
@@ -3,8 +3,8 @@
  *
  *  Copyright (C) 2011-2014 Intel Corporation
  *    Author: Halley Zhao<halley.zhao@intel.com>
- *    Author: Xu Guangxin <guangxin.xu@intel.com>
- *    Author: Liu Yangbin <yangbinx.liu@intel.com>
+ *            Xu Guangxin<guangxin.xu@intel.com>
+ *            Liu Yangbin<yangbinx.liu@intel.com>
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public License
@@ -25,114 +25,30 @@
 #ifndef decodeoutput_h
 #define decodeoutput_h
 
-#include "VideoDecoderDefs.h"
-#include "VideoDecoderInterface.h"
+#include "vppinputoutput.h"
+#include "VideoPostProcessHost.h"
+#include "VideoCommonDefs.h"
+#include "common/common_def.h"
 
-#include <stdio.h>
-#include <vector>
-#include <sstream>
-
-#if  __ENABLE_MD5__
-#include <openssl/md5.h>
-#endif
-
-using namespace YamiMediaCodec;
+#include <string>
+#include <cassert>
 
 class DecodeOutput
 {
 public:
-    static DecodeOutput* create(IVideoDecoder* decoder, int mode);
-    virtual bool setVideoSize(int width, int height);
-    virtual Decode_Status renderOneFrame(bool drain) = 0;
-    Decode_Status processOneFrame(bool drain);
-    uint32_t renderFrameCount() { return m_renderFrames; };
-
-    virtual ~DecodeOutput() {};
-
+    static DecodeOutput* create(int renderMode, uint32_t fourcc, const char* inputFile, const char* outputFile);
+    virtual bool output(const SharedPtr<VideoFrame>& frame) = 0;
+    SharedPtr<NativeDisplay> nativeDisplay();
+    virtual ~DecodeOutput() {}
 protected:
-    DecodeOutput(IVideoDecoder* decoder);
-    IVideoDecoder* m_decoder;
+    virtual bool setVideoSize(uint32_t with, uint32_t height);
+
+    virtual bool init();
+
     uint32_t m_width;
     uint32_t m_height;
-    uint32_t m_renderFrames;
-    VideoFrameRawData m_frame;
+    SharedPtr<VADisplay> m_vaDisplay;
+    SharedPtr<NativeDisplay> m_nativeDisplay;
 };
-
-class DecodeOutputNull: public DecodeOutput
-{
-friend DecodeOutput* DecodeOutput::create(IVideoDecoder* decoder, int mode);
-public:
-    virtual Decode_Status renderOneFrame(bool drain);
-    ~DecodeOutputNull() {};
-
-private:
-    DecodeOutputNull(IVideoDecoder* decoder):DecodeOutput(decoder) {};
-};
-
-class ColorConvert;
-class DecodeOutputRaw : public DecodeOutput
-{
-friend DecodeOutput* DecodeOutput::create(IVideoDecoder* decoder, int mode);
-public:
-    virtual bool config(const char* source, const char* dest, uint32_t fourcc) = 0;
-    virtual Decode_Status renderOneFrame(bool drain);
-    ~DecodeOutputRaw();
-
-protected:
-    virtual bool render(VideoFrameRawData* frame) = 0;
-    void setFourcc(uint32_t fourcc);
-    uint32_t getFourcc();
-    DecodeOutputRaw(IVideoDecoder* decoder);
-
-private:
-    ColorConvert* m_convert;
-    uint32_t m_srcFourcc;
-    uint32_t m_destFourcc;
-    bool m_enableSoftI420Convert;
-    DISALLOW_COPY_AND_ASSIGN(DecodeOutputRaw);
-};
-
-class DecodeOutputFileDump : public DecodeOutputRaw
-{
-friend DecodeOutput* DecodeOutput::create(IVideoDecoder* decoder, int mode);
-public:
-    bool config(const char* source, const char* dest, uint32_t fourcc);
-    virtual bool setVideoSize(int width, int height);
-    ~DecodeOutputFileDump();
-
-protected:
-    DecodeOutputFileDump(IVideoDecoder* decoder);
-    virtual bool render(VideoFrameRawData* frame);
-
-private:
-    std::ostringstream m_name;
-    FILE* m_fp;
-    bool m_appendSize;
-
-};
-
-#if  __ENABLE_MD5__
-class DecodeOutputExtractMD5 : public DecodeOutputRaw
-{
-friend DecodeOutput* DecodeOutput::create(IVideoDecoder* decoder, int mode);
-public:
-    DecodeOutputExtractMD5(IVideoDecoder* decoder);
-    ~DecodeOutputExtractMD5();
-
-    virtual bool render(VideoFrameRawData* frame);
-
-    bool config(const char* source, const char* dest, uint32_t fourcc);
-
-private:
-	std::string extractMd5ToHexStr(MD5_CTX& ctx);
-
-    MD5_CTX m_md5Ctx;
-    FILE* m_fp;
-};
-#endif
-
-//help functions
-bool renderOutputFrames(DecodeOutput* output, uint32_t maxframes, bool drain = false);
-bool configDecodeOutput(DecodeOutput* output);
 
 #endif //decodeoutput_h

--- a/tests/encodeInputDecoder.h
+++ b/tests/encodeInputDecoder.h
@@ -26,12 +26,14 @@
 #include "encodeinput.h"
 
 #include "VideoDecoderHost.h"
+#include <map>
 
 using namespace YamiMediaCodec;
 
+class MyRawImage;
 class EncodeInputDecoder : public  EncodeInput {
 public:
-    EncodeInputDecoder(DecodeInput* input):m_input(input), m_decoder(NULL), m_isEOS(false){}
+    EncodeInputDecoder(DecodeInput* input);
     ~EncodeInputDecoder();
     virtual bool init(const char* inputFileName, uint32_t fourcc, int width, int height);
     virtual bool getOneFrameInput(VideoFrameRawData &inputBuffer);
@@ -42,6 +44,11 @@ private:
     DecodeInput* m_input;
     IVideoDecoder* m_decoder;
     bool m_isEOS;
+
+    typedef std::map<uint32_t, SharedPtr<MyRawImage> > ImageMap;
+
+    ImageMap m_images;
+    uint32_t m_id;
     DISALLOW_COPY_AND_ASSIGN(EncodeInputDecoder);
 };
 #endif

--- a/tests/encodecapi.c
+++ b/tests/encodecapi.c
@@ -77,21 +77,21 @@ int main(int argc, char** argv)
     //configure encoding parameters
     VideoParamsCommon encVideoParams;
     encVideoParams.size = sizeof(VideoParamsCommon);
-    getParameters(encoder, VideoParamsTypeCommon, &encVideoParams);
+    encodeGetParameters(encoder, VideoParamsTypeCommon, &encVideoParams);
     setEncoderParameters(&encVideoParams);
     encVideoParams.size = sizeof(VideoParamsCommon);
-    setParameters(encoder, VideoParamsTypeCommon, &encVideoParams);
+    encodeSetParameters(encoder, VideoParamsTypeCommon, &encVideoParams);
 
     VideoConfigAVCStreamFormat streamFormat;
     streamFormat.size = sizeof(VideoConfigAVCStreamFormat);
     streamFormat.streamFormat = AVC_STREAM_FORMAT_ANNEXB;
-    setParameters(encoder, VideoConfigTypeAVCStreamFormat, &streamFormat);
+    encodeSetParameters(encoder, VideoConfigTypeAVCStreamFormat, &streamFormat);
 
     status = encodeStart(encoder);
     assert(status == ENCODE_SUCCESS);
 
     //init output buffer
-    getMaxOutSize(encoder, &maxOutSize);
+    encodeGetMaxOutSize(encoder, &maxOutSize);
 
     if (!createOutputBuffer(&outputBuffer, maxOutSize)) {
         fprintf (stderr, "fail to init input stream\n");
@@ -102,7 +102,7 @@ int main(int argc, char** argv)
     {
         memset(&inputBuffer, 0, sizeof(inputBuffer));
         if (getOneFrameInput(input, &inputBuffer)){
-            status = encode(encoder, &inputBuffer);
+            status = encodeEncodeRawData(encoder, &inputBuffer);
             recycleOneFrameInput(input, &inputBuffer);
         }
         else

--- a/tests/vppinputdecode.cpp
+++ b/tests/vppinputdecode.cpp
@@ -46,7 +46,8 @@ bool VppInputDecode::config(NativeDisplay& nativeDisplay)
         configBuffer.data = (uint8_t*)codecData.data();
         configBuffer.size = codecData.size();
     }
-
+    configBuffer.width = m_input->getWidth();
+    configBuffer.height = m_input->getHeight();
     Decode_Status status = m_decoder->start(&configBuffer);
     if (status == DECODE_SUCCESS) {
         //read first frame to update width height
@@ -68,6 +69,8 @@ bool VppInputDecode::read(SharedPtr<VideoFrame>& frame)
         frame = m_decoder->getOutput();
         if (frame)
             return true;
+        if (m_error || m_eos)
+            return false;
         VideoDecodeBuffer inputBuffer;
         Decode_Status status = DECODE_FAIL;
         if (m_input->getNextDecodeUnit(inputBuffer)) {
@@ -83,15 +86,17 @@ bool VppInputDecode::read(SharedPtr<VideoFrame>& frame)
                 status = m_decoder->decode(&inputBuffer);
             }
         } else { /*EOS, need to flush*/
-            if(m_eos)
-                return false;
             inputBuffer.data = NULL;
             inputBuffer.size = 0;
             status = m_decoder->decode(&inputBuffer);
             m_eos = true;
         }
-        if (status != DECODE_SUCCESS)
-            return false;
+        if (status != DECODE_SUCCESS) { /*failed, need to flush*/
+            inputBuffer.data = NULL;
+            inputBuffer.size = 0;
+            m_decoder->decode(&inputBuffer);
+            m_error = true;
+        }
     }
 
 }

--- a/tests/vppinputdecode.h
+++ b/tests/vppinputdecode.h
@@ -29,7 +29,11 @@
 class VppInputDecode : public VppInput
 {
 public:
-    VppInputDecode():m_eos(false) {}
+    VppInputDecode()
+        : m_eos(false)
+        , m_error(false)
+    {
+    }
     bool init(const char* inputFileName, uint32_t fourcc = 0, int width = 0, int height = 0);
     bool read(SharedPtr<VideoFrame>& frame);
 
@@ -37,6 +41,7 @@ public:
     virtual ~VppInputDecode() {}
 private:
     bool m_eos;
+    bool m_error;
     SharedPtr<IVideoDecoder> m_decoder;
     SharedPtr<DecodeInput>   m_input;
     SharedPtr<VideoFrame>    m_first;

--- a/tests/vppinputdecodecapi.cpp
+++ b/tests/vppinputdecodecapi.cpp
@@ -1,0 +1,105 @@
+/*
+ *  vppinputdecodecapi.cpp - vpp input from decoded file for capi
+ *
+ *  Copyright (C) 2015 Intel Corporation
+ *    Author: Lin Hai<hai1.lin@intel.com>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2.1
+ *  of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "vppinputdecodecapi.h"
+
+static void freeFrame(VideoFrame* frame)
+{
+    frame->free(frame);
+}
+
+VppInputDecodeCapi::~VppInputDecodeCapi()
+{
+    decodeStop(m_decoder);
+    releaseDecoder(m_decoder);
+}
+
+bool VppInputDecodeCapi::init(const char* inputFileName, uint32_t /*fourcc*/, int /*width*/, int /*height*/)
+{
+    m_input.reset(DecodeInput::create(inputFileName));
+    if (!m_input)
+        return false;
+    m_decoder = createDecoder(m_input->getMimeType());
+    if (!m_decoder) {
+        fprintf(stderr, "failed create decoder for %s", m_input->getMimeType());
+        return false;
+    }
+    return true;
+}
+
+bool VppInputDecodeCapi::config(NativeDisplay& nativeDisplay)
+{
+    decodeSetNativeDisplay(m_decoder, &nativeDisplay);
+
+    VideoConfigBuffer configBuffer;
+    memset(&configBuffer, 0, sizeof(configBuffer));
+    configBuffer.profile = VAProfileNone;
+    const string codecData = m_input->getCodecData();
+    if (codecData.size()) {
+        configBuffer.data = (uint8_t*)codecData.data();
+        configBuffer.size = codecData.size();
+    }
+    configBuffer.width = m_input->getWidth();
+    configBuffer.height = m_input->getHeight();
+    Decode_Status status = decodeStart(m_decoder, &configBuffer);
+    return status == DECODE_SUCCESS;
+}
+
+bool VppInputDecodeCapi::read(SharedPtr<VideoFrame>& frame)
+{
+    while (1) {
+        VideoFrame* tmp = decodeGetOutput(m_decoder);
+        if (tmp) {
+            frame.reset(tmp, freeFrame);
+            return true;
+        }
+        if (m_error || m_eos)
+            return false;
+        VideoDecodeBuffer inputBuffer;
+        Decode_Status status = DECODE_FAIL;
+        if (m_input->getNextDecodeUnit(inputBuffer)) {
+            status = decodeDecode(m_decoder, &inputBuffer);
+            if (DECODE_FORMAT_CHANGE == status) {
+                const VideoFormatInfo* info = decodeGetFormatInfo(m_decoder);
+                ERROR("resolution changed to %dx%d", info->width, info->height);
+                //resend the buffer
+                status = decodeDecode(m_decoder, &inputBuffer);
+            }
+        }
+        else { /*EOS, need to flush*/
+            inputBuffer.data = NULL;
+            inputBuffer.size = 0;
+            decodeDecode(m_decoder, &inputBuffer);
+            m_eos = true;
+        }
+        if (status != DECODE_SUCCESS) { /*failed, need to flush*/
+            inputBuffer.data = NULL;
+            inputBuffer.size = 0;
+            decodeDecode(m_decoder, &inputBuffer);
+            m_error = true;
+        }
+    }
+}

--- a/tests/vppinputdecodecapi.h
+++ b/tests/vppinputdecodecapi.h
@@ -1,0 +1,51 @@
+/*
+ *  vppinputdecodecapi.h - vpp input from decoded file for capi
+ *
+ *  Copyright (C) 2015 Intel Corporation
+ *    Author: Lin Hai<hai1.lin@intel.com>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2.1
+ *  of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA
+ */
+
+#ifndef vppinputdecodecapi_h
+#define vppinputdecodecapi_h
+
+#include "VideoDecoderHost.h"
+#include "decodeinput.h"
+#include "vppinputoutput.h"
+#include "capi/VideoDecoderCapi.h"
+
+class VppInputDecodeCapi : public VppInput {
+public:
+    VppInputDecodeCapi()
+        : m_eos(false)
+        , m_error(false)
+    {
+    }
+    ~VppInputDecodeCapi();
+
+    bool init(const char* inputFileName, uint32_t fourcc = 0, int width = 0, int height = 0);
+    bool read(SharedPtr<VideoFrame>& frame);
+    bool config(NativeDisplay& nativeDisplay);
+
+private:
+    bool m_eos;
+    bool m_error;
+    DecodeHandler m_decoder;
+    SharedPtr<DecodeInput> m_input;
+};
+
+#endif //vppinputdecodecapi_h

--- a/tests/vppinputoutput.cpp
+++ b/tests/vppinputoutput.cpp
@@ -199,12 +199,6 @@ bool VppOutputFile::init(const char* outputFileName, uint32_t fourcc, int width,
         ERROR("output file name is null");
         return false;
     }
-    if(!fourcc || !width || !height) {
-        if (!guessFormat(outputFileName, fourcc, width, height)) {
-            ERROR("guess format from %s failed", outputFileName);
-            return false;
-        }
-    }
     m_fourcc = fourcc;
     m_width = width;
     m_height = height;

--- a/tests/vppinputoutput.cpp
+++ b/tests/vppinputoutput.cpp
@@ -43,9 +43,13 @@ using namespace YamiMediaCodec;
 SharedPtr<VADisplay> createVADisplay()
 {
     SharedPtr<VADisplay> display;
-    int fd = open("/dev/dri/card0", O_RDWR);
+    int fd = open("/dev/dri/renderD128", O_RDWR);
     if (fd < 0) {
-        ERROR("open card0 failed");
+        ERROR("can't open /dev/dri/renderD128, try to /dev/dri/card0");
+        fd = open("/dev/dri/card0", O_RDWR);
+    }
+    if (fd < 0) {
+        ERROR("can't open drm device");
         return display;
     }
     VADisplay vadisplay = vaGetDisplayDRM(fd);

--- a/tests/vppinputoutput.cpp
+++ b/tests/vppinputoutput.cpp
@@ -36,7 +36,9 @@
 #include "vppinputoutput.h"
 #include "vppoutputencode.h"
 #include "vppinputdecode.h"
-
+#ifdef __ENABLE_CAPI__
+#include "vppinputdecodecapi.h"
+#endif
 using namespace YamiMediaCodec;
 
 #ifndef ANDROID
@@ -71,9 +73,15 @@ SharedPtr<VppInput> VppInput::create(const char* inputFileName, uint32_t fourcc,
     if (!inputFileName)
         return input;
 
+#ifdef __ENABLE_CAPI__
+    input.reset(new VppInputDecodeCapi);
+    if (input->init(inputFileName, fourcc, width, height))
+        return input;
+#else
     input.reset(new VppInputDecode);
     if(input->init(inputFileName, fourcc, width, height))
         return input;
+#endif
     input.reset(new VppInputFile);
     if (input->init(inputFileName, fourcc, width, height))
         return input;

--- a/tests/vppinputoutput.h
+++ b/tests/vppinputoutput.h
@@ -257,8 +257,7 @@ public:
     int getWidth() { return m_width;}
     int getHeight() { return m_height;}
 
-    virtual ~VppInput() {};
-
+    virtual ~VppInput() {}
 protected:
     uint32_t m_fourcc;
     int m_width;

--- a/tests/vppinputoutput.h
+++ b/tests/vppinputoutput.h
@@ -89,6 +89,7 @@ public:
     }
     bool setFormat(uint32_t fourcc, int width, int height)
     {
+        destroySurfaces();
         m_surfaces.resize(m_poolsize);
         VASurfaceAttrib attrib;
         attrib.flags = VA_SURFACE_ATTRIB_SETTABLE;
@@ -128,11 +129,16 @@ public:
     {
         return m_pool->alloc();
     }
-    ~PooledFrameAllocator()
+    void destroySurfaces()
     {
         if (m_surfaces.size())
             vaDestroySurfaces(*m_display, &m_surfaces[0], m_surfaces.size());
     }
+    ~PooledFrameAllocator()
+    {
+        destroySurfaces();
+    }
+
 private:
     SharedPtr<VADisplay> m_display;
     std::vector<VASurfaceID> m_surfaces;
@@ -164,8 +170,10 @@ public:
             return false;
         }
         uint32_t byteWidth[3], byteHeight[3], planes;
-        if (!getPlaneResolution(image.format.fourcc, image.width, image.height, byteWidth, byteHeight, planes)) {
-            ERROR("get plane reoslution failed for %x, %dx%d", image.format.fourcc, image.width, image.height);
+        //image.width is not equal to frame->crop.width.
+        //for supporting VPG Driver, use YV12 to replace I420
+        if (!getPlaneResolution(frame->fourcc, frame->crop.width, frame->crop.height, byteWidth, byteHeight, planes)) {
+            ERROR("get plane reoslution failed for %x, %dx%d", frame->fourcc, frame->crop.width, frame->crop.height);
             return false;
         }
         char* buf;

--- a/v4l2/v4l2_decode.cpp
+++ b/v4l2/v4l2_decode.cpp
@@ -200,31 +200,30 @@ bool V4l2Decoder::outputPulse(uint32_t &index)
 #else
 bool V4l2Decoder::outputPulse(uint32_t &index)
 {
-    Decode_Status status = DECODE_SUCCESS;
-
-    VideoFrameRawData *frame=NULL;
+    SharedPtr<VideoFrame> frame;
 
     ASSERT(index >= 0 && index < m_maxBufferCount[OUTPUT]);
     DEBUG("index: %d", index);
 
-    frame = &m_outputRawFrames[index];
+    //frame = &m_outputRawFrames[index];
     if (m_memoryType == VIDEO_DATA_MEMORY_TYPE_RAW_COPY) {
-        if (!m_bufferSpace[OUTPUT])
+        /* if (!m_bufferSpace[OUTPUT])
             return false;
         ASSERT(frame->handle);
         frame->fourcc = VA_FOURCC_NV12;
-        frame->memoryType = VIDEO_DATA_MEMORY_TYPE_RAW_COPY;
+        frame->memoryType = VIDEO_DATA_MEMORY_TYPE_RAW_COPY;*/
+        ASSERT("TODO: support raw copy" && 0);
+        return false;
     }
     if (m_memoryType == VIDEO_DATA_MEMORY_TYPE_DRM_NAME || m_memoryType == VIDEO_DATA_MEMORY_TYPE_DMA_BUF) {
         if (m_eglVaapiImages.empty())
             return false;
-        frame->memoryType = VIDEO_DATA_MEMORY_TYPE_SURFACE_ID;
     }
 
 
-    status = m_decoder->getOutput(frame);
+    frame = m_decoder->getOutput();
 
-    if (status == RENDER_NO_AVAILABLE_FRAME) {
+    if (!frame) {
         if (eosState() == EosStateInput) {
             setEosState(EosStateOutput);
             DEBUG("flush-debug flush done on OUTPUT thread");
@@ -232,16 +231,13 @@ bool V4l2Decoder::outputPulse(uint32_t &index)
 
         if (eosState() > EosStateNormal) {
             DEBUG("seek/EOS flush, return empty buffer");
-            return false;
         }
+        return false;
     }
 
-    if (status != RENDER_SUCCESS)
-        return false;
     if (m_memoryType == VIDEO_DATA_MEMORY_TYPE_DRM_NAME || m_memoryType == VIDEO_DATA_MEMORY_TYPE_DMA_BUF) {
         // FIXME, it introduce one GPU copy; which is not necessary in major case and should be avoided in most case
-        m_eglVaapiImages[index]->blt(*frame);
-        m_decoder->renderDone(frame);
+        m_eglVaapiImages[index]->blt(frame);
         if (!m_bindEglImage)
             m_eglVaapiImages[index]->exportFrame(m_memoryType, m_outputRawFrames[index]);
     }

--- a/vaapi/Android.mk
+++ b/vaapi/Android.mk
@@ -7,6 +7,7 @@ LOCAL_SRC_FILES := \
         vaapibuffer.cpp \
         vaapiimage.cpp \
         vaapisurface.cpp\
+        vaapiimageutils.cpp \
         vaapiutils.cpp \
         vaapidisplay.cpp \
         vaapicontext.cpp \

--- a/vaapi/Makefile.am
+++ b/vaapi/Makefile.am
@@ -5,6 +5,7 @@ libyami_vaapi_source_c = \
 	vaapibuffer.cpp \
 	vaapiimage.cpp \
 	vaapisurface.cpp\
+	vaapiimageutils.cpp \
 	vaapiutils.cpp \
 	vaapidisplay.cpp \
 	vaapicontext.cpp \
@@ -17,6 +18,7 @@ libyami_vaapi_source_h_priv = \
 	vaapibuffer.h \
 	vaapiimage.h \
 	vaapisurface.h \
+	vaapiimageutils.h \
 	vaapiutils.h \
 	vaapitypes.h \
 	vaapidisplay.h \

--- a/vaapi/vaapiimageutils.cpp
+++ b/vaapi/vaapiimageutils.cpp
@@ -1,0 +1,53 @@
+/*
+ *  vaapiimageutils.cpp - vaapi image utils
+ *
+ *  Copyright (C) 2011-2014 Intel Corporation
+ *    Author: Xu Guangxin<guangxin.xu@intel.com>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2.1
+ *  of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "vaapiimageutils.h"
+
+#include "vaapiutils.h"
+
+namespace YamiMediaCodec{
+
+uint8_t* mapSurfaceToImage(VADisplay display, intptr_t surface, VAImage& image)
+{
+    uint8_t* p = NULL;
+    VAStatus status = vaDeriveImage(display, (VASurfaceID)surface, &image);
+    if (!checkVaapiStatus(status, "vaDeriveImage"))
+        return NULL;
+    status = vaMapBuffer(display, image.buf, (void**)&p);
+    if (!checkVaapiStatus(status, "vaMapBuffer")) {
+        checkVaapiStatus(vaDestroyImage(display, image.image_id), "vaDestroyImage");
+        return NULL;
+    }
+    return p;
+}
+
+void unmapImage(VADisplay display, const VAImage& image)
+{
+    checkVaapiStatus(vaUnmapBuffer(display, image.buf), "vaUnmapBuffer");
+    checkVaapiStatus(vaDestroyImage(display, image.image_id), "vaDestroyImage");
+}
+
+}

--- a/vaapi/vaapiimageutils.h
+++ b/vaapi/vaapiimageutils.h
@@ -1,0 +1,32 @@
+/*
+ *  vaapiimageutils.h - vaapi image utils
+ *
+ *  Copyright (C) 2011-2014 Intel Corporation
+ *    Author: Xu Guangxin<guangxin.xu@intel.com>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2.1
+ *  of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA
+ */
+
+#include <stdint.h>
+#include <va/va.h>
+
+namespace YamiMediaCodec{
+
+uint8_t* mapSurfaceToImage(VADisplay display, intptr_t surface, VAImage& image);
+
+void unmapImage(VADisplay display, const VAImage& image);
+
+} //namespace YamiMediaCodec

--- a/vpp/vaapipostprocess_scaler.cpp
+++ b/vpp/vaapipostprocess_scaler.cpp
@@ -49,7 +49,10 @@ static void copyVideoFrameMeta(const SharedPtr<VideoFrame>& src, const SharedPtr
 //android csc need us set color standard
 VAProcColorStandardType fourccToColorStandard(uint32_t fourcc)
 {
-    if (fourcc == YAMI_FOURCC_RGBX || fourcc == YAMI_FOURCC_RGBA) {
+    if (fourcc == YAMI_FOURCC_RGBX
+        || fourcc == YAMI_FOURCC_RGBA
+        || fourcc == YAMI_FOURCC_BGRX
+        || fourcc == YAMI_FOURCC_BGRA) {
         //we should return VAProcColorStandardSRGB here
         //but it only exist on libva staging. so we return None
         //side effect is android libva will print error info when we convert it to RGB
@@ -59,7 +62,6 @@ VAProcColorStandardType fourccToColorStandard(uint32_t fourcc)
     }
     if (fourcc == YAMI_FOURCC_NV12)
         return VAProcColorStandardBT601;
-    ERROR("invalid fourcc, set color stand to bt601");
     return VAProcColorStandardBT601;
 }
 


### PR DESCRIPTION

this have many benefits:
1.make api more clearly. 
Current we have 4 getOutputs. and getOutput(VideoFrameRawData* frame)" have 8 variables. technically we have  11 getOutputs.Most head ache thing is not all platform support all getOutput's. After this serial patches, We only have one version of getOutput. 
2. it do not duplicate libva's exist functions. take  X11 version of getOutput for example, we just wrapper libva‘s vaPutSurface, do not add any thing more.