### PR TITLE
OCL VPP mosaic/flip/rotate implementation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AC_PREREQ([2.68])
 # YAMI-API version for api headers, only change it when the api interface is changed.
 m4_define([yami_api_major_version], 0)
 m4_define([yami_api_minor_version], 1)
-m4_define([yami_api_micro_version], 2)
+m4_define([yami_api_micro_version], 3)
 m4_define([yami_api_version],
     [yami_api_major_version.yami_api_minor_version.yami_api_micro_version])
 

--- a/interface/VideoCommonDefs.h
+++ b/interface/VideoCommonDefs.h
@@ -223,6 +223,7 @@ typedef struct VideoFrame {
 #define YAMI_VPP_SCALER "vpp/scaler"
 #define YAMI_VPP_OCL_BLENDER "vpp/ocl_blender"
 #define YAMI_VPP_OCL_OSD "vpp/ocl_osd"
+#define YAMI_VPP_OCL_TRANSFORM "vpp/ocl_transform"
 
 #ifdef __cplusplus
 }

--- a/interface/VideoCommonDefs.h
+++ b/interface/VideoCommonDefs.h
@@ -224,6 +224,7 @@ typedef struct VideoFrame {
 #define YAMI_VPP_OCL_BLENDER "vpp/ocl_blender"
 #define YAMI_VPP_OCL_OSD "vpp/ocl_osd"
 #define YAMI_VPP_OCL_TRANSFORM "vpp/ocl_transform"
+#define YAMI_VPP_OCL_MOSAIC "vpp/ocl_mosaic"
 
 #ifdef __cplusplus
 }

--- a/interface/VideoPostProcessDefs.h
+++ b/interface/VideoPostProcessDefs.h
@@ -29,12 +29,27 @@ extern "C" {
 
 typedef enum {
     VppParamTypeOsd,
+    VppParamTypeTransform,
 } VppParamType;
 
 typedef struct VppParamOsd {
     size_t size;
     uint32_t threshold;
 } VppParamOsd;
+
+typedef enum {
+    VPP_TRANSFORM_NONE   = 0x0,
+    VPP_TRANSFORM_FLIP_H = 0x1,
+    VPP_TRANSFORM_FLIP_V = 0x2,
+    VPP_TRANSFORM_ROT_90 = 0x4,
+    VPP_TRANSFORM_ROT_180 = 0x8,
+    VPP_TRANSFORM_ROT_270 = 0x10,
+} VppTransform;
+
+typedef struct VppParamTransform {
+    size_t size;
+    uint32_t transform;
+} VppParamTransform;
 
 #ifdef __cplusplus
 }

--- a/ocl/kernels/mosaic.cl
+++ b/ocl/kernels/mosaic.cl
@@ -1,0 +1,78 @@
+/*
+ *  mosaic.cl - mosaic filter
+ *
+ *  Copyright (C) 2016 Intel Corporation
+ *    Author: Jia Meng<jia.meng@intel.com>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2.1
+ *  of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA
+ */
+
+__kernel void mosaic(__write_only image2d_t img_y_dst,
+                     __read_only image2d_t img_y,
+                     __write_only image2d_t img_uv_dst,
+                     __read_only image2d_t img_uv,
+                     uint crop_x,
+                     uint crop_y,
+                     uint blk_size,
+                     __local float* sum)
+{
+    sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+    size_t g_id_x = get_global_id(0);
+    size_t g_id_y = get_global_id(1);
+    size_t l_id_x = get_local_id(0);
+
+    float4 Y;
+    sum[l_id_x] = 0;
+    for (uint i = 0; i < blk_size; i++) {
+        Y = read_imagef(img_y, (int2)(g_id_x + crop_x, g_id_y * blk_size + i + crop_y));
+        sum[l_id_x] += Y.x;
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+    if (l_id_x % blk_size == 0) {
+        for (uint i = 1; i < blk_size; i++) {
+            sum[l_id_x] += sum[l_id_x + i];
+        }
+        sum[l_id_x] /= (blk_size * blk_size);
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+    Y.x = sum[l_id_x / blk_size * blk_size];
+    for (uint i = 0; i < blk_size; i++) {
+        write_imagef(img_y_dst, (int2)(g_id_x + crop_x, g_id_y * blk_size + i + crop_y), Y);
+    }
+
+    float4 UV;
+    sum[l_id_x] = 0;
+    for (uint i = 0; i < blk_size / 2; i++) {
+        UV = read_imagef(img_uv, (int2)(g_id_x + crop_x, g_id_y * blk_size / 2 + i + crop_y / 2));
+        sum[l_id_x] += UV.x;
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+    if (l_id_x % blk_size == 0 || l_id_x % blk_size == 1) {
+        for (uint i = 2; i < blk_size; i+=2) {
+            sum[l_id_x] += sum[l_id_x + i];
+        }
+        sum[l_id_x] /= (blk_size * blk_size / 4);
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+    if (l_id_x % 2 == 0) {
+        UV.x = sum[l_id_x / blk_size * blk_size];
+    } else {
+        UV.x = sum[l_id_x / blk_size * blk_size + 1];
+    }
+    for (uint i = 0; i < blk_size / 2; i++) {
+        write_imagef(img_uv_dst, (int2)(g_id_x + crop_x, g_id_y * blk_size / 2 + i + crop_y / 2), UV);
+    }
+}

--- a/ocl/kernels/transform.cl
+++ b/ocl/kernels/transform.cl
@@ -1,0 +1,255 @@
+/*
+ *  transform.cl - flip and rotate
+ *
+ *  Copyright (C) 2016 Intel Corporation
+ *    Author: Jia Meng<jia.meng@intel.com>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2.1
+ *  of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA
+ */
+
+__kernel void transform_flip_h(__write_only image2d_t img_y_dst,
+                               __write_only image2d_t img_uv_dst,
+                               __read_only image2d_t img_y_src,
+                               __read_only image2d_t img_uv_src,
+                               uint w)
+{
+    sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE |
+                        CLK_ADDRESS_CLAMP_TO_EDGE   |
+                        CLK_FILTER_NEAREST;
+    size_t g_id_x = get_global_id(0);
+    size_t g_id_y = get_global_id(1);
+    float4 src, dst;
+
+    int coord_y = 2 * g_id_y;
+    src = read_imagef(img_y_src, sampler, (int2)(g_id_x, coord_y));
+    dst = (float4)(src.w, src.z, src.y, src.x);
+    write_imagef(img_y_dst, (int2)(w - g_id_x, coord_y), dst);
+
+    src = read_imagef(img_y_src, sampler, (int2)(g_id_x, coord_y + 1));
+    dst = (float4)(src.w, src.z, src.y, src.x);
+    write_imagef(img_y_dst, (int2)(w - g_id_x, coord_y + 1), dst);
+
+    src = read_imagef(img_uv_src, sampler, (int2)(g_id_x, g_id_y));
+    dst = (float4)(src.z, src.w, src.x, src.y);
+    write_imagef(img_uv_dst, (int2)(w - g_id_x, g_id_y), dst);
+}
+
+__kernel void transform_flip_v(__write_only image2d_t img_y_dst,
+                               __write_only image2d_t img_uv_dst,
+                               __read_only image2d_t img_y_src,
+                               __read_only image2d_t img_uv_src,
+                               uint h)
+{
+    sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE |
+                        CLK_ADDRESS_CLAMP_TO_EDGE   |
+                        CLK_FILTER_NEAREST;
+    size_t g_id_x = get_global_id(0);
+    size_t g_id_y = get_global_id(1);
+    float4 data;
+
+    int coord_y = 2 * g_id_y;
+    data = read_imagef(img_y_src, sampler, (int2)(g_id_x, coord_y));
+    write_imagef(img_y_dst, (int2)(g_id_x, h - 1 - coord_y), data);
+    data = read_imagef(img_y_src, sampler, (int2)(g_id_x, coord_y + 1));
+    write_imagef(img_y_dst, (int2)(g_id_x, h - 1 - coord_y - 1), data);
+
+    data = read_imagef(img_uv_src, sampler, (int2)(g_id_x, g_id_y));
+    write_imagef(img_uv_dst, (int2)(g_id_x, h / 2 - g_id_y), data);
+}
+
+__kernel void transform_rot_180(__write_only image2d_t img_y_dst,
+                                __write_only image2d_t img_uv_dst,
+                                __read_only image2d_t img_y_src,
+                                __read_only image2d_t img_uv_src,
+                                uint w,
+                                uint h)
+{
+    sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE |
+                        CLK_ADDRESS_CLAMP_TO_EDGE   |
+                        CLK_FILTER_NEAREST;
+    size_t g_id_x = get_global_id(0);
+    size_t g_id_y = get_global_id(1);
+    float4 src, dst;
+
+    int coord_y = 2 * g_id_y;
+    src = read_imagef(img_y_src, sampler, (int2)(g_id_x, coord_y));
+    dst = (float4)(src.w, src.z, src.y, src.x);
+    write_imagef(img_y_dst, (int2)(w - g_id_x, h - 1 - coord_y), dst);
+
+    src = read_imagef(img_y_src, sampler, (int2)(g_id_x, coord_y + 1));
+    dst = (float4)(src.w, src.z, src.y, src.x);
+    write_imagef(img_y_dst, (int2)(w - g_id_x, h - 1 - coord_y - 1), dst);
+
+    src = read_imagef(img_uv_src, sampler, (int2)(g_id_x, g_id_y));
+    dst = (float4)(src.z, src.w, src.x, src.y);
+    write_imagef(img_uv_dst, (int2)(w - g_id_x, h / 2 - g_id_y), dst);
+}
+
+__kernel void transform_rot_90(__write_only image2d_t img_y_dst,
+                               __write_only image2d_t img_uv_dst,
+                               __read_only image2d_t img_y_src,
+                               __read_only image2d_t img_uv_src,
+                               uint w,
+                               uint h)
+{
+    sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE |
+                        CLK_ADDRESS_CLAMP_TO_EDGE   |
+                        CLK_FILTER_NEAREST;
+    size_t g_id_x = get_global_id(0);
+    size_t g_id_y = get_global_id(1);
+    float4 src0, src1, src2, src3, dst;
+
+    int coord_x = 4 * g_id_x;
+    int coord_y = 4 * g_id_y;
+    src0 = read_imagef(img_y_src, sampler, (int2)(g_id_x, coord_y));
+    src1 = read_imagef(img_y_src, sampler, (int2)(g_id_x, coord_y + 1));
+    src2 = read_imagef(img_y_src, sampler, (int2)(g_id_x, coord_y + 2));
+    src3 = read_imagef(img_y_src, sampler, (int2)(g_id_x, coord_y + 3));
+    dst = (float4)(src3.x, src2.x, src1.x, src0.x);
+    write_imagef(img_y_dst, (int2)(h - g_id_y, coord_x), dst);
+    dst = (float4)(src3.y, src2.y, src1.y, src0.y);
+    write_imagef(img_y_dst, (int2)(h - g_id_y, coord_x + 1), dst);
+    dst = (float4)(src3.z, src2.z, src1.z, src0.z);
+    write_imagef(img_y_dst, (int2)(h - g_id_y, coord_x + 2), dst);
+    dst = (float4)(src3.w, src2.w, src1.w, src0.w);
+    write_imagef(img_y_dst, (int2)(h - g_id_y, coord_x + 3), dst);
+
+    coord_x = 2 * g_id_x;
+    coord_y = 2 * g_id_y;
+    src0 = read_imagef(img_uv_src, sampler, (int2)(g_id_x, coord_y));
+    src1 = read_imagef(img_uv_src, sampler, (int2)(g_id_x, coord_y + 1));
+    dst = (float4)(src1.x, src1.y, src0.x, src0.y);
+    write_imagef(img_uv_dst, (int2)(h - g_id_y, coord_x), dst);
+    dst = (float4)(src1.z, src1.w, src0.z, src0.w);
+    write_imagef(img_uv_dst, (int2)(h - g_id_y, coord_x + 1), dst);
+}
+
+__kernel void transform_rot_270(__write_only image2d_t img_y_dst,
+                                __write_only image2d_t img_uv_dst,
+                                __read_only image2d_t img_y_src,
+                                __read_only image2d_t img_uv_src,
+                                uint w,
+                                uint h)
+{
+    sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE |
+                        CLK_ADDRESS_CLAMP_TO_EDGE   |
+                        CLK_FILTER_NEAREST;
+    size_t g_id_x = get_global_id(0);
+    size_t g_id_y = get_global_id(1);
+    float4 src0, src1, src2, src3, dst;
+
+    int coord_x = 4 * g_id_x;
+    int coord_y = 4 * g_id_y;
+    src0 = read_imagef(img_y_src, sampler, (int2)(g_id_x, coord_y));
+    src1 = read_imagef(img_y_src, sampler, (int2)(g_id_x, coord_y + 1));
+    src2 = read_imagef(img_y_src, sampler, (int2)(g_id_x, coord_y + 2));
+    src3 = read_imagef(img_y_src, sampler, (int2)(g_id_x, coord_y + 3));
+    dst = (float4)(src0.w, src1.w, src2.w, src3.w);
+    write_imagef(img_y_dst, (int2)(g_id_y, w * 4 - coord_x), dst);
+    dst = (float4)(src0.z, src1.z, src2.z, src3.z);
+    write_imagef(img_y_dst, (int2)(g_id_y, w * 4 - coord_x + 1), dst);
+    dst = (float4)(src0.y, src1.y, src2.y, src3.y);
+    write_imagef(img_y_dst, (int2)(g_id_y, w * 4 - coord_x + 2), dst);
+    dst = (float4)(src0.x, src1.x, src2.x, src3.x);
+    write_imagef(img_y_dst, (int2)(g_id_y, w * 4 - coord_x + 3), dst);
+
+    coord_x = 2 * g_id_x;
+    coord_y = 2 * g_id_y;
+    src0 = read_imagef(img_uv_src, sampler, (int2)(g_id_x, coord_y));
+    src1 = read_imagef(img_uv_src, sampler, (int2)(g_id_x, coord_y + 1));
+    dst = (float4)(src0.z, src0.w, src1.z, src1.w);
+    write_imagef(img_uv_dst, (int2)(g_id_y, w * 2 - coord_x), dst);
+    dst = (float4)(src0.x, src0.y, src1.x, src1.y);
+    write_imagef(img_uv_dst, (int2)(g_id_y, w * 2 - coord_x + 1), dst);
+}
+
+__kernel void transform_flip_h_rot_90(__write_only image2d_t img_y_dst,
+                                      __write_only image2d_t img_uv_dst,
+                                      __read_only image2d_t img_y_src,
+                                      __read_only image2d_t img_uv_src,
+                                      uint w,
+                                      uint h)
+{
+    sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE |
+                        CLK_ADDRESS_CLAMP_TO_EDGE   |
+                        CLK_FILTER_NEAREST;
+    size_t g_id_x = get_global_id(0);
+    size_t g_id_y = get_global_id(1);
+    float4 src0, src1, src2, src3, dst;
+
+    int coord_x = 4 * g_id_x;
+    int coord_y = 4 * g_id_y;
+    src0 = read_imagef(img_y_src, sampler, (int2)(g_id_x, coord_y));
+    src1 = read_imagef(img_y_src, sampler, (int2)(g_id_x, coord_y + 1));
+    src2 = read_imagef(img_y_src, sampler, (int2)(g_id_x, coord_y + 2));
+    src3 = read_imagef(img_y_src, sampler, (int2)(g_id_x, coord_y + 3));
+    dst = (float4)(src3.w, src2.w, src1.w, src0.w);
+    write_imagef(img_y_dst, (int2)(h - g_id_y, w * 4 - coord_x), dst);
+    dst = (float4)(src3.z, src2.z, src1.z, src0.z);
+    write_imagef(img_y_dst, (int2)(h - g_id_y, w * 4 - coord_x + 1), dst);
+    dst = (float4)(src3.y, src2.y, src1.y, src0.y);
+    write_imagef(img_y_dst, (int2)(h - g_id_y, w * 4 - coord_x + 2), dst);
+    dst = (float4)(src3.x, src2.x, src1.x, src0.x);
+    write_imagef(img_y_dst, (int2)(h - g_id_y, w * 4 - coord_x + 3), dst);
+
+    coord_x = 2 * g_id_x;
+    coord_y = 2 * g_id_y;
+    src0 = read_imagef(img_uv_src, sampler, (int2)(g_id_x, coord_y));
+    src1 = read_imagef(img_uv_src, sampler, (int2)(g_id_x, coord_y + 1));
+    dst = (float4)(src1.z, src1.w, src0.z, src0.w);
+    write_imagef(img_uv_dst, (int2)(h - g_id_y, w * 2 - coord_x), dst);
+    dst = (float4)(src1.x, src1.y, src0.x, src0.y);
+    write_imagef(img_uv_dst, (int2)(h - g_id_y, w * 2 - coord_x + 1), dst);
+}
+
+__kernel void transform_flip_v_rot_90(__write_only image2d_t img_y_dst,
+                                      __write_only image2d_t img_uv_dst,
+                                      __read_only image2d_t img_y_src,
+                                      __read_only image2d_t img_uv_src,
+                                      uint w,
+                                      uint h)
+{
+    sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE |
+                        CLK_ADDRESS_CLAMP_TO_EDGE   |
+                        CLK_FILTER_NEAREST;
+    size_t g_id_x = get_global_id(0);
+    size_t g_id_y = get_global_id(1);
+    float4 src0, src1, src2, src3, dst;
+
+    int coord_x = 4 * g_id_x;
+    int coord_y = 4 * g_id_y;
+    src0 = read_imagef(img_y_src, sampler, (int2)(g_id_x, coord_y));
+    src1 = read_imagef(img_y_src, sampler, (int2)(g_id_x, coord_y + 1));
+    src2 = read_imagef(img_y_src, sampler, (int2)(g_id_x, coord_y + 2));
+    src3 = read_imagef(img_y_src, sampler, (int2)(g_id_x, coord_y + 3));
+    dst = (float4)(src0.x, src1.x, src2.x, src3.x);
+    write_imagef(img_y_dst, (int2)(g_id_y, coord_x), dst);
+    dst = (float4)(src0.y, src1.y, src2.y, src3.y);
+    write_imagef(img_y_dst, (int2)(g_id_y, coord_x + 1), dst);
+    dst = (float4)(src0.z, src1.z, src2.z, src3.z);
+    write_imagef(img_y_dst, (int2)(g_id_y, coord_x + 2), dst);
+    dst = (float4)(src0.w, src1.w, src2.w, src3.w);
+    write_imagef(img_y_dst, (int2)(g_id_y, coord_x + 3), dst);
+
+    coord_x = 2 * g_id_x;
+    coord_y = 2 * g_id_y;
+    src0 = read_imagef(img_uv_src, sampler, (int2)(g_id_x, coord_y));
+    src1 = read_imagef(img_uv_src, sampler, (int2)(g_id_x, coord_y + 1));
+    dst = (float4)(src0.x, src0.y, src1.x, src1.y);
+    write_imagef(img_uv_dst, (int2)(g_id_y, coord_x), dst);
+    dst = (float4)(src0.z, src0.w, src1.z, src1.w);
+    write_imagef(img_uv_dst, (int2)(g_id_y, coord_x + 1), dst);
+}

--- a/ocl/oclcontext.cpp
+++ b/ocl/oclcontext.cpp
@@ -207,7 +207,8 @@ bool OclDevice::loadFile(const char* path, vector<char>& dest)
 bool OclDevice::loadKernel_l(cl_context context, const char* name, OclKernelMap& kernelMap)
 {
     bool ret = true;
-    string path = name;
+    string path = KERNEL_DIR;
+    path += name;
     path += ".cl";
 
     vector<char> text;

--- a/vpp/Makefile.am
+++ b/vpp/Makefile.am
@@ -63,6 +63,18 @@ libyami_vpp_cppflags = \
 	$(NULL)
 
 if BUILD_OCL_BLENDER
+libyami_vpp_ocl_kernel = \
+	../ocl/kernels/blend.cl \
+	../ocl/kernels/osd.cl \
+	../ocl/kernels/transform.cl \
+	../ocl/kernels/mosaic.cl \
+	$(NULL)
+kerneldir             = $(datadir)/libyami/kernel
+kernel_DATA           = $(libyami_vpp_ocl_kernel)
+libyami_vpp_cppflags += -DKERNEL_DIR=\"$(kerneldir)/\"
+endif
+
+if BUILD_OCL_BLENDER
 libyami_vpp_ldflags += -lOpenCL
 endif
 

--- a/vpp/Makefile.am
+++ b/vpp/Makefile.am
@@ -20,6 +20,7 @@ endif
 if BUILD_OCL_BLENDER
 libyami_vpp_source_c += oclpostprocess_blender.cpp
 libyami_vpp_source_c += oclpostprocess_osd.cpp
+libyami_vpp_source_c += oclpostprocess_transform.cpp
 endif
 
 libyami_vpp_source_h = \
@@ -44,6 +45,7 @@ endif
 if BUILD_OCL_BLENDER
 libyami_vpp_source_h_priv += oclpostprocess_blender.h
 libyami_vpp_source_h_priv += oclpostprocess_osd.h
+libyami_vpp_source_h_priv += oclpostprocess_transform.h
 endif
 
 libyami_vpp_ldflags = \

--- a/vpp/Makefile.am
+++ b/vpp/Makefile.am
@@ -21,6 +21,7 @@ if BUILD_OCL_BLENDER
 libyami_vpp_source_c += oclpostprocess_blender.cpp
 libyami_vpp_source_c += oclpostprocess_osd.cpp
 libyami_vpp_source_c += oclpostprocess_transform.cpp
+libyami_vpp_source_c += oclpostprocess_mosaic.cpp
 endif
 
 libyami_vpp_source_h = \
@@ -46,6 +47,7 @@ if BUILD_OCL_BLENDER
 libyami_vpp_source_h_priv += oclpostprocess_blender.h
 libyami_vpp_source_h_priv += oclpostprocess_osd.h
 libyami_vpp_source_h_priv += oclpostprocess_transform.h
+libyami_vpp_source_h_priv += oclpostprocess_mosaic.h
 endif
 
 libyami_vpp_ldflags = \

--- a/vpp/oclpostprocess_base.h
+++ b/vpp/oclpostprocess_base.h
@@ -52,6 +52,23 @@ public:
     virtual ~OclPostProcessBase();
 
 protected:
+    class VideoFrameDeleter {
+    public:
+        VideoFrameDeleter(VADisplay display)
+            : m_display(display)
+        {
+        }
+        void operator()(VideoFrame* frame)
+        {
+            VASurfaceID id = (VASurfaceID)frame->surface;
+            vaDestroySurfaces(m_display, &id, 1);
+            delete frame;
+        }
+
+    private:
+        VADisplay m_display;
+    };
+
     uint32_t getPixelSize(const cl_image_format& fmt);
     cl_kernel getKernel(const char* name);
 

--- a/vpp/oclpostprocess_mosaic.cpp
+++ b/vpp/oclpostprocess_mosaic.cpp
@@ -1,0 +1,122 @@
+/*
+ *  oclpostprocess_mosaic.cpp - opencl based mosaic filter
+ *
+ *  Copyright (C) 2016 Intel Corporation
+ *    Author: Jia Meng<jia.meng@intel.com>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2.1
+ *  of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "oclpostprocess_mosaic.h"
+#include "vaapipostprocess_factory.h"
+#include "common/common_def.h"
+#include "common/log.h"
+#include "ocl/oclcontext.h"
+#include "vpp/oclvppimage.h"
+
+namespace YamiMediaCodec {
+
+YamiStatus
+OclPostProcessMosaic::process(const SharedPtr<VideoFrame>& src,
+    const SharedPtr<VideoFrame>& dst)
+{
+    YamiStatus status = ensureContext("mosaic");
+    if (status != YAMI_SUCCESS)
+        return status;
+
+    if (src != dst) {
+        ERROR("src and dst must be the same for mosaic filter");
+        return YAMI_INVALID_PARAM;
+    }
+
+    if (dst->fourcc != YAMI_FOURCC_NV12) {
+        ERROR("only support mosaic filter on NV12 video frame");
+        return YAMI_INVALID_PARAM;
+    }
+
+    cl_image_format format;
+    format.image_channel_order = CL_R;
+    format.image_channel_data_type = CL_UNORM_INT8;
+    SharedPtr<OclVppCLImage> imagePtr = OclVppCLImage::create(m_display, dst, m_context, format);
+    if (!imagePtr->numPlanes()) {
+        ERROR("failed to create cl image from dst frame");
+        return YAMI_FAIL;
+    }
+
+    cl_mem bgImageMem[3];
+    for (uint32_t n = 0; n < imagePtr->numPlanes(); n++) {
+        bgImageMem[n] = imagePtr->plane(n);
+    }
+
+    size_t globalWorkSize[2], localWorkSize[2];
+    localWorkSize[0] = 256 / m_blockSize * m_blockSize;
+    localWorkSize[1] = 1;
+    globalWorkSize[0] = (dst->crop.width / localWorkSize[0] + 1) * localWorkSize[0];
+    globalWorkSize[1] = dst->crop.height / m_blockSize + 1;
+    size_t localMemSize = localWorkSize[0] * sizeof(float);
+
+    cl_kernel kernel = getKernel("mosaic");
+    if (!kernel) {
+        ERROR("failed to get cl kernel");
+        return YAMI_FAIL;
+    }
+    if ((CL_SUCCESS != clSetKernelArg(kernel, 0, sizeof(cl_mem), &imagePtr->plane(0)))
+         || (CL_SUCCESS != clSetKernelArg(kernel, 1, sizeof(cl_mem), &bgImageMem[0]))
+         || (CL_SUCCESS != clSetKernelArg(kernel, 2, sizeof(cl_mem), &imagePtr->plane(1)))
+         || (CL_SUCCESS != clSetKernelArg(kernel, 3, sizeof(cl_mem), &bgImageMem[1]))
+         || (CL_SUCCESS != clSetKernelArg(kernel, 4, sizeof(uint32_t), &dst->crop.x))
+         || (CL_SUCCESS != clSetKernelArg(kernel, 5, sizeof(uint32_t), &dst->crop.y))
+         || (CL_SUCCESS != clSetKernelArg(kernel, 6, sizeof(uint32_t), &m_blockSize))
+         || (CL_SUCCESS != clSetKernelArg(kernel, 7, localMemSize, NULL))) {
+        ERROR("clSetKernelArg failed");
+        return YAMI_FAIL;
+    }
+
+    if (!checkOclStatus(clEnqueueNDRangeKernel(m_context->m_queue, kernel, 2, NULL,
+                            globalWorkSize, localWorkSize, 0, NULL, NULL),
+            "EnqueueNDRangeKernel")) {
+        return YAMI_FAIL;
+    }
+
+    return status;
+}
+
+YamiStatus OclPostProcessMosaic::setParameters(VppParamType type, void* vppParam)
+{
+    YamiStatus status = YAMI_INVALID_PARAM;
+
+    switch (type) {
+    case VppParamTypeMosaic: {
+        VppParamMosaic* mosaic = (VppParamMosaic*)vppParam;
+        if (mosaic->size == sizeof(VppParamMosaic)) {
+            if (mosaic->blockSize > 0 && mosaic->blockSize <= 256) {
+                m_blockSize = mosaic->blockSize;
+                status = YAMI_SUCCESS;
+            }
+        }
+    } break;
+    default:
+        status = OclPostProcessBase::setParameters(type, vppParam);
+        break;
+    }
+    return status;
+}
+
+const bool OclPostProcessMosaic::s_registered = VaapiPostProcessFactory::register_<OclPostProcessMosaic>(YAMI_VPP_OCL_MOSAIC);
+}

--- a/vpp/oclpostprocess_mosaic.h
+++ b/vpp/oclpostprocess_mosaic.h
@@ -1,5 +1,5 @@
 /*
- *  VideoPostProcessDefs.h - video postprocessing definitions
+ *  oclpostprocess_mosaic.h - opencl based mosaic filter
  *
  *  Copyright (C) 2016 Intel Corporation
  *    Author: Jia Meng<jia.meng@intel.com>
@@ -19,45 +19,33 @@
  *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  *  Boston, MA 02110-1301 USA
  */
+#ifndef oclpostprocess_mosaic_h
+#define oclpostprocess_mosaic_h
 
-#ifndef __VIDEO_POST_PROCESS_DEFS_H__
-#define __VIDEO_POST_PROCESS_DEFS_H__
+#include "interface/VideoCommonDefs.h"
+#include "oclpostprocess_base.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+namespace YamiMediaCodec {
 
-typedef enum {
-    VppParamTypeOsd,
-    VppParamTypeTransform,
-    VppParamTypeMosaic,
-} VppParamType;
+/**
+ * \class OclPostProcessMosaic
+ * \brief OpenCL based mosaic filter
+ */
+class OclPostProcessMosaic : public OclPostProcessBase {
+public:
+    virtual YamiStatus process(const SharedPtr<VideoFrame>& src,
+        const SharedPtr<VideoFrame>& dst);
 
-typedef struct VppParamOsd {
-    size_t size;
-    uint32_t threshold;
-} VppParamOsd;
+    virtual YamiStatus setParameters(VppParamType type, void* vppParam);
 
-typedef enum {
-    VPP_TRANSFORM_NONE   = 0x0,
-    VPP_TRANSFORM_FLIP_H = 0x1,
-    VPP_TRANSFORM_FLIP_V = 0x2,
-    VPP_TRANSFORM_ROT_90 = 0x4,
-    VPP_TRANSFORM_ROT_180 = 0x8,
-    VPP_TRANSFORM_ROT_270 = 0x10,
-} VppTransform;
+    explicit OclPostProcessMosaic()
+        : m_blockSize(32)
+    {
+    }
 
-typedef struct VppParamTransform {
-    size_t size;
-    uint32_t transform;
-} VppParamTransform;
-
-typedef struct VppParamMosaic {
-    size_t size;
-    uint32_t blockSize;
-} VppParamMosaic;
-
-#ifdef __cplusplus
+private:
+    static const bool s_registered; // VaapiPostProcessFactory registration result
+    int m_blockSize;
+};
 }
-#endif
-#endif /*  __VIDEO_POST_PROCESS_DEFS_H__ */
+#endif //oclpostprocess_mosaic_h

--- a/vpp/oclpostprocess_transform.cpp
+++ b/vpp/oclpostprocess_transform.cpp
@@ -1,0 +1,290 @@
+/*
+ *  oclpostprocess_transform.cpp - opencl based flip and rotate
+ *
+ *  Copyright (C) 2016 Intel Corporation
+ *    Author: Jia Meng<jia.meng@intel.com>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2.1
+ *  of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "oclpostprocess_transform.h"
+#include "vaapipostprocess_factory.h"
+#include "common/common_def.h"
+#include "common/log.h"
+#include "ocl/oclcontext.h"
+#include "vaapi/vaapiutils.h"
+#include "vpp/oclvppimage.h"
+
+namespace YamiMediaCodec {
+
+YamiStatus
+OclPostProcessTransform::process(const SharedPtr<VideoFrame>& src,
+    const SharedPtr<VideoFrame>& dst)
+{
+    YamiStatus status = ensureContext("transform");
+    if (status != YAMI_SUCCESS)
+        return status;
+
+    if (src->fourcc != YAMI_FOURCC_NV12 || dst->fourcc != YAMI_FOURCC_NV12) {
+        ERROR("only support transform of NV12 video frame");
+        return YAMI_INVALID_PARAM;
+    }
+
+    cl_image_format format;
+    format.image_channel_order = CL_RGBA;
+    format.image_channel_data_type = CL_UNORM_INT8;
+    SharedPtr<OclVppCLImage> srcImage = OclVppCLImage::create(m_display, src, m_context, format);
+    if (!srcImage) {
+        ERROR("failed to create cl image from src video frame");
+        return YAMI_FAIL;
+    }
+    SharedPtr<OclVppCLImage> dstImage = OclVppCLImage::create(m_display, dst, m_context, format);
+    if (!dstImage) {
+        ERROR("failed to create cl image from dst video frame");
+        return YAMI_FAIL;
+    }
+
+    if (m_transform & VPP_TRANSFORM_FLIP_H && m_transform & VPP_TRANSFORM_FLIP_V) {
+        // flip both v and h is effectively rotate 180
+        m_transform &= ~(VPP_TRANSFORM_FLIP_H | VPP_TRANSFORM_FLIP_V);
+        switch (m_transform) {
+        case VPP_TRANSFORM_NONE:
+            m_transform = VPP_TRANSFORM_ROT_180;
+        case VPP_TRANSFORM_ROT_90:
+            m_transform = VPP_TRANSFORM_ROT_270;
+            break;
+        case VPP_TRANSFORM_ROT_180:
+            m_transform = VPP_TRANSFORM_NONE;
+            break;
+        case VPP_TRANSFORM_ROT_270:
+            m_transform = VPP_TRANSFORM_ROT_90;
+            break;
+        default:
+            ERROR("unsupported transform type");
+            return YAMI_INVALID_PARAM;
+        }
+    }
+
+    status = YAMI_INVALID_PARAM;
+    switch (m_transform) {
+    case VPP_TRANSFORM_FLIP_H | VPP_TRANSFORM_ROT_90:
+    case VPP_TRANSFORM_FLIP_V | VPP_TRANSFORM_ROT_270:
+        status = flipAndRotate(srcImage, dstImage, "transform_flip_h_rot_90");
+        break;
+    case VPP_TRANSFORM_FLIP_V | VPP_TRANSFORM_ROT_90:
+    case VPP_TRANSFORM_FLIP_H | VPP_TRANSFORM_ROT_270:
+        status = flipAndRotate(srcImage, dstImage, "transform_flip_v_rot_90");
+        break;
+    case VPP_TRANSFORM_FLIP_H | VPP_TRANSFORM_ROT_180:
+    case VPP_TRANSFORM_FLIP_V:
+        m_transform = VPP_TRANSFORM_FLIP_V;
+        status = flip(srcImage, dstImage);
+        break;
+    case VPP_TRANSFORM_FLIP_V | VPP_TRANSFORM_ROT_180:
+    case VPP_TRANSFORM_FLIP_H:
+        m_transform = VPP_TRANSFORM_FLIP_H;
+        status = flip(srcImage, dstImage);
+        break;
+    case VPP_TRANSFORM_ROT_90:
+    case VPP_TRANSFORM_ROT_180:
+    case VPP_TRANSFORM_ROT_270:
+        status = rotate(srcImage, dstImage);
+        break;
+    default:
+        ERROR("unsupported transform type");
+        break;
+    }
+
+    return status;
+}
+
+YamiStatus OclPostProcessTransform::setParameters(VppParamType type, void* vppParam)
+{
+    YamiStatus status = YAMI_INVALID_PARAM;
+
+    switch (type) {
+    case VppParamTypeTransform: {
+        VppParamTransform* param = (VppParamTransform*)vppParam;
+        if (param->size == sizeof(VppParamTransform)) {
+            m_transform = param->transform;
+            status = YAMI_SUCCESS;
+        }
+    } break;
+    default:
+        status = OclPostProcessBase::setParameters(type, vppParam);
+        break;
+    }
+    return status;
+}
+
+YamiStatus OclPostProcessTransform::flip(const SharedPtr<OclVppCLImage>& src,
+    const SharedPtr<OclVppCLImage>& dst)
+{
+    uint32_t width = src->getWidth();
+    uint32_t height = src->getHeight();
+    if (width != dst->getWidth() || height != dst->getHeight()) {
+        ERROR("flip failed due to unmatched resolution");
+        return YAMI_INVALID_PARAM;
+    }
+
+    uint32_t size;
+    cl_kernel kernel = NULL;
+    if (m_transform & VPP_TRANSFORM_FLIP_H) {
+        size = width / 4 - 1;
+        kernel = getKernel("transform_flip_h");
+    }
+    else if (m_transform & VPP_TRANSFORM_FLIP_V) {
+        size = height;
+        kernel = getKernel("transform_flip_v");
+    }
+    if (!kernel) {
+        ERROR("failed to get cl kernel");
+        return YAMI_FAIL;
+    }
+    if ((CL_SUCCESS != clSetKernelArg(kernel, 0, sizeof(cl_mem), &dst->plane(0)))
+         || (CL_SUCCESS != clSetKernelArg(kernel, 1, sizeof(cl_mem), &dst->plane(1)))
+         || (CL_SUCCESS != clSetKernelArg(kernel, 2, sizeof(cl_mem), &src->plane(0)))
+         || (CL_SUCCESS != clSetKernelArg(kernel, 3, sizeof(cl_mem), &src->plane(1)))
+         || (CL_SUCCESS != clSetKernelArg(kernel, 4, sizeof(uint32_t), &size))) {
+        ERROR("clSetKernelArg failed");
+        return YAMI_FAIL;
+    }
+
+    size_t globalWorkSize[2], localWorkSize[2];
+    localWorkSize[0] = 8;
+    localWorkSize[1] = 8;
+    globalWorkSize[0] = ALIGN_POW2(width, localWorkSize[0] * 4) / 4;
+    globalWorkSize[1] = ALIGN_POW2(height, localWorkSize[1] * 2) / 2;
+    if (!checkOclStatus(clEnqueueNDRangeKernel(m_context->m_queue, kernel, 2, NULL,
+                            globalWorkSize, localWorkSize, 0, NULL, NULL),
+            "EnqueueNDRangeKernel")) {
+        return YAMI_FAIL;
+    }
+    return YAMI_SUCCESS;
+}
+
+YamiStatus OclPostProcessTransform::rotate(const SharedPtr<OclVppCLImage>& src,
+    const SharedPtr<OclVppCLImage>& dst)
+{
+    uint32_t width = src->getWidth();
+    uint32_t height = src->getHeight();
+
+    uint32_t size, w, h;
+    cl_kernel kernel = NULL;
+    if (m_transform & VPP_TRANSFORM_ROT_90) {
+        if (width != dst->getHeight() || height != dst->getWidth()) {
+            ERROR("rotate failed due to unmatched resolution");
+            return YAMI_INVALID_PARAM;
+        }
+        size = 4;
+        w = width / 4 - 1;
+        h = height / 4 - 1;
+        kernel = getKernel("transform_rot_90");
+    }
+    else if (m_transform & VPP_TRANSFORM_ROT_180) {
+        if (width != dst->getWidth() || height != dst->getHeight()) {
+            ERROR("rotate failed due to unmatched resolution");
+            return YAMI_INVALID_PARAM;
+        }
+        size = 2;
+        w = width / 4 - 1;
+        h = height;
+        kernel = getKernel("transform_rot_180");
+    }
+    else if (m_transform & VPP_TRANSFORM_ROT_270) {
+        if (width != dst->getHeight() || height != dst->getWidth()) {
+            ERROR("rotate failed due to unmatched resolution");
+            return YAMI_INVALID_PARAM;
+        }
+        size = 4;
+        w = width / 4 - 1;
+        h = height / 4 - 1;
+        kernel = getKernel("transform_rot_270");
+    }
+    if (!kernel) {
+        ERROR("failed to get cl kernel");
+        return YAMI_FAIL;
+    }
+    if ((CL_SUCCESS != clSetKernelArg(kernel, 0, sizeof(cl_mem), &dst->plane(0)))
+         || (CL_SUCCESS != clSetKernelArg(kernel, 1, sizeof(cl_mem), &dst->plane(1)))
+         || (CL_SUCCESS != clSetKernelArg(kernel, 2, sizeof(cl_mem), &src->plane(0)))
+         || (CL_SUCCESS != clSetKernelArg(kernel, 3, sizeof(cl_mem), &src->plane(1)))
+         || (CL_SUCCESS != clSetKernelArg(kernel, 4, sizeof(uint32_t), &w))
+         || (CL_SUCCESS != clSetKernelArg(kernel, 5, sizeof(uint32_t), &h))) {
+        ERROR("clSetKernelArg failed");
+        return YAMI_FAIL;
+    }
+
+    size_t globalWorkSize[2], localWorkSize[2];
+    localWorkSize[0] = 8;
+    localWorkSize[1] = 8;
+    globalWorkSize[0] = ALIGN_POW2(width, localWorkSize[0] * 4) / 4;
+    globalWorkSize[1] = ALIGN_POW2(height, localWorkSize[1] * size) / size;
+    if (!checkOclStatus(clEnqueueNDRangeKernel(m_context->m_queue, kernel, 2, NULL,
+                            globalWorkSize, localWorkSize, 0, NULL, NULL),
+            "EnqueueNDRangeKernel")) {
+        return YAMI_FAIL;
+    }
+    return YAMI_SUCCESS;
+}
+
+YamiStatus OclPostProcessTransform::flipAndRotate(const SharedPtr<OclVppCLImage>& src,
+    const SharedPtr<OclVppCLImage>& dst,
+    const char* kernelName)
+{
+    uint32_t width = src->getWidth();
+    uint32_t height = src->getHeight();
+    if (width != dst->getHeight() || height != dst->getWidth()) {
+        ERROR("flipAndRotate failed due to unmatched resolution");
+        return YAMI_INVALID_PARAM;
+    }
+
+    uint32_t size = 4;
+    uint32_t w = width / 4 - 1;
+    uint32_t h = height / 4 - 1;
+    cl_kernel kernel = getKernel(kernelName);
+    if (!kernel) {
+        ERROR("failed to get cl kernel");
+        return YAMI_FAIL;
+    }
+    if ((CL_SUCCESS != clSetKernelArg(kernel, 0, sizeof(cl_mem), &dst->plane(0)))
+         || (CL_SUCCESS != clSetKernelArg(kernel, 1, sizeof(cl_mem), &dst->plane(1)))
+         || (CL_SUCCESS != clSetKernelArg(kernel, 2, sizeof(cl_mem), &src->plane(0)))
+         || (CL_SUCCESS != clSetKernelArg(kernel, 3, sizeof(cl_mem), &src->plane(1)))
+         || (CL_SUCCESS != clSetKernelArg(kernel, 4, sizeof(uint32_t), &w))
+         || (CL_SUCCESS != clSetKernelArg(kernel, 5, sizeof(uint32_t), &h))) {
+        ERROR("clSetKernelArg failed");
+        return YAMI_FAIL;
+    }
+
+    size_t globalWorkSize[2], localWorkSize[2];
+    localWorkSize[0] = 8;
+    localWorkSize[1] = 8;
+    globalWorkSize[0] = ALIGN_POW2(width, localWorkSize[0] * 4) / 4;
+    globalWorkSize[1] = ALIGN_POW2(height, localWorkSize[1] * size) / size;
+    if (!checkOclStatus(clEnqueueNDRangeKernel(m_context->m_queue, kernel, 2, NULL,
+                            globalWorkSize, localWorkSize, 0, NULL, NULL),
+            "EnqueueNDRangeKernel")) {
+        return YAMI_FAIL;
+    }
+    return YAMI_SUCCESS;
+}
+
+const bool OclPostProcessTransform::s_registered = VaapiPostProcessFactory::register_<OclPostProcessTransform>(YAMI_VPP_OCL_TRANSFORM);
+}

--- a/vpp/oclpostprocess_transform.h
+++ b/vpp/oclpostprocess_transform.h
@@ -1,0 +1,62 @@
+/*
+ *  oclpostprocess_transform.h - opencl based flip and rotate
+ *
+ *  Copyright (C) 2016 Intel Corporation
+ *    Author: Jia Meng<jia.meng@intel.com>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2.1
+ *  of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA
+ */
+#ifndef oclpostprocess_transform_h
+#define oclpostprocess_transform_h
+
+#include <vector>
+#include "interface/VideoCommonDefs.h"
+#include "oclpostprocess_base.h"
+
+using std::vector;
+
+namespace YamiMediaCodec {
+class OclVppCLImage;
+/**
+ * \class OclPostProcessTransform
+ * \brief OpenCL based flip and rotate
+ */
+class OclPostProcessTransform : public OclPostProcessBase {
+public:
+    virtual YamiStatus process(const SharedPtr<VideoFrame>& src,
+        const SharedPtr<VideoFrame>& dst);
+
+    virtual YamiStatus setParameters(VppParamType type, void* vppParam);
+
+    explicit OclPostProcessTransform()
+        : m_transform(0)
+    {
+    }
+
+private:
+    YamiStatus flip(const SharedPtr<OclVppCLImage>& src,
+        const SharedPtr<OclVppCLImage>& dst);
+    YamiStatus rotate(const SharedPtr<OclVppCLImage>& src,
+        const SharedPtr<OclVppCLImage>& dst);
+    YamiStatus flipAndRotate(const SharedPtr<OclVppCLImage>& src,
+        const SharedPtr<OclVppCLImage>& dst,
+        const char* kernelName);
+
+    static const bool s_registered; // VaapiPostProcessFactory registration result
+    uint32_t m_transform;
+};
+}
+#endif //oclpostprocess_transform_h

--- a/vpp/oclvppimage.h
+++ b/vpp/oclvppimage.h
@@ -39,6 +39,9 @@ public:
     const MemType& plane(int n) { return m_mem[n]; }
     uint32_t pitch(int n) { return m_image.pitches[n]; }
     uint32_t numPlanes() { return m_image.num_planes; }
+    uint32_t getWidth() { return m_image.width; }
+    uint32_t getHeight() { return m_image.height; }
+    uint32_t getFourcc() { return m_frame->fourcc; }
 
 protected:
     OclVppImage(VADisplay d, const SharedPtr<VideoFrame>& f)


### PR DESCRIPTION
1. ocl: flip and rotate transform
    * support flip horizontal and vertical and rotate clockwise of 90, 180 and 270 degrees.
2. ocl: implement mosaic filter
    * apply mosaic filter using local average of blocks.
    * API update to 0.1.3.
3. example: enable mosaic and transform 
    * enable mosaic and transform to example blend, and add command arguments to select different tests
4. ocl: install ocl kernels to datadir

Test command:
$ ./blend -o --ot 128 -m --ms 32 --flip 1 --rotate 270 some.h264
