### PR TITLE
tests: Add B frame number setting. Add idrinterval for yamitranscode.

### DIFF
--- a/tests/encodehelp.h
+++ b/tests/encodehelp.h
@@ -28,7 +28,6 @@
 static int idrInterval = 0;
 static int intraPeriod = 30;
 static int ipPeriod = 1;
-static int ipbMode = 1;
 static char *inputFileName = NULL;
 static char defaultOutputFile[] = "test.264";
 static char *outputFileName = defaultOutputFile;
@@ -71,7 +70,7 @@ static void print_help(const char* app)
     printf("   -N <number of frames to encode(camera default 50), useful for camera>\n");
     printf("   --qp <initial qp> optional\n");
     printf("   --rcmode <CBR|CQP> optional\n");
-    printf("   --ipbmode <0(I frame only ) | 1 (I and P frames) | 2 (I,P,B frames)> optional\n");
+    printf("   --ipperiod <0 (I frame only) | 1 (I and P frames) | N (I,P and B frames, B frame number is N-1)> optional\n");
     printf("   --intraperiod <Intra frame period (default 30)> optional\n");
     printf("   --refnum <number of referece frames(default 1)> optional\n");
     printf("   --idrinterval <AVC/HEVC IDR frame interval (default 0)> optional\n");
@@ -99,7 +98,7 @@ static bool process_cmdline(int argc, char *argv[])
         {"help", no_argument, NULL, 'h' },
         {"qp", required_argument, NULL, 0 },
         {"rcmode", required_argument, NULL, 0 },
-        {"ipbmode", required_argument, NULL, 0 },
+        {"ipperiod", required_argument, NULL, 0 },
         {"intraperiod", required_argument, NULL, 0 },
         {"refnum", required_argument, NULL, 0 },
         {"idrinterval", required_argument, NULL, 0 },
@@ -155,7 +154,7 @@ static bool process_cmdline(int argc, char *argv[])
                     rcMode = string_to_rc_mode(optarg);
                     break;
                 case 3:
-                    ipbMode= atoi(optarg);
+                    ipPeriod = atoi(optarg);
                     break;
                 case 4:
                     intraPeriod = atoi(optarg);
@@ -192,13 +191,6 @@ void ensureInputParameters()
 {
     if (!fps)
         fps = 30;
-
-    if (ipbMode == 0)
-        ipPeriod = 0;
-    else if (ipbMode == 1)
-        ipPeriod = 1;
-    else if (ipbMode == 2)
-        ipPeriod = 3;
 
     /* if (!bitRate) {
         int rawBitRate = videoWidth * videoHeight * fps  * 3 / 2 * 8;

--- a/tests/vppoutputencode.cpp
+++ b/tests/vppoutputencode.cpp
@@ -31,9 +31,9 @@ EncodeParams::EncodeParams()
     , bitRate(0)
     , fps(30)
     , ipPeriod(1)
-    , ipbMode(1)
-    , kIPeriod(30)
+    , intraPeriod(30)
     , numRefFrames(1)
+    , idrInterval(0)
     , codec("AVC")
 {
     /*nothing to do*/
@@ -89,7 +89,7 @@ static void setEncodeParam(const SharedPtr<IVideoEncoder>& encoder,
     encVideoParams.frameRate.frameRateNum = encParam->fps;
 
     //picture type and bitrate
-    encVideoParams.intraPeriod = encParam->kIPeriod;
+    encVideoParams.intraPeriod = encParam->intraPeriod;
     encVideoParams.ipPeriod = encParam->ipPeriod;
     encVideoParams.rcParams.bitRate = encParam->bitRate;
     encVideoParams.rcParams.initQP = encParam->initQp;
@@ -98,6 +98,14 @@ static void setEncodeParam(const SharedPtr<IVideoEncoder>& encoder,
 
     encVideoParams.size = sizeof(VideoParamsCommon);
     encoder->setParameters(VideoParamsTypeCommon, &encVideoParams);
+
+    // configure AVC encoding parameters
+    VideoParamsAVC encVideoParamsAVC;
+    encVideoParamsAVC.size = sizeof(VideoParamsAVC);
+    encoder->getParameters(VideoParamsTypeAVC, &encVideoParamsAVC);
+    encVideoParamsAVC.idrInterval = encParam->idrInterval;
+    encVideoParamsAVC.size = sizeof(VideoParamsAVC);
+    encoder->setParameters(VideoParamsTypeAVC, &encVideoParamsAVC);
 
     VideoConfigAVCStreamFormat streamFormat;
     streamFormat.size = sizeof(VideoConfigAVCStreamFormat);

--- a/tests/vppoutputencode.h
+++ b/tests/vppoutputencode.h
@@ -40,9 +40,9 @@ public:
     int32_t bitRate;
     int32_t fps;
     int32_t ipPeriod;
-    int32_t ipbMode;
-    int32_t kIPeriod;
+    int32_t intraPeriod;
     int32_t numRefFrames;
+    int32_t idrInterval;
     string codec;
 };
 


### PR DESCRIPTION
Also change the "keyperiod" name to "intraperiod" in yamitranscoder to be consistent with its feature.