### PR TITLE
ocl: cache cl kernel objects within ocl vpp handlers

### DIFF
--- a/vpp/oclpostprocess_base.cpp
+++ b/vpp/oclpostprocess_base.cpp
@@ -52,7 +52,9 @@ YamiStatus OclPostProcessBase::ensureContext(const char* name)
     if (m_kernels.size())
         return YAMI_SUCCESS;
     m_context = OclContext::create();
-    if (!m_context || !m_context->createKernel(name, m_kernels))
+    if (!m_context
+        || !m_context->createKernel(name, m_kernels)
+        || !prepareKernels())
         return YAMI_DRIVER_FAIL;
     return YAMI_SUCCESS;
 }
@@ -123,15 +125,18 @@ uint32_t OclPostProcessBase::getPixelSize(const cl_image_format& fmt)
     return size;
 }
 
+cl_kernel OclPostProcessBase::prepareKernel(const char* name)
+{
+    OclKernelMap::iterator it = m_kernels.find(name);
+    if (it == m_kernels.end())
+        return NULL;
+    else
+        return it->second;
+}
+
 OclPostProcessBase::~OclPostProcessBase()
 {
     if (m_context)
         m_context->releaseKernel(m_kernels);
-}
-
-cl_kernel OclPostProcessBase::getKernel(const char* name)
-{
-    OclKernelMap::iterator it = m_kernels.find(name);
-    return it == m_kernels.end() ? 0 : it->second;
 }
 }

--- a/vpp/oclpostprocess_base.h
+++ b/vpp/oclpostprocess_base.h
@@ -70,11 +70,14 @@ protected:
     };
 
     uint32_t getPixelSize(const cl_image_format& fmt);
-    cl_kernel getKernel(const char* name);
+    cl_kernel prepareKernel(const char* name);
 
     VADisplay m_display;
-    OclKernelMap m_kernels;
     SharedPtr<OclContext> m_context;
+    OclKernelMap m_kernels;
+
+private:
+    virtual bool prepareKernels() = 0;
 };
 }
 #endif                          /* vaapipostprocess_base_h */

--- a/vpp/oclpostprocess_blender.h
+++ b/vpp/oclpostprocess_blender.h
@@ -36,12 +36,18 @@ class OclPostProcessBlender : public OclPostProcessBase {
 public:
     virtual YamiStatus process(const SharedPtr<VideoFrame>& src,
                                const SharedPtr<VideoFrame>& dest);
+    explicit OclPostProcessBlender()
+        : m_kernelBlend(NULL)
+    {
+    }
 
 private:
-    static const bool s_registered; // VaapiPostProcessFactory registration result
-
+    virtual bool prepareKernels();
     YamiStatus blend(const SharedPtr<VideoFrame>& src,
                      const SharedPtr<VideoFrame>& dst);
+
+    static const bool s_registered; // VaapiPostProcessFactory registration result
+    cl_kernel m_kernelBlend;
 };
 
 }

--- a/vpp/oclpostprocess_mosaic.h
+++ b/vpp/oclpostprocess_mosaic.h
@@ -40,12 +40,16 @@ public:
 
     explicit OclPostProcessMosaic()
         : m_blockSize(32)
+        , m_kernelMosaic(NULL)
     {
     }
 
 private:
+    virtual bool prepareKernels();
+
     static const bool s_registered; // VaapiPostProcessFactory registration result
     int m_blockSize;
+    cl_kernel m_kernelMosaic;
 };
 }
 #endif //oclpostprocess_mosaic_h

--- a/vpp/oclpostprocess_osd.h
+++ b/vpp/oclpostprocess_osd.h
@@ -44,10 +44,13 @@ public:
     explicit OclPostProcessOsd()
         : m_blockCount(0)
         , m_threshold(128)
+        , m_kernelOsd(NULL)
+        , m_kernelReduceLuma(NULL)
     {
     }
 
 private:
+    virtual bool prepareKernels();
     YamiStatus computeBlockLuma(const SharedPtr<VideoFrame> frame);
 
     static const bool s_registered; // VaapiPostProcessFactory registration result
@@ -55,6 +58,8 @@ private:
     vector<uint32_t> m_lineBuf;
     int m_blockCount;
     uint32_t m_threshold;
+    cl_kernel m_kernelOsd;
+    cl_kernel m_kernelReduceLuma;
 };
 }
 #endif //oclpostprocess_osd_h

--- a/vpp/oclpostprocess_transform.h
+++ b/vpp/oclpostprocess_transform.h
@@ -43,20 +43,35 @@ public:
 
     explicit OclPostProcessTransform()
         : m_transform(0)
+        , m_kernelFlipH(NULL)
+        , m_kernelFlipV(NULL)
+        , m_kernelRot180(NULL)
+        , m_kernelRot90(NULL)
+        , m_kernelRot270(NULL)
+        , m_kernelFlipHRot90(NULL)
+        , m_kernelFlipVRot90(NULL)
     {
     }
 
 private:
+    virtual bool prepareKernels();
     YamiStatus flip(const SharedPtr<OclVppCLImage>& src,
         const SharedPtr<OclVppCLImage>& dst);
     YamiStatus rotate(const SharedPtr<OclVppCLImage>& src,
         const SharedPtr<OclVppCLImage>& dst);
     YamiStatus flipAndRotate(const SharedPtr<OclVppCLImage>& src,
         const SharedPtr<OclVppCLImage>& dst,
-        const char* kernelName);
+        const cl_kernel& kernel);
 
     static const bool s_registered; // VaapiPostProcessFactory registration result
     uint32_t m_transform;
+    cl_kernel m_kernelFlipH;
+    cl_kernel m_kernelFlipV;
+    cl_kernel m_kernelRot180;
+    cl_kernel m_kernelRot90;
+    cl_kernel m_kernelRot270;
+    cl_kernel m_kernelFlipHRot90;
+    cl_kernel m_kernelFlipVRot90;
 };
 }
 #endif //oclpostprocess_transform_h


### PR DESCRIPTION
each ocl vpp handler will cache cl kernel objects after creating them, to avoid find from kernel map every frame.