### PR TITLE
decoder/vaapidecoder_h265: split annexb and is_nalff in h265

### DIFF
--- a/decoder/vaapidecoder_h265.h
+++ b/decoder/vaapidecoder_h265.h
@@ -136,6 +136,7 @@ private:
     void getPoc(const PicturePtr&, const H265SliceHdr* const,
             const H265NalUnit* const);
     Decode_Status decodeCurrent();
+    bool decodeCodecData(uint8_t * buf, uint32_t bufSize);
     Decode_Status outputPicture(const PicturePtr&);
 
     H265Parser* m_parser;
@@ -147,6 +148,9 @@ private:
     bool        m_newStream;
     bool        m_endOfSequence;
     DPB         m_dpb;
+    bool        m_isnalff;
+    uint32_t    m_nalLengthSize;
+    bool        m_resetContext;
     std::map<int32_t, uint8_t> m_pocToIndex;
     SharedPtr<H265SliceHdr> m_prevSlice;
 

--- a/encoder/vaapiencoder_h264.cpp
+++ b/encoder/vaapiencoder_h264.cpp
@@ -637,6 +637,7 @@ public:
         if (ret == ENCODE_SUCCESS) {
             outBuffer->dataSize = out.data - outBuffer->data;
             outBuffer->flag = out.flag;
+            outBuffer->timeStamp = out.timeStamp;
         }
         return ret;
     }

--- a/encoder/vaapiencoder_hevc.cpp
+++ b/encoder/vaapiencoder_hevc.cpp
@@ -804,6 +804,7 @@ public:
         if (ret == ENCODE_SUCCESS) {
             outBuffer->dataSize = out.data - outBuffer->data;
             outBuffer->flag = out.flag;
+            outBuffer->timeStamp = out.timeStamp;
         }
         return ret;
     }

--- a/encoder/vaapiencpicture.cpp
+++ b/encoder/vaapiencpicture.cpp
@@ -91,6 +91,7 @@ Encode_Status VaapiEncPicture::getOutput(VideoEncOutputBuffer * outBuffer)
         outBuffer->flag |= m_codedBuffer->getFlags();
     }
     outBuffer->dataSize = size;
+    outBuffer->timeStamp = this->m_timeStamp;
     return ENCODE_SUCCESS;
 }
 


### PR DESCRIPTION
add the is_nalff mode in vaapidecoder_h265.cpp to support decode the mp4 media file.

Signed-off-by: Yun Zhou <yunx.z.zhou@intel.com>