### PR TITLE
encoder/vp8: fix small resolution video encoding bug

### DIFF
--- a/encoder/vaapiencoder_vp8.cpp
+++ b/encoder/vaapiencoder_vp8.cpp
@@ -78,6 +78,9 @@ void VaapiEncoderVP8::resetParams()
 {
     //5 times compress ratio
     m_maxCodedbufSize = width() * height() * 3 / 2;
+    //when the resolution of video is very small, maybe the size of header is bigger than the body.
+    //the size of actual output buffer maybe be bigger the m_maxCodedbufSize so plusing 4096 avoid the situation.
+    m_maxCodedbufSize += 0x1000;
 }
 
 Encode_Status VaapiEncoderVP8::start()


### PR DESCRIPTION
When the resolution of video is very small, the size of vp8 header
maybe be larger than the body so that m_maxCodedbufSize is less than
the size of actual output of buffer.