### PR TITLE
enc: fix h264 core dump issue when intra_period larger than 1024

### DIFF
--- a/encoder/vaapiencoder_h264.cpp
+++ b/encoder/vaapiencoder_h264.cpp
@@ -696,12 +696,14 @@ public:
 };
 
 VaapiEncoderH264::VaapiEncoderH264():
+    m_numBFrames(0),
     m_useCabac(true),
     m_useDct8x8(false),
     m_reorderState(VAAPI_ENC_REORD_WAIT_FRAMES),
     m_streamFormat(AVC_STREAM_FORMAT_ANNEXB),
     m_frameIndex(0),
-    m_keyPeriod(30)
+    m_keyPeriod(30),
+    m_idrNum(0)
 {
     m_videoParamCommon.profile = VAProfileH264Main;
     m_videoParamCommon.level = 40;
@@ -1013,7 +1015,6 @@ Encode_Status VaapiEncoderH264::getCodecConfig(VideoEncOutputBuffer * outBuffer)
 /* Handle new GOP starts */
 void VaapiEncoderH264::resetGopStart ()
 {
-    m_idrNum = 0;
     m_frameIndex = 0;
     m_curFrameNum = 0;
 }
@@ -1046,6 +1047,7 @@ void VaapiEncoderH264::setIdrFrame (const PicturePtr& pic)
     pic->m_type = VAAPI_PICTURE_TYPE_I;
     pic->m_frameNum = 0;
     pic->m_poc = 0;
+    m_idrNum++;
 }
 
 bool VaapiEncoderH264::

--- a/encoder/vaapiencoder_h264.cpp
+++ b/encoder/vaapiencoder_h264.cpp
@@ -760,12 +760,20 @@ void VaapiEncoderH264::resetParams ()
     DEBUG("resetParams, ensureCodedBufferSize");
     ensureCodedBufferSize();
 
+    if (intraPeriod() == 0){
+        ERROR("intra period must larger than 0");
+        assert(0);
+    }
+
+    if (intraPeriod() <= ipPeriod()){
+        WARNING("intra period is not larger than ip period");
+        m_videoParamCommon.ipPeriod = intraPeriod() - 1;
+    }
+
     if (ipPeriod() == 0)
         m_videoParamCommon.intraPeriod = 1;
     else
         m_numBFrames = ipPeriod() - 1;
-
-    assert(intraPeriod() > ipPeriod());
 	
     m_keyPeriod = intraPeriod() * (m_videoParamAVC.idrInterval + 1);
 

--- a/encoder/vaapiencoder_h264.cpp
+++ b/encoder/vaapiencoder_h264.cpp
@@ -950,7 +950,7 @@ Encode_Status VaapiEncoderH264::reorder(const SurfacePtr& surface, uint64_t time
         m_reorderState = VAAPI_ENC_REORD_DUMP_FRAMES;
     }
 
-    picture->m_poc = ((m_frameIndex * 2) % m_maxPicOrderCnt);
+    picture->m_poc = m_frameIndex * 2;
     m_frameIndex++;
     return ENCODE_SUCCESS;
 }
@@ -1288,7 +1288,7 @@ bool VaapiEncoderH264::addSliceHeaders (const PicturePtr& picture) const
         sliceParam->slice_type = h264_get_slice_type (picture->m_type);
         assert (sliceParam->slice_type != -1);
         sliceParam->idr_pic_id = m_idrNum;
-        sliceParam->pic_order_cnt_lsb = picture->m_poc;
+        sliceParam->pic_order_cnt_lsb = picture->m_poc % m_maxPicOrderCnt;
 
         sliceParam->num_ref_idx_active_override_flag = 1;
         if (picture->m_type != VAAPI_PICTURE_TYPE_I && m_refList0.size() > 0)

--- a/encoder/vaapiencoder_h264.h
+++ b/encoder/vaapiencoder_h264.h
@@ -128,7 +128,7 @@ private:
     uint32_t m_log2MaxFrameNum;
     uint32_t m_maxPicOrderCnt;
     uint32_t m_log2MaxPicOrderCnt;
-    uint32_t m_idrNum;
+    uint16_t m_idrNum; //used to set idr_pic_id, max value is 65535 as spec
 
     StreamHeaderPtr m_headers;
     Lock m_paramLock; // locker for parameters update, for example: m_sps/m_pps/m_maxCodedbufSize (width/height etc)

--- a/encoder/vaapiencoder_hevc.cpp
+++ b/encoder/vaapiencoder_hevc.cpp
@@ -930,12 +930,20 @@ void VaapiEncoderHEVC::resetParams ()
         m_confWinBottomOffset = 0;
     }
 
+    if (intraPeriod() == 0){
+        ERROR("intra period must larger than 0");
+        assert(0);
+    }
+
+    if (intraPeriod() <= ipPeriod()){
+        WARNING("intra period is not larger than ip period");
+        m_videoParamCommon.ipPeriod = intraPeriod() - 1;
+    }
+
     if (ipPeriod() == 0)
         m_videoParamCommon.intraPeriod = 1;
     else if (ipPeriod() >= 1)
         m_numBFrames = ipPeriod() - 1;
-
-    assert(intraPeriod() > ipPeriod());
 
     m_keyPeriod = intraPeriod() * (m_videoParamAVC.idrInterval + 1);
 

--- a/encoder/vaapiencoder_hevc.cpp
+++ b/encoder/vaapiencoder_hevc.cpp
@@ -1145,7 +1145,6 @@ Encode_Status VaapiEncoderHEVC::getCodecConfig(VideoEncOutputBuffer * outBuffer)
 /* Handle new GOP starts */
 void VaapiEncoderHEVC::resetGopStart ()
 {
-    m_idrNum = 0;
     m_frameIndex = 0;
 }
 

--- a/encoder/vaapiencoder_hevc.cpp
+++ b/encoder/vaapiencoder_hevc.cpp
@@ -1084,7 +1084,7 @@ Encode_Status VaapiEncoderHEVC::reorder(const SurfacePtr& surface, uint64_t time
     }
 
     DEBUG("m_frameIndex is %d\n", m_frameIndex);
-    picture->m_poc = ((m_frameIndex) % m_maxPicOrderCnt);
+    picture->m_poc = m_frameIndex;
     m_frameIndex++;
     return ENCODE_SUCCESS;
 }

--- a/encoder/vaapiencoder_hevc.h
+++ b/encoder/vaapiencoder_hevc.h
@@ -152,7 +152,6 @@ private:
     uint32_t m_log2MaxFrameNum;
     uint32_t m_maxPicOrderCnt;
     uint32_t m_log2MaxPicOrderCnt;
-    uint32_t m_idrNum;
 
     bool m_confWinFlag;
     uint32_t m_confWinLeftOffset;


### PR DESCRIPTION
Fix h264/hevc core dump issues when intra_period larger than 1024, or intra_period equal to 1.