### PR TITLE
encoder/vaapiencoder_base: add outbuffer timeStamp set

### DIFF
--- a/decoder/vaapidecoder_h265.h
+++ b/decoder/vaapidecoder_h265.h
@@ -136,6 +136,7 @@ private:
     void getPoc(const PicturePtr&, const H265SliceHdr* const,
             const H265NalUnit* const);
     Decode_Status decodeCurrent();
+    bool decodeCodecData(uint8_t * buf, uint32_t bufSize);
     Decode_Status outputPicture(const PicturePtr&);
 
     H265Parser* m_parser;
@@ -147,6 +148,9 @@ private:
     bool        m_newStream;
     bool        m_endOfSequence;
     DPB         m_dpb;
+    bool        m_isnalff;
+    uint32_t    m_nalLengthSize;
+    bool        m_resetContext;
     std::map<int32_t, uint8_t> m_pocToIndex;
     SharedPtr<H265SliceHdr> m_prevSlice;
 

--- a/encoder/vaapiencoder_base.cpp
+++ b/encoder/vaapiencoder_base.cpp
@@ -527,7 +527,7 @@ Encode_Status VaapiEncoderBase::getOutput(VideoEncOutputBuffer * outBuffer, bool
     ret = picture->getOutput(outBuffer);
     if (ret != ENCODE_SUCCESS)
         return ret;
-
+    outBuffer->timeStamp = picture->m_timeStamp;
     checkCodecData(outBuffer);
     return ENCODE_SUCCESS;
 }


### PR DESCRIPTION
Encoder's outbuffer need to set timeStamp or the getOutput can not get the PTS value.

Signed-off-by: Yun Zhou <yunx.z.zhou@intel.com>