### PR TITLE
include config.h in all .c/.cpp units

### DIFF
--- a/codecparsers/bitReader.cpp
+++ b/codecparsers/bitReader.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <assert.h>
 #include "bitReader.h"
 

--- a/codecparsers/bitReader_unittest.cpp
+++ b/codecparsers/bitReader_unittest.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 // primary header
 #include "bitReader.h"
 

--- a/codecparsers/bitWriter.cpp
+++ b/codecparsers/bitWriter.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "bitWriter.h"
 #include "common/log.h"
 #include <assert.h>

--- a/codecparsers/bitWriter_unittest.cpp
+++ b/codecparsers/bitWriter_unittest.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 // primary header
 #include "bitWriter.h"
 

--- a/codecparsers/h264Parser.cpp
+++ b/codecparsers/h264Parser.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "h264Parser.h"
 
 #include <math.h>

--- a/codecparsers/h264Parser_unittest.cpp
+++ b/codecparsers/h264Parser_unittest.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 // primary header
 #include "h264Parser.h"
 

--- a/codecparsers/h265Parser.cpp
+++ b/codecparsers/h265Parser.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "h265Parser.h"
 
 #include <string.h>

--- a/codecparsers/h265Parser_unittest.cpp
+++ b/codecparsers/h265Parser_unittest.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 // primary header
 #include "h265Parser.h"
 

--- a/codecparsers/jpegParser_unittest.cpp
+++ b/codecparsers/jpegParser_unittest.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 // primary header
 #include "jpegParser.h"
 

--- a/codecparsers/mpeg2_parser_unittest.cpp
+++ b/codecparsers/mpeg2_parser_unittest.cpp
@@ -14,12 +14,15 @@
  * limitations under the License.
  */
 
-// primary header
+#ifdef HAVE_CONFIG_H
 #include "config.h"
-#include "common/log.h"
+#endif
+
+// primary header
 #include "mpeg2_parser.h"
 
 // library headers
+#include "common/log.h"
 #include "common/unittest.h"
 
 // system headers

--- a/codecparsers/nalReader.cpp
+++ b/codecparsers/nalReader.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <assert.h>
 #include "nalReader.h"
 

--- a/codecparsers/vc1Parser.cpp
+++ b/codecparsers/vc1Parser.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "vc1Parser.h"
 #include <cstring>
 #include <cassert>

--- a/codecparsers/vc1Parser_unittest.cpp
+++ b/codecparsers/vc1Parser_unittest.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "vc1Parser.h"
 
 // library headers

--- a/codecparsers/vp8_bool_decoder.cpp
+++ b/codecparsers/vp8_bool_decoder.cpp
@@ -69,6 +69,10 @@
 // project. (http://www.webmproject.org/code)
 // It is used to decode bits from a vp8 stream.
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <algorithm>
 
 #include "vp8_bool_decoder.h"

--- a/codecparsers/vp8_bool_decoder_unittest.cpp
+++ b/codecparsers/vp8_bool_decoder_unittest.cpp
@@ -34,6 +34,10 @@
 
 // This file is taken from Chromium Project and adapted to libyami
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "vp8_bool_decoder.h"
 
 #include <stddef.h>

--- a/codecparsers/vp8_parser.cpp
+++ b/codecparsers/vp8_parser.cpp
@@ -37,6 +37,10 @@
 //
 // This file is taken from Chromium Project and adapted to libyami
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "vp8_parser.h"
 #include "common/log.h"
 

--- a/codecparsers/vp9parser.cpp
+++ b/codecparsers/vp9parser.cpp
@@ -25,6 +25,7 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
 #include "bitReader.h"
 #include "vp9quant.h"
 #include "vp9parser.h"

--- a/common/YamiVersion.cpp
+++ b/common/YamiVersion.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "YamiVersion.h"
 
 void yamiGetApiVersion(uint32_t *apiVersion)

--- a/common/factory_unittest.cpp
+++ b/common/factory_unittest.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 // primary header
 #include "factory.h"
 

--- a/common/nalreader.cpp
+++ b/common/nalreader.cpp
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <algorithm>
 #include "nalreader.h"
 

--- a/common/nalreader_unittest.cpp
+++ b/common/nalreader_unittest.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 // primary header
 #include "nalreader.h"
 

--- a/common/unittest_main.cpp
+++ b/common/unittest_main.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 // library headers
 #include "common/unittest.h"
 

--- a/common/utils_unittest.cpp
+++ b/common/utils_unittest.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 // primary header
 #include "utils.h"
 

--- a/decoder/vaapiDecoderJPEG_unittest.cpp
+++ b/decoder/vaapiDecoderJPEG_unittest.cpp
@@ -14,11 +14,25 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+//
+// The unittest header must be included before va_x11.h (which might be included
+// indirectly).  The va_x11.h includes Xlib.h and X.h.  And the X headers
+// define 'Bool' and 'None' preprocessor types.  Gtest uses the same names
+// to define some struct placeholders.  Thus, this creates a compile conflict
+// if X defines them before gtest.  Hence, the include order requirement here
+// is the only fix for this right now.
+//
+// See bug filed on gtest at https://github.com/google/googletest/issues/371
+// for more details.
+//
+#include "common/factory_unittest.h"
+
 // primary header
 #include "vaapiDecoderJPEG.h"
-
-// library headers
-#include "common/factory_unittest.h"
 
 // system headers
 #include <algorithm>

--- a/decoder/vaapidecoder_h264.cpp
+++ b/decoder/vaapidecoder_h264.cpp
@@ -17,6 +17,7 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
 #include "vaapidecoder_h264.h"
 
 #include "common/log.h"

--- a/decoder/vaapidecoder_h264_unittest.cpp
+++ b/decoder/vaapidecoder_h264_unittest.cpp
@@ -14,11 +14,25 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+//
+// The unittest header must be included before va_x11.h (which might be included
+// indirectly).  The va_x11.h includes Xlib.h and X.h.  And the X headers
+// define 'Bool' and 'None' preprocessor types.  Gtest uses the same names
+// to define some struct placeholders.  Thus, this creates a compile conflict
+// if X defines them before gtest.  Hence, the include order requirement here
+// is the only fix for this right now.
+//
+// See bug filed on gtest at https://github.com/google/googletest/issues/371
+// for more details.
+//
+#include "common/factory_unittest.h"
+
 // primary header
 #include "vaapidecoder_h264.h"
-
-// library headers
-#include "common/factory_unittest.h"
 
 // system headers
 #include <tr1/array>

--- a/decoder/vaapidecoder_h265_unittest.cpp
+++ b/decoder/vaapidecoder_h265_unittest.cpp
@@ -14,11 +14,25 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+//
+// The unittest header must be included before va_x11.h (which might be included
+// indirectly).  The va_x11.h includes Xlib.h and X.h.  And the X headers
+// define 'Bool' and 'None' preprocessor types.  Gtest uses the same names
+// to define some struct placeholders.  Thus, this creates a compile conflict
+// if X defines them before gtest.  Hence, the include order requirement here
+// is the only fix for this right now.
+//
+// See bug filed on gtest at https://github.com/google/googletest/issues/371
+// for more details.
+//
+#include "common/factory_unittest.h"
+
 // primary header
 #include "vaapidecoder_h265.h"
-
-// library headers
-#include "common/factory_unittest.h"
 
 namespace YamiMediaCodec {
 

--- a/decoder/vaapidecoder_mpeg2_unittest.cpp
+++ b/decoder/vaapidecoder_mpeg2_unittest.cpp
@@ -14,11 +14,25 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+//
+// The unittest header must be included before va_x11.h (which might be included
+// indirectly).  The va_x11.h includes Xlib.h and X.h.  And the X headers
+// define 'Bool' and 'None' preprocessor types.  Gtest uses the same names
+// to define some struct placeholders.  Thus, this creates a compile conflict
+// if X defines them before gtest.  Hence, the include order requirement here
+// is the only fix for this right now.
+//
+// See bug filed on gtest at https://github.com/google/googletest/issues/371
+// for more details.
+//
+#include "common/factory_unittest.h"
+
 // primary header
 #include "vaapidecoder_mpeg2.h"
-
-// library headers
-#include "common/factory_unittest.h"
 
 namespace YamiMediaCodec {
 namespace MPEG2 {

--- a/decoder/vaapidecoder_vc1_unittest.cpp
+++ b/decoder/vaapidecoder_vc1_unittest.cpp
@@ -14,11 +14,25 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+//
+// The unittest header must be included before va_x11.h (which might be included
+// indirectly).  The va_x11.h includes Xlib.h and X.h.  And the X headers
+// define 'Bool' and 'None' preprocessor types.  Gtest uses the same names
+// to define some struct placeholders.  Thus, this creates a compile conflict
+// if X defines them before gtest.  Hence, the include order requirement here
+// is the only fix for this right now.
+//
+// See bug filed on gtest at https://github.com/google/googletest/issues/371
+// for more details.
+//
+#include "common/factory_unittest.h"
+
 // primary header
 #include "vaapidecoder_vc1.h"
-
-// library headers
-#include "common/factory_unittest.h"
 
 // system headers
 #include <tr1/array>

--- a/decoder/vaapidecoder_vp8_unittest.cpp
+++ b/decoder/vaapidecoder_vp8_unittest.cpp
@@ -14,11 +14,25 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+//
+// The unittest header must be included before va_x11.h (which might be included
+// indirectly).  The va_x11.h includes Xlib.h and X.h.  And the X headers
+// define 'Bool' and 'None' preprocessor types.  Gtest uses the same names
+// to define some struct placeholders.  Thus, this creates a compile conflict
+// if X defines them before gtest.  Hence, the include order requirement here
+// is the only fix for this right now.
+//
+// See bug filed on gtest at https://github.com/google/googletest/issues/371
+// for more details.
+//
+#include "common/factory_unittest.h"
+
 // primary header
 #include "vaapidecoder_vp8.h"
-
-// library headers
-#include "common/factory_unittest.h"
 
 namespace YamiMediaCodec {
 

--- a/decoder/vaapidecoder_vp9_unittest.cpp
+++ b/decoder/vaapidecoder_vp9_unittest.cpp
@@ -14,7 +14,23 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+//
+// The unittest header must be included before va_x11.h (which might be included
+// indirectly).  The va_x11.h includes Xlib.h and X.h.  And the X headers
+// define 'Bool' and 'None' preprocessor types.  Gtest uses the same names
+// to define some struct placeholders.  Thus, this creates a compile conflict
+// if X defines them before gtest.  Hence, the include order requirement here
+// is the only fix for this right now.
+//
+// See bug filed on gtest at https://github.com/google/googletest/issues/371
+// for more details.
+//
 #include "common/factory_unittest.h"
+
 #include "vaapidecoder_vp9.h"
 
 namespace YamiMediaCodec {

--- a/decoder/vaapidecpicture.cpp
+++ b/decoder/vaapidecpicture.cpp
@@ -17,6 +17,7 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
 #include "vaapidecpicture.h"
 
 #include "log.h"

--- a/decoder/vaapidecsurfacepool.cpp
+++ b/decoder/vaapidecsurfacepool.cpp
@@ -17,6 +17,7 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
 #include "vaapidecsurfacepool.h"
 
 #include "common/log.h"

--- a/encoder/vaapicodedbuffer.cpp
+++ b/encoder/vaapicodedbuffer.cpp
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
 #include "vaapicodedbuffer.h"
 
 #include "vaapicontext.h"

--- a/encoder/vaapiencoder_base.cpp
+++ b/encoder/vaapiencoder_base.cpp
@@ -17,6 +17,7 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
 #include "vaapiencoder_base.h"
 #include <assert.h>
 #include <stdint.h>

--- a/encoder/vaapiencoder_h264.cpp
+++ b/encoder/vaapiencoder_h264.cpp
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
 #include "vaapiencoder_h264.h"
 #include <assert.h>
 #include "bitWriter.h"

--- a/encoder/vaapiencoder_h264_unittest.cpp
+++ b/encoder/vaapiencoder_h264_unittest.cpp
@@ -14,11 +14,25 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+//
+// The unittest header must be included before va_x11.h (which might be included
+// indirectly).  The va_x11.h includes Xlib.h and X.h.  And the X headers
+// define 'Bool' and 'None' preprocessor types.  Gtest uses the same names
+// to define some struct placeholders.  Thus, this creates a compile conflict
+// if X defines them before gtest.  Hence, the include order requirement here
+// is the only fix for this right now.
+//
+// See bug filed on gtest at https://github.com/google/googletest/issues/371
+// for more details.
+//
+#include "common/factory_unittest.h"
+
 // primary header
 #include "vaapiencoder_h264.h"
-
-// library headers
-#include "common/factory_unittest.h"
 
 namespace YamiMediaCodec {
 

--- a/encoder/vaapiencoder_hevc.cpp
+++ b/encoder/vaapiencoder_hevc.cpp
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
 #include "vaapiencoder_hevc.h"
 #include <assert.h>
 #include "bitWriter.h"

--- a/encoder/vaapiencoder_hevc_unittest.cpp
+++ b/encoder/vaapiencoder_hevc_unittest.cpp
@@ -14,11 +14,25 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+//
+// The unittest header must be included before va_x11.h (which might be included
+// indirectly).  The va_x11.h includes Xlib.h and X.h.  And the X headers
+// define 'Bool' and 'None' preprocessor types.  Gtest uses the same names
+// to define some struct placeholders.  Thus, this creates a compile conflict
+// if X defines them before gtest.  Hence, the include order requirement here
+// is the only fix for this right now.
+//
+// See bug filed on gtest at https://github.com/google/googletest/issues/371
+// for more details.
+//
+#include "common/factory_unittest.h"
+
 // primary header
 #include "vaapiencoder_hevc.h"
-
-// library headers
-#include "common/factory_unittest.h"
 
 namespace YamiMediaCodec {
 

--- a/encoder/vaapiencoder_host.cpp
+++ b/encoder/vaapiencoder_host.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "common/log.h"
 #include "interface/VideoEncoderHost.h"
 #include "vaapiencoder_factory.h"

--- a/encoder/vaapiencoder_jpeg.cpp
+++ b/encoder/vaapiencoder_jpeg.cpp
@@ -17,6 +17,7 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
 #include "vaapiencoder_jpeg.h"
 #include "codecparsers/jpegParser.h"
 #include "common/common_def.h"

--- a/encoder/vaapiencoder_jpeg_unittest.cpp
+++ b/encoder/vaapiencoder_jpeg_unittest.cpp
@@ -14,11 +14,27 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+//
+// The unittest header must be included before va_x11.h (which might be included
+// indirectly).  The va_x11.h includes Xlib.h and X.h.  And the X headers
+// define 'Bool' and 'None' preprocessor types.  Gtest uses the same names
+// to define some struct placeholders.  Thus, this creates a compile conflict
+// if X defines them before gtest.  Hence, the include order requirement here
+// is the only fix for this right now.
+//
+// See bug filed on gtest at https://github.com/google/googletest/issues/371
+// for more details.
+//
+#include "common/factory_unittest.h"
+
 // primary header
 #include "vaapiencoder_jpeg.h"
 
 // library headers
-#include "common/factory_unittest.h"
 #include "common/utils.h"
 
 // system headers

--- a/encoder/vaapiencoder_vp8.cpp
+++ b/encoder/vaapiencoder_vp8.cpp
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
 #include "vaapiencoder_vp8.h"
 #include "scopedlogger.h"
 #include "common/common_def.h"

--- a/encoder/vaapiencoder_vp8_unittest.cpp
+++ b/encoder/vaapiencoder_vp8_unittest.cpp
@@ -14,11 +14,25 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+//
+// The unittest header must be included before va_x11.h (which might be included
+// indirectly).  The va_x11.h includes Xlib.h and X.h.  And the X headers
+// define 'Bool' and 'None' preprocessor types.  Gtest uses the same names
+// to define some struct placeholders.  Thus, this creates a compile conflict
+// if X defines them before gtest.  Hence, the include order requirement here
+// is the only fix for this right now.
+//
+// See bug filed on gtest at https://github.com/google/googletest/issues/371
+// for more details.
+//
+#include "common/factory_unittest.h"
+
 // primary header
 #include "vaapiencoder_vp8.h"
-
-// library headers
-#include "common/factory_unittest.h"
 
 namespace YamiMediaCodec {
 

--- a/encoder/vaapiencpicture.cpp
+++ b/encoder/vaapiencpicture.cpp
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
 #include "vaapiencpicture.h"
 #include "vaapicodedbuffer.h"
 

--- a/vaapi/vaapicontext.cpp
+++ b/vaapi/vaapicontext.cpp
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
 #include "vaapi/vaapicontext.h"
 
 #include "common/log.h"

--- a/vaapi/vaapidisplay.cpp
+++ b/vaapi/vaapidisplay.cpp
@@ -17,6 +17,7 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
 #include "vaapi/vaapidisplay.h"
 #include <stdint.h>
 #include <unistd.h>

--- a/vaapi/vaapipicture.cpp
+++ b/vaapi/vaapipicture.cpp
@@ -17,6 +17,7 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
 #include "vaapipicture.h"
 
 #include "common/log.h"

--- a/vaapi/vaapisurfaceallocator.cpp
+++ b/vaapi/vaapisurfaceallocator.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/vpp/oclvppimage.cpp
+++ b/vpp/oclvppimage.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "common/log.h"
 #include "ocl/oclcontext.h"
 #include "oclvppimage.h"


### PR DESCRIPTION
Always include config.h first in every .c/.cpp file
before including other headers.  This will ensure
consistent declarations when headers depend on
config.h defs.

https://www.gnu.org/software/autoconf/manual/autoconf-2.66/html_node/Configuration-Headers.html

Also Fixes #473

Signed-off-by: U. Artie Eoff ullysses.a.eoff@intel.com
