### PR TITLE
README: fix demo app url

### DIFF
--- a/README
+++ b/README
@@ -50,7 +50,7 @@ Git repository for work-in-progress changes is available at:
 
 Simple api demo application
 ---------------------------
-https://github.com/01org/libyami/blob/master/examples/simpleplayer.cpp
+https://github.com/01org/libyami-utils/blob/master/examples/simpleplayer.cpp
 
 
 Build instructions


### PR DESCRIPTION
Demo applications are hosted in libyami-utils project
now.

Signed-off-by: U. Artie Eoff ullysses.a.eoff@intel.com
