### PR TITLE
mpeg2decoder: report properly a port reconfiguration

### DIFF
--- a/decoder/vaapidecoder_mpeg2.cpp
+++ b/decoder/vaapidecoder_mpeg2.cpp
@@ -346,9 +346,6 @@ YamiStatus VaapiDecoderMPEG2::processConfigBuffer()
                 if (status != YAMI_SUCCESS) {
                     return status;
                 }
-                else if (status == YAMI_SUCCESS) {
-                    status = YAMI_DECODE_FORMAT_CHANGE;
-                }
                 break;
 
             case YamiParser::MPEG2::kQuantizationMatrix:
@@ -476,6 +473,10 @@ YamiStatus VaapiDecoderMPEG2::processDecodeBuffer()
             m_sequenceExtension = m_parser->getSequenceExtension();
             m_previousStartCode = m_nextStartCode;
             m_nextStartCode = YamiParser::MPEG2::MPEG2_GROUP_START_CODE;
+            status = fillConfigBuffer();
+            if (status != YAMI_SUCCESS) {
+                return status;
+            }
         }
         break;
     case YamiParser::MPEG2::MPEG2_SEQUENCE_END_CODE:
@@ -543,34 +544,61 @@ YamiStatus VaapiDecoderMPEG2::fillConfigBuffer()
     m_configBuffer.width
         = (m_sequenceExtension->horizontal_size_extension & 0x3)
           | (m_sequenceHeader->horizontal_size_value & 0xFFF);
-    m_configBuffer.height
-        = (m_sequenceExtension->vertical_size_extension & 0x3)
-          | (m_sequenceHeader->vertical_size_value & 0xFFF);
+    m_configBuffer.height = (m_sequenceExtension->vertical_size_extension & 0x3)
+                            | (m_sequenceHeader->vertical_size_value & 0xFFF);
 
-    m_configBuffer.profile = m_VAProfile;
-
-    DEBUG("MPEG2: start() buffer size: %d x %d m_VAProfile %x level %x",
-          m_configBuffer.width, m_configBuffer.height, m_configBuffer.profile,
-          level);
-
-    m_configBuffer.surfaceWidth = m_configBuffer.width;
-    m_configBuffer.surfaceHeight = m_configBuffer.height;
-    if (m_configBuffer.surfaceNumber) {
-        m_configBuffer.surfaceNumber = m_configBuffer.surfaceNumber;
-    } else {
-        m_configBuffer.surfaceNumber = 8;
+    if (m_VAStart) {
+        // sequence start extension code with VA started has to conduct a
+        // port reconfiguration when stream size changes
+        if (m_configBuffer.width > m_videoFormatInfo.width
+            || m_configBuffer.height > m_videoFormatInfo.height) {
+            // need to re-start VA to generate new surfaces
+            status = VaapiDecoderBase::terminateVA();
+            if (status != YAMI_SUCCESS) {
+                return status;
+            }
+            m_VAStart = false;
+        }
+        else if (m_configBuffer.width != m_videoFormatInfo.width
+                 || m_configBuffer.height != m_videoFormatInfo.height) {
+            // VA surfaces can be re-used and client is notified
+            // public member from base class
+            m_videoFormatInfo.width = m_configBuffer.width;
+            m_videoFormatInfo.height = m_configBuffer.height;
+            m_videoFormatInfo.surfaceWidth = m_configBuffer.width;
+            m_videoFormatInfo.surfaceHeight = m_configBuffer.height;
+            m_configBuffer.surfaceWidth = m_configBuffer.width;
+            m_configBuffer.surfaceHeight = m_configBuffer.height;
+            status = YAMI_DECODE_FORMAT_CHANGE;
+        }
     }
-    // no information is sent to start libva at this point
-    m_configBuffer.data = NULL;
-    m_configBuffer.size = 0;
 
-    // ready to start libva
-    status = VaapiDecoderBase::start(&m_configBuffer);
-    if (status != YAMI_SUCCESS) {
-        return status;
+    if (!m_VAStart) {
+
+        m_configBuffer.profile = m_VAProfile;
+
+        DEBUG("MPEG2: start() buffer size: %d x %d m_VAProfile %x level %x",
+              m_configBuffer.width, m_configBuffer.height,
+              m_configBuffer.profile, level);
+
+        m_configBuffer.surfaceWidth = m_configBuffer.width;
+        m_configBuffer.surfaceHeight = m_configBuffer.height;
+        if (!m_configBuffer.surfaceNumber) {
+            m_configBuffer.surfaceNumber = kMinSurfaces;
+        }
+        // no information is sent to start libva at this point
+        m_configBuffer.data = NULL;
+        m_configBuffer.size = 0;
+
+        // ready to start libva
+        status = VaapiDecoderBase::start(&m_configBuffer);
+        if (status != YAMI_SUCCESS) {
+            return status;
+        }
+        m_VAStart = true;
+        status = YAMI_DECODE_FORMAT_CHANGE;
     }
 
-    m_VAStart = true;
     return status;
 }
 

--- a/decoder/vaapidecoder_mpeg2.h
+++ b/decoder/vaapidecoder_mpeg2.h
@@ -34,7 +34,8 @@ enum Mpeg2PictureStructureType {
 };
 
 enum {
-    MPEG2_MAX_REFERENCE_PICTURES = 2,
+    kMaxRefPictures = 2,
+    kMinSurfaces = 8,
 };
 
 struct IQMatricesRefs {
@@ -67,7 +68,7 @@ private:
 
     public:
         DPB(OutputCallback callback)
-            : m_numberSurfaces(MPEG2_MAX_REFERENCE_PICTURES)
+            : m_numberSurfaces(kMaxRefPictures)
             , m_outputPicture(callback)
         {
         }


### PR DESCRIPTION
Port Reconfiguration might happen at any new sequence header extension.
If a new resolution is detected and bigger to current then libva has to
restart with the new resolution.  Smaller new resolution can re-use the
current surfaces.

Also clean up code around the modified lines including the proper selection
when numberSurfaces is not given in the configBuffer

Signed-off-by: Daniel Charles daniel.charles@intel.com
