### PR TITLE
encoder: add timeStamp setting in encoder output buffer

### DIFF
--- a/encoder/vaapiencoder_base.cpp
+++ b/encoder/vaapiencoder_base.cpp
@@ -568,6 +568,7 @@ YamiStatus VaapiEncoderBase::getOutput(VideoEncOutputBuffer* outBuffer, bool wit
     if (ret != YAMI_SUCCESS)
         return ret;
 
+    outBuffer->timeStamp = picture->m_timeStamp;
     checkCodecData(outBuffer);
     return YAMI_SUCCESS;
 }
@@ -595,6 +596,7 @@ YamiStatus VaapiEncoderBase::getOutput(VideoEncOutputBuffer* outBuffer, VideoEnc
         return ret;
     if (data)
         memcpy(MVBuffer->data, data, mappedSize);
+    outBuffer->timeStamp = picture->m_timeStamp;
     checkCodecData(outBuffer);
     return YAMI_SUCCESS;
 }


### PR DESCRIPTION
outbuffer need to set timeStamp or the getOutput() can't get the PTS
(presentation time stamp) value.

Signed-off-by: Jun Zhao jun.zhao@intel.com
