### PR TITLE
add gtest build command to readme.

### DIFF
--- a/README
+++ b/README
@@ -87,6 +87,12 @@ Unit Tests
   The gtest documentation can be found in their source tree under `docs` (online
   or in the downloaded source archive).
 
+  To build gtest you need:
+     cd ${GTEST_DIR}
+     autoreconf -v --install
+     ./configure --disable-shared --enable-static
+     make
+
   To enable the unit tests, when configuring libyami you need to specify:
 
     --enable-gtest=${GTEST_DIR}


### PR DESCRIPTION
Use cmake to build gtest is not working, libyami will complain about missing gtest.config. We need use autoreconf to build gtest
