### PR TITLE
Various configure/compile error fixes for older toolchains

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,4 @@
+ACLOCAL_AMFLAGS = -I m4
 
 # Extra clean files so that maintainer-clean removes *everything*
 DISTCLEANFILES = \

--- a/configure.ac
+++ b/configure.ac
@@ -296,8 +296,8 @@ fi
 AM_CONDITIONAL(ENABLE_DOCS,
     [test "$enable_docs" = "yes"])
 
-AC_SUBST([AM_CFLAGS], ["-g -O2 -Wno-unused-function -Wno-cpp -Wall -Werror"])
-AC_SUBST([AM_CXXFLAGS], ["-g -O2 -Wno-unused-function -Wno-cpp -Wall -Werror"])
+AC_SUBST([AM_CFLAGS], ["-g -O2 -Wall -Wno-unused-function -Wno-cpp -Werror"])
+AC_SUBST([AM_CXXFLAGS], ["-g -O2 -Wall -Wno-unused-function -Wno-cpp -Wno-missing-braces -Werror"])
 
 # Checks for programs.
 AC_DISABLE_STATIC

--- a/v4l2/v4l2_decode.cpp
+++ b/v4l2/v4l2_decode.cpp
@@ -17,6 +17,9 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
+#define __STDC_FORMAT_MACROS
+
 #include <inttypes.h>
 #include <linux/videodev2.h>
 #include <unistd.h>


### PR DESCRIPTION
Fix multiple configure and compile errors on older toolchains (e.g. provided on Fedora 17).

Signed-off-by: U. Artie Eoff ullysses.a.eoff@intel.com
