### PR TITLE
dec: fix mpeg2 decoder can't get PTS issue.

### DIFF
--- a/decoder/vaapidecoder_mpeg2.cpp
+++ b/decoder/vaapidecoder_mpeg2.cpp
@@ -903,6 +903,7 @@ YamiStatus VaapiDecoderMPEG2::decode(VideoDecodeBuffer* buffer)
     m_stream->data = buffer->data;
     m_stream->streamSize = buffer->size;
     m_stream->time_stamp = buffer->timeStamp;
+    m_currentPTS = buffer->timeStamp;
 
     DEBUG("decode size %ld timeStamp %ld", m_stream->streamSize,
           m_stream->time_stamp);


### PR DESCRIPTION
mpeg2 decoder need to update m_currentPTS when decoding, if not mpeg2
decoder get wrong PTS and lead to video/audio sync up issue.

Signed-off-by: Jun Zhao jun.zhao@intel.com
