### PR TITLE
mpeg2dec: do not change the status reported

### DIFF
--- a/decoder/vaapidecoder_mpeg2.cpp
+++ b/decoder/vaapidecoder_mpeg2.cpp
@@ -289,9 +289,6 @@ YamiStatus VaapiDecoderMPEG2::start(VideoConfigBuffer* buffer)
         m_parser->nextStartCode(m_stream.get(), next_code);
         DEBUG("start Next start_code %x", next_code);
         status = processConfigBuffer();
-        if (status == YAMI_DECODE_FORMAT_CHANGE) {
-            status = YAMI_SUCCESS;
-        }
     }
 
     return status;


### PR DESCRIPTION
Client needs to know about the format change on the first
time they'll try to decode a sequence header.

Fixes #505

Signed-off-by: Daniel Charles daniel.charles@intel.com
