### PR TITLE
h264dec: only fill referenced dpb pictures for vaapi

### DIFF
--- a/decoder/vaapidecoder_h264.cpp
+++ b/decoder/vaapidecoder_h264.cpp
@@ -1287,10 +1287,12 @@ void VaapiDecoderH264::fillReference(VAPictureH264* refs, size_t size)
     size_t i = 0;
     DPB::PictureList::iterator it = m_dpb.m_pictures.begin();
 
-    for (; it != m_dpb.m_pictures.end(); i++, it++) {
-        fillVAPictureH264(&refs[i], *it);
-        DEBUG("poc %d, isShortRef %d, isRef %d", (*it)->m_poc,
-              (*it)->m_shortTermRefFlag, (*it)->m_isReference);
+    for (; it != m_dpb.m_pictures.end(); it++) {
+        if (!isReference(*it))
+            continue;
+        fillVAPictureH264(&refs[i++], *it);
+        DEBUG("id %d, poc %d, isShortRef %d, isRef %d", (*it)->getSurfaceID(),
+              (*it)->m_poc, (*it)->m_shortTermRefFlag, (*it)->m_isReference);
     }
 
     for (; i < size; i++) {


### PR DESCRIPTION
Only fill the VAAPI picture reference list with pictures
that are currently referenced in the dpb.  Loading
unreferenced dpb pictures in VAAPI is unnecessary.

Signed-off-by: U. Artie Eoff ullysses.a.eoff@intel.com
