### PR TITLE
h264enc: add different profiles setting

### DIFF
--- a/encoder/vaapiencoder_h264.h
+++ b/encoder/vaapiencoder_h264.h
@@ -89,6 +89,7 @@ private:
     void setIdrFrame(const PicturePtr&);
 
     void resetParams();
+    void checkProfileLimitation();
 
     VideoParamsAVC m_videoParamAVC;
 


### PR DESCRIPTION
1. support baseline/constrained baseline/main/high profile setting.
2. baseline profile is treated as constrained baseline.

Signed-off-by: Zhong Li zhong.li@intel.com
