### PR TITLE
serials patch to fix #495

### DIFF
--- a/codecparsers/Makefile.unittest
+++ b/codecparsers/Makefile.unittest
@@ -3,6 +3,7 @@ noinst_PROGRAMS = unittest
 unittest_SOURCES = \
 	unittest_main.cpp \
 	bitReader_unittest.cpp \
+	nalReader_unittest.cpp \
 	bitWriter_unittest.cpp \
 	$(NULL)
 

--- a/codecparsers/bitReader.h
+++ b/codecparsers/bitReader.h
@@ -28,7 +28,11 @@ public:
     BitReader(const uint8_t* data, uint32_t size);
     virtual ~BitReader() {}
 
+    /* Read specified bits(<= 8*sizeof(uint32_t)) as a uint32_t to v */
+    /* if not enough data, it will return false, eat all data and keep v untouched */
+    bool read(uint32_t& v, uint32_t nbits);
     /* Read specified bits(<= 8*sizeof(uint32_t)) as a uint32_t return value */
+    /* will return 0 if not enough data*/
     uint32_t read(uint32_t nbits);
 
     /*read the next nbits bits from the bitstream but not advance the bitstream pointer*/
@@ -58,13 +62,15 @@ public:
 
 protected:
     virtual void loadDataToCache(uint32_t nbytes);
-    inline uint32_t extractBitsFromCache(uint32_t nbits);
 
     const uint8_t* m_stream; /*a pointer to source data*/
     uint32_t m_size; /*the size of source data in bytes*/
     unsigned long int m_cache; /*the buffer which load less than or equal to 8 bytes*/
     uint32_t m_loadBytes; /*the total bytes of data read from source data*/
     uint32_t m_bitsInCache; /*the remaining bits in cache*/
+private:
+    inline uint32_t extractBitsFromCache(uint32_t nbits);
+    inline void reload();
 };
 
 } /*namespace YamiParser*/

--- a/codecparsers/nalReader.h
+++ b/codecparsers/nalReader.h
@@ -28,7 +28,9 @@ public:
     NalReader(const uint8_t *data, uint32_t size);
 
     /*parse Exp-Golomb coding*/
+    bool readUe(uint32_t& v);
     uint32_t readUe();
+    bool readSe(int32_t& v);
     int32_t readSe();
 
     bool moreRbspData() const;

--- a/codecparsers/nalReader_unittest.cpp
+++ b/codecparsers/nalReader_unittest.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+3B *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+// primary header
+#include "nalReader.h"
+
+// library headers
+#include "common/unittest.h"
+
+namespace YamiParser {
+
+class NalReaderTest
+    : public ::testing::Test {
+};
+
+#define NALREADER_TEST(name) \
+    TEST_F(NalReaderTest, name)
+
+NALREADER_TEST(ReadBeyondBoundary)
+{
+    uint8_t data = 0x55;
+    uint32_t u;
+    int32_t s;
+    NalReader reader(&data, 1);
+    EXPECT_EQ(0u, reader.read(1));
+    EXPECT_EQ(1u, reader.read(1));
+    EXPECT_TRUE(reader.readUe(u));
+    EXPECT_EQ(1u, u);
+    EXPECT_TRUE(reader.readSe(s));
+    EXPECT_EQ(0, s);
+
+    EXPECT_FALSE(reader.end());
+    EXPECT_FALSE(reader.read(u, 8));
+    EXPECT_TRUE(reader.end());
+    EXPECT_FALSE(reader.readUe(u));
+    EXPECT_EQ(0u, reader.readUe());
+    EXPECT_FALSE(reader.readSe(s));
+    EXPECT_EQ(0, reader.readSe());
+}
+
+} // namespace YamiParser

--- a/decoder/vaapidecoder_h264.cpp
+++ b/decoder/vaapidecoder_h264.cpp
@@ -1201,7 +1201,7 @@ YamiStatus VaapiDecoderH264::decodeSps(NalUnit* nalu)
 
     memset(sps.get(), 0, sizeof(SPS));
     if (!m_parser.parseSps(sps, nalu)) {
-        return YAMI_FAIL;
+        return YAMI_DECODE_INVALID_DATA;
     }
 
     return YAMI_SUCCESS;
@@ -1213,7 +1213,7 @@ YamiStatus VaapiDecoderH264::decodePps(NalUnit* nalu)
 
     memset(pps.get(), 0, sizeof(PPS));
     if (!m_parser.parsePps(pps, nalu)) {
-        return YAMI_FAIL;
+        return YAMI_DECODE_INVALID_DATA;
     }
 
     return YAMI_SUCCESS;
@@ -1505,7 +1505,7 @@ YamiStatus VaapiDecoderH264::decodeCurrent()
     if (!m_currPic->decode()) {
         ERROR("decode %d failed", m_currPic->m_poc);
         // ignore it to let application continue to decode the next frame
-        return status;
+        return YAMI_DECODE_INVALID_DATA;
     } else
         DEBUG("decode %d done", m_currPic->m_poc);
 
@@ -1631,7 +1631,7 @@ YamiStatus VaapiDecoderH264::decodeSlice(NalUnit* nalu)
     memset(slice, 0, sizeof(SliceHeader));
 
     if (!slice->parseHeader(&m_parser, nalu))
-        return YAMI_FAIL;
+        return YAMI_DECODE_INVALID_DATA;
 
     status = ensureContext(slice->m_pps->m_sps);
     if (status != YAMI_SUCCESS) {
@@ -1658,7 +1658,7 @@ YamiStatus VaapiDecoderH264::decodeSlice(NalUnit* nalu)
     m_dpb.initReference(m_currPic, slice);
 
     if (!m_currPic)
-        return YAMI_FAIL;
+        return YAMI_DECODE_INVALID_DATA;
 
     if (!fillSlice(m_currPic, slice, nalu))
         return YAMI_FAIL;


### PR DESCRIPTION
The root cause of #495 is we have issue in error bit stream handle. When we read ue at end of stream. We will enter infinite loop. Core code is here.

```
for (uint32_t b = 0; !b; leadingZeroBits++) {
  b = read(1);
```

when we read to end of stream read always return 0, so !b never become false. It enter infinite loop.
We need return a value in read to indicate read failed.
