### PR TITLE
h264dec: reduce decoder buffering frame number.

### DIFF
--- a/decoder/vaapidecoder_h264.cpp
+++ b/decoder/vaapidecoder_h264.cpp
@@ -1085,8 +1085,10 @@ bool VaapiDecoderH264::DPB::add(const PicturePtr& picture)
         return output(picture);
     }
 
-    while (isFull())
-        bump();
+    while (isFull()) {
+        if (!bump())
+            return false;
+    }
 
     if (!isSecondField(picture))
         m_pictures.insert(picture);

--- a/decoder/vaapidecoder_h264.h
+++ b/decoder/vaapidecoder_h264.h
@@ -25,7 +25,7 @@
 
 namespace YamiMediaCodec {
 
-enum { H264_EXTRA_SURFACE_NUMBER = 3, H264_MAX_REFRENCE_SURFACE_NUMBER = 16 };
+#define H264_MAX_REFRENCE_SURFACE_NUMBER 16
 
 class VaapiDecPictureH264;
 class VaapiDecoderH264 : public VaapiDecoderBase {
@@ -62,7 +62,8 @@ private:
         DPB(OutputCallback output);
         bool init(const PicturePtr&, const PicturePtr&,
                   const SliceHeader* const, const NalUnit* const,
-                  bool newStream, bool contextChanged);
+                  bool newStream, bool contextChanged,
+                  uint32_t maxDecFrameBuffering);
         bool add(const PicturePtr&);
         void initReference(const PicturePtr&, const SliceHeader* const);
         void flush();
@@ -129,7 +130,7 @@ private:
     YamiStatus decodePps(NalUnit*);
     YamiStatus decodeSlice(NalUnit*);
 
-    YamiStatus ensureContext(const SharedPtr<SPS> sps);
+    YamiStatus ensureContext(const SharedPtr<SPS>& sps);
     bool fillPicture(const PicturePtr&, const SliceHeader* const);
     bool fillSlice(const PicturePtr&, const SliceHeader* const,
                    const NalUnit* const);
@@ -143,7 +144,7 @@ private:
     void fillReferenceIndexForList(VASliceParameterBufferH264* sliceParam,
                                    const SliceHeader* const slice,
                                    RefSet& refSet, bool isList0);
-    bool isDecodeContextChanged(const SharedPtr<SPS> sps);
+    bool isDecodeContextChanged(const SharedPtr<SPS>& sps);
     bool decodeAvcRecordData(uint8_t* buf, int32_t bufSize);
 
     YamiStatus createPicture(const SliceHeader* const,


### PR DESCRIPTION
1. remove H264_EXTRA_SURFACE_NUMBER, since it handled by
   vaapisurfaceallocator.
2. limit m_maxDecFrameBuffering as level_idc, it is benefit to reduce
   memory consume and decoding latency.
3. chech bump status to avoid infinite loop
