### PR TITLE
h264dec: check read beyond boundary for every bit

### DIFF
--- a/codecparsers/bitReader.h
+++ b/codecparsers/bitReader.h
@@ -35,6 +35,15 @@ public:
     /* will return 0 if not enough data*/
     uint32_t read(uint32_t nbits);
 
+    /*TODO: change to this to read, and change read to readBits */
+    template <class T>
+    inline bool readT(T& v, uint32_t nbits);
+
+    template <class T>
+    inline bool readT(T& v);
+
+    inline bool readT(bool& v);
+
     /*read the next nbits bits from the bitstream but not advance the bitstream pointer*/
     uint32_t peek(uint32_t nbits) const;
 
@@ -72,6 +81,27 @@ private:
     inline uint32_t extractBitsFromCache(uint32_t nbits);
     inline void reload();
 };
+
+template <class T>
+bool BitReader::readT(T& v, uint32_t nbits)
+{
+    uint32_t tmp;
+    if (!read(tmp, nbits))
+        return false;
+    v = tmp;
+    return true;
+}
+
+template <class T>
+bool BitReader::readT(T& v)
+{
+    return readT(v, sizeof(v) << 3);
+}
+
+bool BitReader::readT(bool& v)
+{
+    return readT(v, 1);
+}
 
 } /*namespace YamiParser*/
 

--- a/codecparsers/h264Parser.cpp
+++ b/codecparsers/h264Parser.cpp
@@ -22,6 +22,38 @@
 
 #include <math.h>
 
+#define READ(f)                             \
+    do {                                    \
+        if (!br.readT(f)) {                 \
+            ERROR("failed to read %s", #f); \
+            return false;                   \
+        }                                   \
+    } while (0)
+
+#define READ_BITS(f, bits)                              \
+    do {                                                \
+        if (!br.readT(f, bits)) {                       \
+            ERROR("failed to read %d to %s", bits, #f); \
+            return false;                               \
+        }                                               \
+    } while (0)
+
+#define READ_UE(f)                            \
+    do {                                      \
+        if (!br.readUe(f)) {                  \
+            ERROR("failed to readUe %s", #f); \
+            return false;                     \
+        }                                     \
+    } while (0)
+
+#define READ_SE(f)                            \
+    do {                                      \
+        if (!br.readSe(f)) {                  \
+            ERROR("failed to readSe %s", #f); \
+            return false;                     \
+        }                                     \
+    } while (0)
+
 namespace YamiParser {
 namespace H264 {
 
@@ -82,14 +114,14 @@ static int32_t searchStartPos(const uint8_t* src, uint32_t size)
 }
 
 //7.3.2.1.1.1 Scaling list syntax
-static void scalingList(NalReader& nr, uint8_t* sl, uint32_t size, uint32_t index)
+static bool scalingList(NalReader& br, uint8_t* sl, uint32_t size, uint32_t index)
 {
     uint8_t lastScale = 8;
     uint8_t nextScale = 8;
     int32_t delta_scale;
     for (uint32_t j = 0; j < size; j++) {
         if (nextScale) {
-            delta_scale = nr.readSe();
+            READ_SE(delta_scale);
             nextScale = (lastScale + delta_scale + 256) % 256;
         }
         if (!j && !nextScale) {
@@ -99,6 +131,7 @@ static void scalingList(NalReader& nr, uint8_t* sl, uint32_t size, uint32_t inde
         sl[j] = (!nextScale) ? lastScale : nextScale;
         lastScale = sl[j];
     }
+    return true;
 }
 
 PPS::~PPS()
@@ -107,29 +140,31 @@ PPS::~PPS()
 }
 
 //according to G.7.3.1.1
-void NalUnit::parseSvcExtension(BitReader& br)
+bool NalUnit::parseSvcExtension(BitReader& br)
 {
-    m_svc.idr_flag = br.read(1);
-    m_svc.priority_id = br.read(6);
-    m_svc.no_inter_layer_pred_flag = br.read(1);
-    m_svc.dependency_id = br.read(3);
-    m_svc.quality_id = br.read(4);
-    m_svc.temporal_id = br.read(3);
-    m_svc.use_ref_base_pic_flag = br.read(1);
-    m_svc.discardable_flag = br.read(1);
-    m_svc.output_flag = br.read(1);
-    m_svc.reserved_three_2bits = br.read(2);
+    READ(m_svc.idr_flag);
+    READ_BITS(m_svc.priority_id, 6);
+    READ(m_svc.no_inter_layer_pred_flag);
+    READ_BITS(m_svc.dependency_id, 3);
+    READ_BITS(m_svc.quality_id, 4);
+    READ_BITS(m_svc.temporal_id, 3);
+    READ(m_svc.use_ref_base_pic_flag);
+    READ(m_svc.discardable_flag);
+    READ(m_svc.output_flag);
+    READ_BITS(m_svc.reserved_three_2bits, 2);
+    return true;
 }
 
 //according to H.7.3.1.1
-void NalUnit::parseMvcExtension(BitReader& br)
+bool NalUnit::parseMvcExtension(BitReader& br)
 {
-    m_mvc.non_idr_flag = br.read(1);
-    m_mvc.priority_id = br.read(6);
-    m_mvc.view_id = br.read(10);
-    m_mvc.temporal_id = br.read(3);
-    m_mvc.anchor_pic_flag = br.read(1);
-    m_mvc.inter_view_flag = br.read(1);
+    READ(m_mvc.non_idr_flag);
+    READ_BITS(m_mvc.priority_id, 6);
+    READ_BITS(m_mvc.view_id, 10);
+    READ_BITS(m_mvc.temporal_id, 3);
+    READ(m_mvc.anchor_pic_flag);
+    READ(m_mvc.inter_view_flag);
+    return true;
 }
 
 bool NalUnit::parseNalUnit(const uint8_t* src, size_t size)
@@ -142,23 +177,25 @@ bool NalUnit::parseNalUnit(const uint8_t* src, size_t size)
     BitReader br(m_data, m_size);
 
     br.skip(1); // forbidden_zero_bit
-    nal_ref_idc = br.read(2);
-    nal_unit_type = br.read(5);
+    READ_BITS(nal_ref_idc, 2);
+    READ_BITS(nal_unit_type, 5);
     //7-1
     m_idrPicFlag = (nal_unit_type == 5 ? 1 : 0);
     m_nalUnitHeaderBytes = 1;
 
-    uint8_t svc_extension_flag;
+    bool svc_extension_flag;
     if (nal_unit_type == NAL_PREFIX_UNIT
         || nal_unit_type == NAL_SLICE_EXT
         || nal_unit_type == NAL_SLICE_EXT_DEPV) {
-        svc_extension_flag = br.read(1);
+        READ(svc_extension_flag);
         if (svc_extension_flag) {
-            parseSvcExtension(br);
+            if (!parseSvcExtension(br))
+                return false;
             //G.7.4.1.1
             m_idrPicFlag = m_svc.idr_flag;
         } else {
-            parseMvcExtension(br);
+            if (!parseMvcExtension(br))
+                return false;
             //H.7.4.1.1
             m_idrPicFlag = !m_mvc.non_idr_flag;
         }
@@ -170,108 +207,108 @@ bool NalUnit::parseNalUnit(const uint8_t* src, size_t size)
 
 const uint8_t Parser::EXTENDED_SAR = 255;
 
-bool Parser::hrdParameters(HRDParameters* hrd, NalReader& nr)
+bool Parser::hrdParameters(HRDParameters* hrd, NalReader& br)
 {
-    hrd->cpb_cnt_minus1 = nr.readUe();
+    READ_UE(hrd->cpb_cnt_minus1);
     if (hrd->cpb_cnt_minus1 > MAX_CPB_CNT_MINUS1)
         return false;
-    hrd->bit_rate_scale = nr.read(4);
-    hrd->cpb_size_scale = nr.read(4);
+    READ_BITS(hrd->bit_rate_scale, 4);
+    READ_BITS(hrd->cpb_size_scale, 4);
 
     for (uint32_t SchedSelIdx = 0; SchedSelIdx <= hrd->cpb_cnt_minus1; SchedSelIdx++) {
-        hrd->bit_rate_value_minus1[SchedSelIdx] = nr.readUe();
-        hrd->cpb_size_value_minus1[SchedSelIdx] = nr.readUe();
-        hrd->cbr_flag[SchedSelIdx] = nr.read(1);
+        READ_UE(hrd->bit_rate_value_minus1[SchedSelIdx]);
+        READ_UE(hrd->cpb_size_value_minus1[SchedSelIdx]);
+        READ(hrd->cbr_flag[SchedSelIdx]);
     }
 
-    hrd->initial_cpb_removal_delay_length_minus1 = nr.read(5);
-    hrd->cpb_removal_delay_length_minus1 = nr.read(5);
-    hrd->dpb_output_delay_length_minus1 = nr.read(5);
-    hrd->time_offset_length = nr.read(5);
+    READ_BITS(hrd->initial_cpb_removal_delay_length_minus1, 5);
+    READ_BITS(hrd->cpb_removal_delay_length_minus1, 5);
+    READ_BITS(hrd->dpb_output_delay_length_minus1, 5);
+    READ_BITS(hrd->time_offset_length, 5);
 
     return true;
 }
 
-bool Parser::vuiParameters(SharedPtr<SPS>& sps, NalReader& nr)
+bool Parser::vuiParameters(SharedPtr<SPS>& sps, NalReader& br)
 {
     VUIParameters* vui = &sps->m_vui;
-    vui->aspect_ratio_info_present_flag = nr.read(1);
+    READ(vui->aspect_ratio_info_present_flag);
     if (vui->aspect_ratio_info_present_flag) {
-        vui->aspect_ratio_idc = nr.read(8);
+        READ(vui->aspect_ratio_idc);
         if (vui->aspect_ratio_idc == EXTENDED_SAR) {
-            vui->sar_width = nr.read(16);
-            vui->sar_height = nr.read(16);
+            READ(vui->sar_width);
+            READ(vui->sar_height);
         }
     }
 
-    vui->overscan_info_present_flag = nr.read(1);
+    READ(vui->overscan_info_present_flag);
     if (vui->overscan_info_present_flag)
-        vui->overscan_appropriate_flag = nr.read(1);
+        READ(vui->overscan_appropriate_flag);
 
-    vui->video_signal_type_present_flag = nr.read(1);
+    READ(vui->video_signal_type_present_flag);
     if (vui->video_signal_type_present_flag) {
-        vui->video_format = nr.read(3);
-        vui->video_full_range_flag = nr.read(1);
-        vui->colour_description_present_flag = nr.read(1);
+        READ_BITS(vui->video_format, 3);
+        READ(vui->video_full_range_flag);
+        READ(vui->colour_description_present_flag);
         if (vui->colour_description_present_flag) {
-            vui->colour_primaries = nr.read(8);
-            vui->transfer_characteristics = nr.read(8);
-            vui->matrix_coefficients = nr.read(8);
+            READ(vui->colour_primaries);
+            READ(vui->transfer_characteristics);
+            READ(vui->matrix_coefficients);
         }
     }
 
-    vui->chroma_loc_info_present_flag = nr.read(1);
+    READ(vui->chroma_loc_info_present_flag);
     if (vui->chroma_loc_info_present_flag) {
-        vui->chroma_sample_loc_type_top_field = nr.readUe();
+        READ_UE(vui->chroma_sample_loc_type_top_field);
         //chroma_sample_loc_type_top_field and chroma_sample_loc_type_bottom_field
         //specify the location of chroma samples, and it shall be in the range of 0 to 5
         if (vui->chroma_sample_loc_type_top_field > 5)
             return false;
-        vui->chroma_sample_loc_type_bottom_field = nr.readUe();
+        READ_UE(vui->chroma_sample_loc_type_bottom_field);
         if (vui->chroma_sample_loc_type_bottom_field > 5)
             return false;
     }
 
-    vui->timing_info_present_flag = nr.read(1);
+    READ(vui->timing_info_present_flag);
     if (vui->timing_info_present_flag) {
-        vui->num_units_in_tick = nr.read(32);
-        vui->time_scale = nr.read(32);
-        vui->fixed_frame_rate_flag = nr.read(1);
+        READ(vui->num_units_in_tick);
+        READ(vui->time_scale);
+        READ(vui->fixed_frame_rate_flag);
     }
 
-    vui->nal_hrd_parameters_present_flag = nr.read(1);
+    READ(vui->nal_hrd_parameters_present_flag);
     if (vui->nal_hrd_parameters_present_flag) {
-        if (!hrdParameters(&vui->nal_hrd_parameters, nr))
+        if (!hrdParameters(&vui->nal_hrd_parameters, br))
             return false;
     }
 
-    vui->vcl_hrd_parameters_present_flag = nr.read(1);
+    READ(vui->vcl_hrd_parameters_present_flag);
     if (vui->vcl_hrd_parameters_present_flag) {
-        if (!hrdParameters(&vui->vcl_hrd_parameters, nr))
+        if (!hrdParameters(&vui->vcl_hrd_parameters, br))
             return false;
     }
 
     if (vui->nal_hrd_parameters_present_flag || vui->vcl_hrd_parameters_present_flag)
-        vui->low_delay_hrd_flag = nr.read(1);
+        READ(vui->low_delay_hrd_flag);
 
-    vui->pic_struct_present_flag = nr.read(1);
-    vui->bitstream_restriction_flag = nr.read(1);
+    READ(vui->pic_struct_present_flag);
+    READ(vui->bitstream_restriction_flag);
     if (vui->bitstream_restriction_flag) {
-        vui->motion_vectors_over_pic_boundaries_flag = nr.read(1);
-        vui->max_bytes_per_pic_denom = nr.readUe();
-        vui->max_bits_per_mb_denom = nr.readUe();
+        READ(vui->motion_vectors_over_pic_boundaries_flag);
+        READ_UE(vui->max_bytes_per_pic_denom);
+        READ_UE(vui->max_bits_per_mb_denom);
         //max_bits_per_mb_denom in the range of 0 to 16
         if (vui->max_bits_per_mb_denom > 16)
             return false;
         //both log2_max_mv_length_horizontal and log2_max_mv_length_vertical
         //shall be in the range of 0 to 16
-        vui->log2_max_mv_length_horizontal = nr.readUe();
-        vui->log2_max_mv_length_vertical = nr.readUe();
+        READ_UE(vui->log2_max_mv_length_horizontal);
+        READ_UE(vui->log2_max_mv_length_vertical);
         if (vui->log2_max_mv_length_horizontal > 16
             || vui->log2_max_mv_length_vertical > 16)
             return false;
-        vui->max_num_reorder_frames = nr.readUe();
-        vui->max_dec_frame_buffering = nr.readUe();
+        READ_UE(vui->max_num_reorder_frames);
+        READ_UE(vui->max_dec_frame_buffering);
     }
 
     return true;
@@ -279,19 +316,19 @@ bool Parser::vuiParameters(SharedPtr<SPS>& sps, NalReader& nr)
 
 bool Parser::parseSps(SharedPtr<SPS>& sps, const NalUnit* nalu)
 {
-    NalReader nr(nalu->m_data + nalu->m_nalUnitHeaderBytes,
+    NalReader br(nalu->m_data + nalu->m_nalUnitHeaderBytes,
         nalu->m_size - nalu->m_nalUnitHeaderBytes);
 
-    sps->profile_idc = nr.read(8);
-    sps->constraint_set0_flag = nr.read(1);
-    sps->constraint_set1_flag = nr.read(1);
-    sps->constraint_set2_flag = nr.read(1);
-    sps->constraint_set3_flag = nr.read(1);
-    sps->constraint_set4_flag = nr.read(1);
-    sps->constraint_set5_flag = nr.read(1);
-    nr.skip(2); //reserved_zero_2bits
-    sps->level_idc = nr.read(8);
-    sps->sps_id = nr.readUe();
+    READ(sps->profile_idc);
+    READ(sps->constraint_set0_flag);
+    READ(sps->constraint_set1_flag);
+    READ(sps->constraint_set2_flag);
+    READ(sps->constraint_set3_flag);
+    READ(sps->constraint_set4_flag);
+    READ(sps->constraint_set5_flag);
+    br.skip(2); //reserved_zero_2bits
+    READ(sps->level_idc);
+    READ_UE(sps->sps_id);
     if (sps->sps_id > MAX_SPS_ID)
         return false;
 
@@ -320,23 +357,23 @@ bool Parser::parseSps(SharedPtr<SPS>& sps, const NalUnit* nalu)
         || sps->profile_idc == PROFILE_MULTIVIEW_HIGH
         || sps->profile_idc == PROFILE_STEREO_HIGH
         || sps->profile_idc == PROFILE_MULTIVIEW_DEPTH_HIGH) {
-        sps->chroma_format_idc = nr.readUe();
+        READ_UE(sps->chroma_format_idc);
         if (sps->chroma_format_idc > MAX_CHROMA_FORMAT_IDC)
             return false;
         if (sps->chroma_format_idc == MAX_CHROMA_FORMAT_IDC)
-            sps->separate_colour_plane_flag = nr.read(1);
+            READ(sps->separate_colour_plane_flag);
 
         //both bit_depth_luma_minus8 and bit_depth_chroma_minus8 shall be
         //in the range of 0 to 6. When they are not present, its shall be inferred
         //to be equal to 0, at the begining of this function
-        sps->bit_depth_luma_minus8 = nr.readUe();
-        sps->bit_depth_chroma_minus8 = nr.readUe();
+        READ_UE(sps->bit_depth_luma_minus8);
+        READ_UE(sps->bit_depth_chroma_minus8);
         if (sps->bit_depth_luma_minus8 > 6
             || sps->bit_depth_chroma_minus8 > 6)
             return false;
-        sps->qpprime_y_zero_transform_bypass_flag = nr.read(1);
+        READ(sps->qpprime_y_zero_transform_bypass_flag);
 
-        sps->seq_scaling_matrix_present_flag = nr.read(1);
+        READ(sps->seq_scaling_matrix_present_flag);
 
         //according to Table 7-2, Scaling list fall-back rule set A
         const uint8_t* const Fall_Back_Scaling_List[12] = {
@@ -349,12 +386,16 @@ bool Parser::parseSps(SharedPtr<SPS>& sps, const NalUnit* nalu)
         if (sps->seq_scaling_matrix_present_flag) {
             uint32_t loop = (sps->chroma_format_idc != 3) ? 8 : 12;
             for (uint32_t i = 0; i < loop; i++) {
-                sps->seq_scaling_list_present_flag[i] = nr.read(1);
+                READ(sps->seq_scaling_list_present_flag[i]);
                 if (sps->seq_scaling_list_present_flag[i]) {
-                    if (i < 6)
-                        scalingList(nr, sps->scaling_lists_4x4[i], 16, i);
-                    else
-                        scalingList(nr, sps->scaling_lists_8x8[i - 6], 64, i);
+                    if (i < 6) {
+                        if (!scalingList(br, sps->scaling_lists_4x4[i], 16, i))
+                            return false;
+                    }
+                    else {
+                        if (!scalingList(br, sps->scaling_lists_8x8[i - 6], 64, i))
+                            return false;
+                    }
                 } else {
                     if(i < 6)
                         memcpy(sps->scaling_lists_4x4[i], Fall_Back_Scaling_List[i], 16);
@@ -367,52 +408,52 @@ bool Parser::parseSps(SharedPtr<SPS>& sps, const NalUnit* nalu)
 
     //log2_max_frame_num_minus4 specifies the value of the variable MaxFrameNum that
     //is used in frame_num related, and shall be in the range of 0 to 12
-    sps->log2_max_frame_num_minus4 = nr.readUe();
+    READ_UE(sps->log2_max_frame_num_minus4);
     if (sps->log2_max_frame_num_minus4 > 12)
         return false;
     sps->m_maxFrameNum = 1 << (sps->log2_max_frame_num_minus4 + 4);
-    sps->pic_order_cnt_type = nr.readUe();
+    READ_UE(sps->pic_order_cnt_type);
     if (sps->pic_order_cnt_type > 2)
         return false;
     if (!sps->pic_order_cnt_type) {
         //log2_max_pic_order_cnt_lsb_minus4 specifies the value of the variable
         //MaxPicOrderCntLsb that is used in the decoing process for picture order
         //count, and shall be in the range of 0 to 12
-        sps->log2_max_pic_order_cnt_lsb_minus4 = nr.readUe();
+        READ_UE(sps->log2_max_pic_order_cnt_lsb_minus4);
         if (sps->log2_max_pic_order_cnt_lsb_minus4 > 12)
             return false;
     } else if (sps->pic_order_cnt_type == 1) {
-        sps->delta_pic_order_always_zero_flag = nr.read(1);
-        sps->offset_for_non_ref_pic = nr.readSe();
-        sps->offset_for_top_to_bottom_field = nr.readSe();
-        sps->num_ref_frames_in_pic_order_cnt_cycle = nr.readUe();
+        READ(sps->delta_pic_order_always_zero_flag);
+        READ_SE(sps->offset_for_non_ref_pic);
+        READ_SE(sps->offset_for_top_to_bottom_field);
+        READ_UE(sps->num_ref_frames_in_pic_order_cnt_cycle);
         if (sps->num_ref_frames_in_pic_order_cnt_cycle > 255)
             return false;
         for (uint32_t i = 0; i < sps->num_ref_frames_in_pic_order_cnt_cycle; i++)
-            sps->offset_for_ref_frame[i] = nr.readSe();
+            READ_SE(sps->offset_for_ref_frame[i]);
     }
 
-    sps->num_ref_frames = nr.readUe();
-    sps->gaps_in_frame_num_value_allowed_flag = nr.read(1);
-    sps->pic_width_in_mbs_minus1 = nr.readUe();
-    sps->pic_height_in_map_units_minus1 = nr.readUe();
-    sps->frame_mbs_only_flag = nr.read(1);
+    READ_UE(sps->num_ref_frames);
+    READ(sps->gaps_in_frame_num_value_allowed_flag);
+    READ_UE(sps->pic_width_in_mbs_minus1);
+    READ_UE(sps->pic_height_in_map_units_minus1);
+    READ(sps->frame_mbs_only_flag);
 
     if (!sps->frame_mbs_only_flag)
-        sps->mb_adaptive_frame_field_flag = nr.read(1);
+        READ(sps->mb_adaptive_frame_field_flag);
 
-    sps->direct_8x8_inference_flag = nr.read(1);
-    sps->frame_cropping_flag = nr.read(1);
+    READ(sps->direct_8x8_inference_flag);
+    READ(sps->frame_cropping_flag);
     if (sps->frame_cropping_flag) {
-        sps->frame_crop_left_offset = nr.readUe();
-        sps->frame_crop_right_offset = nr.readUe();
-        sps->frame_crop_top_offset = nr.readUe();
-        sps->frame_crop_bottom_offset = nr.readUe();
+        READ_UE(sps->frame_crop_left_offset);
+        READ_UE(sps->frame_crop_right_offset);
+        READ_UE(sps->frame_crop_top_offset);
+        READ_UE(sps->frame_crop_bottom_offset);
     }
 
-    sps->vui_parameters_present_flag = nr.read(1);
+    READ(sps->vui_parameters_present_flag);
     if (sps->vui_parameters_present_flag) {
-        if (!vuiParameters(sps, nr))
+        if (!vuiParameters(sps, br))
             return false;
     }
 
@@ -466,14 +507,14 @@ bool Parser::parseSps(SharedPtr<SPS>& sps, const NalUnit* nalu)
 bool Parser::parsePps(SharedPtr<PPS>& pps, const NalUnit* nalu)
 {
     SharedPtr<SPS> sps;
-    uint8_t pic_scaling_matrix_present_flag;
+    bool pic_scaling_matrix_present_flag;
     int32_t qp_bd_offset;
 
-    NalReader nr(nalu->m_data + nalu->m_nalUnitHeaderBytes,
+    NalReader br(nalu->m_data + nalu->m_nalUnitHeaderBytes,
         nalu->m_size - nalu->m_nalUnitHeaderBytes);
 
-    pps->pps_id = nr.readUe();
-    pps->sps_id = nr.readUe();
+    READ_UE(pps->pps_id);
+    READ_UE(pps->sps_id);
     if (pps->pps_id > MAX_PPS_ID || pps->sps_id > MAX_SPS_ID)
         return false;
 
@@ -492,68 +533,68 @@ bool Parser::parsePps(SharedPtr<PPS>& pps, const NalUnit* nalu)
     memcpy(&pps->scaling_lists_8x8, &sps->scaling_lists_8x8,
         sizeof(sps->scaling_lists_8x8));
 
-    pps->entropy_coding_mode_flag = nr.read(1);
-    pps->pic_order_present_flag = nr.read(1);
-    pps->num_slice_groups_minus1 = nr.readUe();
+    READ(pps->entropy_coding_mode_flag);
+    READ(pps->pic_order_present_flag);
+    READ_UE(pps->num_slice_groups_minus1);
     //num_slice_groups_minus1 in the range of 0 to 7, according to A.2.1
     if (pps->num_slice_groups_minus1 > 7)
         return false;
     if (pps->num_slice_groups_minus1 > 0) {
-        pps->slice_group_map_type = nr.readUe();
+        READ_UE(pps->slice_group_map_type);
         if (pps->slice_group_map_type > SLICE_GROUP_ASSIGNMENT)
             return false;
         if (!pps->slice_group_map_type) {
             for (uint32_t iGroup = 0; iGroup <= pps->num_slice_groups_minus1; iGroup++)
-                pps->run_length_minus1[iGroup] = nr.readUe();
+                READ_UE(pps->run_length_minus1[iGroup]);
         } else if (pps->slice_group_map_type == SLIEC_GROUP_FOREGROUND_LEFTOVER) {
             for (uint32_t iGroup = 0; iGroup < pps->num_slice_groups_minus1; iGroup++) {
-                pps->top_left[iGroup] = nr.readUe();
-                pps->bottom_right[iGroup] = nr.readUe();
+                READ_UE(pps->top_left[iGroup]);
+                READ_UE(pps->bottom_right[iGroup]);
             }
         } else if (pps->slice_group_map_type == SLICE_GROUP_CHANGING3
                    || pps->slice_group_map_type == SLICE_GROUP_CHANGING4
                    || pps->slice_group_map_type == SLICE_GROUP_CHANGING5) {
-            pps->slice_group_change_direction_flag = nr.read(1);
-            pps->slice_group_change_rate_minus1 = nr.readUe();
+            READ(pps->slice_group_change_direction_flag);
+            READ_UE(pps->slice_group_change_rate_minus1);
         } else if (pps->slice_group_map_type == SLICE_GROUP_ASSIGNMENT) {
-            pps->pic_size_in_map_units_minus1 = nr.readUe();
+            READ_UE(pps->pic_size_in_map_units_minus1);
             int32_t bits = ceil(log2(pps->num_slice_groups_minus1 + 1));
             pps->slice_group_id =
                 (uint8_t*)malloc(sizeof(uint8_t)*(pps->pic_size_in_map_units_minus1 + 1));
             if (!pps->slice_group_id)
                 return false;
             for (uint32_t i = 0; i <= pps->pic_size_in_map_units_minus1; i++)
-                pps->slice_group_id[i] = nr.read(bits);
+                READ_BITS(pps->slice_group_id[i], bits);
         }
     }
 
-    pps->num_ref_idx_l0_active_minus1 = nr.readUe();
-    pps->num_ref_idx_l1_active_minus1 = nr.readUe();
+    READ_UE(pps->num_ref_idx_l0_active_minus1);
+    READ_UE(pps->num_ref_idx_l1_active_minus1);
     if (pps->num_ref_idx_l0_active_minus1 > 31
         || pps->num_ref_idx_l1_active_minus1 > 31)
         goto error;
-    pps->weighted_pred_flag = nr.read(1);
-    pps->weighted_bipred_idc = nr.read(2);
-    pps->pic_init_qp_minus26 = nr.readSe();
+    READ(pps->weighted_pred_flag);
+    READ_BITS(pps->weighted_bipred_idc, 2);
+    READ_SE(pps->pic_init_qp_minus26);
     if (pps->pic_init_qp_minus26 < -(26 + qp_bd_offset)
         || pps->pic_init_qp_minus26 > 25)
         goto error;
-    pps->pic_init_qs_minus26 = nr.readSe();
+    READ_SE(pps->pic_init_qs_minus26);
     if (pps->pic_init_qs_minus26 < -26
         || pps->pic_init_qs_minus26 > 25)
         goto error;
-    pps->chroma_qp_index_offset = nr.readSe();
+    READ_SE(pps->chroma_qp_index_offset);
     if (pps->chroma_qp_index_offset < -12
         || pps->chroma_qp_index_offset > 12)
         goto error;
     pps->second_chroma_qp_index_offset = pps->chroma_qp_index_offset;
-    pps->deblocking_filter_control_present_flag = nr.read(1);
-    pps->constrained_intra_pred_flag = nr.read(1);
-    pps->redundant_pic_cnt_present_flag = nr.read(1);
+    READ(pps->deblocking_filter_control_present_flag);
+    READ(pps->constrained_intra_pred_flag);
+    READ(pps->redundant_pic_cnt_present_flag);
 
-    if (nr.moreRbspData()) {
-        pps->transform_8x8_mode_flag = nr.read(1);
-        pic_scaling_matrix_present_flag = nr.read(1);
+    if (br.moreRbspData()) {
+        READ(pps->transform_8x8_mode_flag);
+        READ(pic_scaling_matrix_present_flag);
 
         //according to Table 7-2, Scaling list fall-back rule set A
         const uint8_t* const Fall_Back_A_Scaling_List[12] = {
@@ -573,12 +614,16 @@ bool Parser::parsePps(SharedPtr<PPS>& pps, const NalUnit* nalu)
             uint32_t loop = 6
                 + ((sps->chroma_format_idc != 3) ? 2 : 6) * pps->transform_8x8_mode_flag;
             for (uint32_t i = 0; i < loop; i++) {
-                pps->pic_scaling_list_present_flag[i] = nr.read(1);
+                READ(pps->pic_scaling_list_present_flag[i]);
                 if (pps->pic_scaling_list_present_flag[i]) {
-                    if (i < 6)
-                        scalingList(nr, pps->scaling_lists_4x4[i], 16, i);
-                    else
-                        scalingList(nr, pps->scaling_lists_8x8[i - 6], 64, i);
+                    if (i < 6) {
+                        if (!scalingList(br, pps->scaling_lists_4x4[i], 16, i))
+                            return false;
+                    }
+                    else {
+                        if (!scalingList(br, pps->scaling_lists_8x8[i - 6], 64, i))
+                            return false;
+                    }
                 } else if (!sps->seq_scaling_matrix_present_flag) {
                     //fall-back rule set A be used
                     if (i < 6)
@@ -594,7 +639,7 @@ bool Parser::parsePps(SharedPtr<PPS>& pps, const NalUnit* nalu)
                 }
             }
         }
-        pps->second_chroma_qp_index_offset = nr.readSe();
+        READ_SE(pps->second_chroma_qp_index_offset);
         if (pps->second_chroma_qp_index_offset < -12
             || pps->second_chroma_qp_index_offset > 12)
             goto error;
@@ -628,25 +673,25 @@ Parser::searchSps(uint8_t id) const
     return res;
 }
 
-bool SliceHeader::refPicListModification(NalReader& nr, RefPicListModification* pm0,
+bool SliceHeader::refPicListModification(NalReader& br, RefPicListModification* pm0,
     RefPicListModification* pm1, bool is_mvc)
 {
     uint32_t i = 0;
     if (!IS_I_SLICE(slice_type) && !IS_SI_SLICE(slice_type)) {
-        ref_pic_list_modification_flag_l0 = nr.read(1);
+        READ(ref_pic_list_modification_flag_l0);
         if (ref_pic_list_modification_flag_l0) {
             do {
-                pm0[i].modification_of_pic_nums_idc = nr.readUe();
+                READ_UE(pm0[i].modification_of_pic_nums_idc);
                 if (pm0[i].modification_of_pic_nums_idc == 0
                     || pm0[i].modification_of_pic_nums_idc == 1) {
-                    pm0[i].abs_diff_pic_num_minus1 = nr.readUe();
+                    READ_UE(pm0[i].abs_diff_pic_num_minus1);
                     if (pm0[i].abs_diff_pic_num_minus1 > m_maxPicNum - 1)
                         return false;
                 } else if (pm0[i].modification_of_pic_nums_idc == 2) {
-                    pm0[i].long_term_pic_num = nr.readUe();
+                    READ_UE(pm0[i].long_term_pic_num);
                 } else if (is_mvc && (pm0[i].modification_of_pic_nums_idc == 4
                     || pm0[i].modification_of_pic_nums_idc == 5)) {
-                    pm0[i].abs_diff_view_idx_minus1 = nr.readUe();
+                    READ_UE(pm0[i].abs_diff_view_idx_minus1);
                 }
             } while (pm0[i++].modification_of_pic_nums_idc != 3);
             n_ref_pic_list_modification_l0 = i;
@@ -655,20 +700,20 @@ bool SliceHeader::refPicListModification(NalReader& nr, RefPicListModification* 
 
     if (IS_B_SLICE(slice_type)) {
         i = 0;
-        ref_pic_list_modification_flag_l1 = nr.read(1);
+        READ(ref_pic_list_modification_flag_l1);
         if (ref_pic_list_modification_flag_l1) {
             do {
-                pm1[i].modification_of_pic_nums_idc = nr.readUe();
+                READ_UE(pm1[i].modification_of_pic_nums_idc);
                 if (pm1[i].modification_of_pic_nums_idc == 0
                     || pm1[i].modification_of_pic_nums_idc == 1) {
-                    pm1[i].abs_diff_pic_num_minus1 = nr.readUe();
+                    READ_UE(pm1[i].abs_diff_pic_num_minus1);
                     if (pm1[i].abs_diff_pic_num_minus1 > m_maxPicNum - 1)
                         return false;
                 } else if (pm1[i].modification_of_pic_nums_idc == 2) {
-                    pm1[i].long_term_pic_num = nr.readUe();
+                    READ_UE(pm1[i].long_term_pic_num);
                 } else if (is_mvc && (pm1[i].modification_of_pic_nums_idc == 4
                     || pm1[i].modification_of_pic_nums_idc == 5)) {
-                    pm1[i].abs_diff_view_idx_minus1 = nr.readUe();
+                    READ_UE(pm1[i].abs_diff_view_idx_minus1);
                 }
             } while (pm1[i++].modification_of_pic_nums_idc != 3);
         }
@@ -678,28 +723,28 @@ bool SliceHeader::refPicListModification(NalReader& nr, RefPicListModification* 
     return true;
 }
 
-bool SliceHeader::decRefPicMarking(NalUnit* nalu, NalReader& nr)
+bool SliceHeader::decRefPicMarking(NalUnit* nalu, NalReader& br)
 {
     if (nalu->m_idrPicFlag) {
-        dec_ref_pic_marking.no_output_of_prior_pics_flag = nr.read(1);
-        dec_ref_pic_marking.long_term_reference_flag = nr.read(1);
+        READ(dec_ref_pic_marking.no_output_of_prior_pics_flag);
+        READ(dec_ref_pic_marking.long_term_reference_flag);
     } else {
-        dec_ref_pic_marking.adaptive_ref_pic_marking_mode_flag = nr.read(1);
+        READ(dec_ref_pic_marking.adaptive_ref_pic_marking_mode_flag);
         if (dec_ref_pic_marking.adaptive_ref_pic_marking_mode_flag) {
             uint32_t i = 0;
             RefPicMarking* const subpm = dec_ref_pic_marking.ref_pic_marking;
             do {
-                subpm[i].memory_management_control_operation = nr.readUe();
+                READ_UE(subpm[i].memory_management_control_operation);
                 if (subpm[i].memory_management_control_operation == 1
                     || subpm[i].memory_management_control_operation == 3)
-                    subpm[i].difference_of_pic_nums_minus1 = nr.readUe();
+                    READ_UE(subpm[i].difference_of_pic_nums_minus1);
                 if (subpm[i].memory_management_control_operation == 2)
-                    subpm[i].long_term_pic_num = nr.readUe();
+                    READ_UE(subpm[i].long_term_pic_num);
                 if (subpm[i].memory_management_control_operation == 3
                     || subpm[i].memory_management_control_operation == 6)
-                    subpm[i].long_term_frame_idx = nr.readUe();
+                    READ_UE(subpm[i].long_term_frame_idx);
                 if (subpm[i].memory_management_control_operation == 4)
-                    subpm[i].max_long_term_frame_idx_plus1 = nr.readUe();
+                    READ_UE(subpm[i].max_long_term_frame_idx_plus1);
             } while (subpm[i++].memory_management_control_operation != 0);
             dec_ref_pic_marking.n_ref_pic_marking = --i;
         }
@@ -707,20 +752,20 @@ bool SliceHeader::decRefPicMarking(NalUnit* nalu, NalReader& nr)
     return true;
 }
 
-bool SliceHeader::predWeightTable(NalReader& nr, uint8_t chromaArrayType)
+bool SliceHeader::predWeightTable(NalReader& br, uint8_t chromaArrayType)
 {
     PredWeightTable& preTab = pred_weight_table;
-    preTab.luma_log2_weight_denom = nr.readUe();
+    READ_UE(preTab.luma_log2_weight_denom);
     if (preTab.luma_log2_weight_denom > 7)
         return false;
     if (chromaArrayType)
-        preTab.chroma_log2_weight_denom = nr.readUe();
+        READ_UE(preTab.chroma_log2_weight_denom);
     for (uint32_t i = 0; i <= num_ref_idx_l0_active_minus1; i++) {
-        preTab.luma_weight_l0_flag = nr.read(1);
+        READ(preTab.luma_weight_l0_flag);
         if (preTab.luma_weight_l0_flag) {
             //7.4.3.2
-            preTab.luma_weight_l0[i] = nr.readSe();
-            preTab.luma_offset_l0[i] = nr.readSe();
+            READ_SE(preTab.luma_weight_l0[i]);
+            READ_SE(preTab.luma_offset_l0[i]);
             if (preTab.luma_weight_l0[i] < -128
                 || preTab.luma_weight_l0[i] > 127
                 || preTab.luma_offset_l0[i] < -128
@@ -730,11 +775,11 @@ bool SliceHeader::predWeightTable(NalReader& nr, uint8_t chromaArrayType)
             preTab.luma_weight_l0[i] = 1 << preTab.luma_log2_weight_denom;
         }
         if (chromaArrayType) {
-            preTab.chroma_weight_l0_flag = nr.read(1);
+            READ(preTab.chroma_weight_l0_flag);
             for (uint32_t j = 0; j < 2; j++) {
                 if (preTab.chroma_weight_l0_flag) {
-                    preTab.chroma_weight_l0[i][j] = nr.readSe();
-                    preTab.chroma_offset_l0[i][j] = nr.readSe();
+                    READ_SE(preTab.chroma_weight_l0[i][j]);
+                    READ_SE(preTab.chroma_offset_l0[i][j]);
                 } else {
                     preTab.chroma_weight_l0[i][j] = 1 << preTab.chroma_log2_weight_denom;
                 }
@@ -743,19 +788,19 @@ bool SliceHeader::predWeightTable(NalReader& nr, uint8_t chromaArrayType)
     }
     if (IS_B_SLICE(slice_type))
         for (uint32_t i = 0; i <= num_ref_idx_l1_active_minus1; i++) {
-            preTab.luma_weight_l1_flag = nr.read(1);
+            READ(preTab.luma_weight_l1_flag);
             if (preTab.luma_weight_l1_flag) {
-                preTab.luma_weight_l1[i] = nr.readSe();
-                preTab.luma_offset_l1[i] = nr.readSe();
+                READ_SE(preTab.luma_weight_l1[i]);
+                READ_SE(preTab.luma_offset_l1[i]);
             } else {
                 preTab.luma_weight_l1[i] = 1 << preTab.luma_log2_weight_denom;
             }
             if (chromaArrayType) {
-                preTab.chroma_weight_l1_flag = nr.read(1);
+                READ(preTab.chroma_weight_l1_flag);
                 for (uint32_t j = 0; j < 2; j++) {
                     if (preTab.chroma_weight_l1_flag) {
-                        preTab.chroma_weight_l1[i][j] = nr.readSe();
-                        preTab.chroma_offset_l1[i][j] = nr.readSe();
+                        READ_SE(preTab.chroma_weight_l1[i][j]);
+                        READ_SE(preTab.chroma_offset_l1[i][j]);
                     } else {
                         preTab.chroma_weight_l1[i][j] = 1 << preTab.chroma_log2_weight_denom;
                     }
@@ -767,18 +812,18 @@ bool SliceHeader::predWeightTable(NalReader& nr, uint8_t chromaArrayType)
 
 bool SliceHeader::parseHeader(Parser* nalparser, NalUnit* nalu)
 {
-    int32_t pps_id;
+    uint32_t pps_id;
     SharedPtr<SPS> sps;
 
     if (!nalu->m_size)
         return false;
 
-    NalReader nr(nalu->m_data + nalu->m_nalUnitHeaderBytes,
+    NalReader br(nalu->m_data + nalu->m_nalUnitHeaderBytes,
         nalu->m_size - nalu->m_nalUnitHeaderBytes);
 
-    first_mb_in_slice = nr.readUe();
-    slice_type = nr.readUe();
-    pps_id = nr.readUe();
+    READ_UE(first_mb_in_slice);
+    READ_UE(slice_type);
+    READ_UE(pps_id);
     if (pps_id > MAX_PPS_ID)
         return false;
 
@@ -794,14 +839,14 @@ bool SliceHeader::parseHeader(Parser* nalparser, NalUnit* nalu)
     num_ref_idx_l1_active_minus1 = m_pps->num_ref_idx_l1_active_minus1;
 
     if (sps->separate_colour_plane_flag == 1)
-        colour_plane_id = nr.read(2);
+        READ_BITS(colour_plane_id, 2);
 
-    frame_num = nr.read(sps->log2_max_frame_num_minus4 + 4);
+    READ_BITS(frame_num, sps->log2_max_frame_num_minus4 + 4);
 
     if (!sps->frame_mbs_only_flag) {
-        field_pic_flag = nr.read(1);
+        READ(field_pic_flag);
         if (field_pic_flag)
-            bottom_field_flag = nr.read(1);
+            READ(bottom_field_flag);
     }
 
     //calculate MaxPicNum
@@ -811,40 +856,40 @@ bool SliceHeader::parseHeader(Parser* nalparser, NalUnit* nalu)
         m_maxPicNum = sps->m_maxFrameNum;
 
     if (nalu->m_idrPicFlag) {
-        idr_pic_id = nr.readUe();
+        READ_UE(idr_pic_id);
         if (idr_pic_id > MAX_IDR_PIC_ID)
             return false;
     }
 
     if (!sps->pic_order_cnt_type) {
-        pic_order_cnt_lsb = nr.read(sps->log2_max_pic_order_cnt_lsb_minus4 + 4);
+        READ_BITS(pic_order_cnt_lsb, sps->log2_max_pic_order_cnt_lsb_minus4 + 4);
         if (m_pps->pic_order_present_flag && !field_pic_flag)
-            delta_pic_order_cnt_bottom = nr.readSe();
+            READ_SE(delta_pic_order_cnt_bottom);
     }
 
     if (sps->pic_order_cnt_type == 1 && !sps->delta_pic_order_always_zero_flag) {
-        delta_pic_order_cnt[0] = nr.readSe();
+        READ_SE(delta_pic_order_cnt[0]);
         if (m_pps->pic_order_present_flag && !field_pic_flag)
-            delta_pic_order_cnt[1] = nr.readSe();
+            READ_SE(delta_pic_order_cnt[1]);
     }
 
     if (m_pps->redundant_pic_cnt_present_flag) {
-        redundant_pic_cnt = nr.readUe();
+        READ_UE(redundant_pic_cnt);
         if (redundant_pic_cnt > 127)
             return false;
     }
 
     if (IS_B_SLICE(slice_type))
-        direct_spatial_mv_pred_flag = nr.read(1);
+        READ(direct_spatial_mv_pred_flag);
 
     if (IS_P_SLICE(slice_type) || IS_SP_SLICE(slice_type) || IS_B_SLICE(slice_type)) {
-        num_ref_idx_active_override_flag = nr.read(1);
+        READ(num_ref_idx_active_override_flag);
         if (num_ref_idx_active_override_flag) {
-            num_ref_idx_l0_active_minus1 = nr.readUe();
+            READ_UE(num_ref_idx_l0_active_minus1);
             if (num_ref_idx_l0_active_minus1 > 31)
                 return false;
             if (IS_B_SLICE(slice_type)) {
-                num_ref_idx_l1_active_minus1 = nr.readUe();
+                READ_UE(num_ref_idx_l1_active_minus1);
                 if (num_ref_idx_l1_active_minus1 > 31)
                     return false;
             }
@@ -853,31 +898,31 @@ bool SliceHeader::parseHeader(Parser* nalparser, NalUnit* nalu)
 
     if (nalu->nal_unit_type == NAL_SLICE_EXT
         || nalu->nal_unit_type == NAL_SLICE_EXT_DEPV)
-        refPicListModification(nr, ref_pic_list_modification_l0,
+        refPicListModification(br, ref_pic_list_modification_l0,
             ref_pic_list_modification_l1, true);
     else
-        refPicListModification(nr, ref_pic_list_modification_l0,
+        refPicListModification(br, ref_pic_list_modification_l0,
             ref_pic_list_modification_l1, false);
 
     if ((m_pps->weighted_pred_flag && (IS_P_SLICE(slice_type) || IS_SP_SLICE(slice_type)))
         || (m_pps->weighted_bipred_idc == 1 && IS_B_SLICE(slice_type))) {
-        if (!predWeightTable(nr, sps->m_chromaArrayType))
+        if (!predWeightTable(br, sps->m_chromaArrayType))
             return false;
     }
 
     if (nalu->nal_ref_idc) {
-        if (!decRefPicMarking(nalu, nr))
+        if (!decRefPicMarking(nalu, br))
             return false;
     }
 
     if (m_pps->entropy_coding_mode_flag
         && !IS_I_SLICE(slice_type) && !IS_SI_SLICE(slice_type)) {
-        cabac_init_idc = nr.readUe();
+        READ_UE(cabac_init_idc);
         if (cabac_init_idc > 2)
             return false;
     }
 
-    slice_qp_delta = nr.readSe();
+    READ_SE(slice_qp_delta);
     //according to 7-29, the value of slice_qp_delta shall be limited
     //so that sliceQPY is in the range of -QpBdOffsetY to +51.
     //sliceQPY = 26 + pic_init_qp_minus26 + slice_qp_delta
@@ -889,17 +934,17 @@ bool SliceHeader::parseHeader(Parser* nalparser, NalUnit* nalu)
 
     if (IS_SP_SLICE(slice_type) || IS_SI_SLICE(slice_type)) {
         if (IS_SP_SLICE(slice_type))
-            sp_for_switch_flag = nr.read(1);
-        slice_qs_delta = nr.readSe();
+            READ(sp_for_switch_flag);
+        READ_SE(slice_qs_delta);
     }
 
     if (m_pps->deblocking_filter_control_present_flag) {
-        disable_deblocking_filter_idc = nr.readUe();
+        READ_UE(disable_deblocking_filter_idc);
         if (disable_deblocking_filter_idc > 2)
             return false;
         if (disable_deblocking_filter_idc != 1) {
-            slice_alpha_c0_offset_div2 = nr.readSe();
-            slice_beta_offset_div2 = nr.readSe();
+            READ_SE(slice_alpha_c0_offset_div2);
+            READ_SE(slice_beta_offset_div2);
         }
     }
 
@@ -913,11 +958,11 @@ bool SliceHeader::parseHeader(Parser* nalparser, NalUnit* nalu)
         uint32_t picSizeInMapUnits = picWidthInMbs * picHeightInMapUnits;
         uint32_t sliceGroupChangeRate = m_pps->slice_group_change_rate_minus1 + 1;
         const uint32_t n = ceil(log2(picSizeInMapUnits / sliceGroupChangeRate + 1));
-        slice_group_change_cycle = nr.read(n);
+        READ_BITS(slice_group_change_cycle, n);
     }
 
-    m_headerSize = nr.getPos();
-    m_emulationPreventionBytes = nr.getEpbCnt();
+    m_headerSize = br.getPos();
+    m_emulationPreventionBytes = br.getEpbCnt();
 
     return true;
 }

--- a/codecparsers/h264Parser.h
+++ b/codecparsers/h264Parser.h
@@ -178,8 +178,8 @@ public:
     NaluHeadSvcExt m_svc;
 
 private:
-    void parseSvcExtension(BitReader& br);
-    void parseMvcExtension(BitReader& br);
+    bool parseSvcExtension(BitReader& br);
+    bool parseMvcExtension(BitReader& br);
 };
 
 struct HRDParameters {
@@ -241,7 +241,7 @@ struct SPS {
     bool constraint_set4_flag;
     bool constraint_set5_flag;
     uint8_t level_idc;
-    int32_t sps_id; //seq_parameter_set_id
+    uint32_t sps_id; //seq_parameter_set_id
     uint8_t chroma_format_idc;
     bool separate_colour_plane_flag;
     uint8_t bit_depth_luma_minus8;
@@ -290,8 +290,8 @@ struct SPS {
 struct PPS {
     ~PPS();
 
-    int32_t pps_id;
-    int32_t sps_id;
+    uint32_t pps_id;
+    uint32_t sps_id;
 
     SharedPtr<SPS> m_sps;
 
@@ -383,7 +383,7 @@ public:
     uint16_t frame_num;
     bool field_pic_flag;
     bool bottom_field_flag;
-    uint16_t idr_pic_id;
+    uint32_t idr_pic_id;
     uint16_t pic_order_cnt_lsb;
     int32_t delta_pic_order_cnt_bottom;
     int32_t delta_pic_order_cnt[2];

--- a/codecparsers/h264Parser.h
+++ b/codecparsers/h264Parser.h
@@ -130,24 +130,24 @@ enum NalUnitType {
 };
 
 struct NaluHeadMvcExt {
-    uint8_t non_idr_flag;
+    bool non_idr_flag;
     uint8_t priority_id;
     uint16_t view_id;
     uint8_t temporal_id;
-    uint8_t anchor_pic_flag;
-    uint8_t inter_view_flag;
+    bool anchor_pic_flag;
+    bool inter_view_flag;
 };
 
 struct NaluHeadSvcExt {
-    uint8_t idr_flag;
+    bool idr_flag;
     uint8_t priority_id;
-    uint8_t no_inter_layer_pred_flag;
+    bool no_inter_layer_pred_flag;
     uint8_t dependency_id;
     uint8_t quality_id;
     uint8_t temporal_id;
-    uint8_t use_ref_base_pic_flag;
-    uint8_t discardable_flag;
-    uint8_t output_flag;
+    bool use_ref_base_pic_flag;
+    bool discardable_flag;
+    bool output_flag;
     uint8_t reserved_three_2bits;
 };
 
@@ -171,7 +171,7 @@ public:
     uint16_t nal_unit_type;
 
     //calc value, used by other syntax structs
-    uint8_t m_idrPicFlag;
+    bool m_idrPicFlag;
     uint8_t m_nalUnitHeaderBytes;
 
     NaluHeadMvcExt m_mvc;
@@ -188,7 +188,7 @@ struct HRDParameters {
     uint8_t cpb_size_scale;
     uint32_t bit_rate_value_minus1[32];
     uint32_t cpb_size_value_minus1[32];
-    uint8_t cbr_flag[32];
+    bool cbr_flag[32];
     uint8_t initial_cpb_removal_delay_length_minus1;
     uint8_t cpb_removal_delay_length_minus1;
     uint8_t dpb_output_delay_length_minus1;
@@ -196,34 +196,34 @@ struct HRDParameters {
 };
 
 struct VUIParameters {
-    uint8_t aspect_ratio_info_present_flag;
+    bool aspect_ratio_info_present_flag;
     uint8_t aspect_ratio_idc;
     uint16_t sar_width;
     uint16_t sar_height;
-    uint8_t overscan_info_present_flag;
-    uint8_t overscan_appropriate_flag;
-    uint8_t video_signal_type_present_flag;
+    bool overscan_info_present_flag;
+    bool overscan_appropriate_flag;
+    bool video_signal_type_present_flag;
     uint8_t video_format;
-    uint8_t video_full_range_flag;
-    uint8_t colour_description_present_flag;
+    bool video_full_range_flag;
+    bool colour_description_present_flag;
     uint8_t colour_primaries;
     uint8_t transfer_characteristics;
     uint8_t matrix_coefficients;
-    uint8_t chroma_loc_info_present_flag;
+    bool chroma_loc_info_present_flag;
     uint8_t chroma_sample_loc_type_top_field;
     uint8_t chroma_sample_loc_type_bottom_field;
-    uint8_t timing_info_present_flag;
+    bool timing_info_present_flag;
     uint32_t num_units_in_tick;
     uint32_t time_scale;
-    uint8_t fixed_frame_rate_flag;
-    uint8_t nal_hrd_parameters_present_flag;
+    bool fixed_frame_rate_flag;
+    bool nal_hrd_parameters_present_flag;
     HRDParameters nal_hrd_parameters;
-    uint8_t vcl_hrd_parameters_present_flag;
+    bool vcl_hrd_parameters_present_flag;
     HRDParameters vcl_hrd_parameters;
-    uint8_t low_delay_hrd_flag;
-    uint8_t pic_struct_present_flag;
-    uint8_t bitstream_restriction_flag;
-    uint8_t motion_vectors_over_pic_boundaries_flag;
+    bool low_delay_hrd_flag;
+    bool pic_struct_present_flag;
+    bool bitstream_restriction_flag;
+    bool motion_vectors_over_pic_boundaries_flag;
     uint32_t max_bytes_per_pic_denom;
     uint32_t max_bits_per_mb_denom;
     uint32_t log2_max_mv_length_horizontal;
@@ -234,44 +234,44 @@ struct VUIParameters {
 
 struct SPS {
     uint8_t profile_idc;
-    uint8_t constraint_set0_flag;
-    uint8_t constraint_set1_flag;
-    uint8_t constraint_set2_flag;
-    uint8_t constraint_set3_flag;
-    uint8_t constraint_set4_flag;
-    uint8_t constraint_set5_flag;
+    bool constraint_set0_flag;
+    bool constraint_set1_flag;
+    bool constraint_set2_flag;
+    bool constraint_set3_flag;
+    bool constraint_set4_flag;
+    bool constraint_set5_flag;
     uint8_t level_idc;
     int32_t sps_id; //seq_parameter_set_id
     uint8_t chroma_format_idc;
-    uint8_t separate_colour_plane_flag;
+    bool separate_colour_plane_flag;
     uint8_t bit_depth_luma_minus8;
     uint8_t bit_depth_chroma_minus8;
-    uint8_t qpprime_y_zero_transform_bypass_flag;
-    uint8_t seq_scaling_matrix_present_flag;
-    uint8_t seq_scaling_list_present_flag[12];
+    bool qpprime_y_zero_transform_bypass_flag;
+    bool seq_scaling_matrix_present_flag;
+    bool seq_scaling_list_present_flag[12];
     uint8_t scaling_lists_4x4[6][16];
     uint8_t scaling_lists_8x8[6][64];
     uint8_t log2_max_frame_num_minus4;
     uint8_t pic_order_cnt_type;
     uint8_t log2_max_pic_order_cnt_lsb_minus4;
-    uint8_t delta_pic_order_always_zero_flag;
+    bool delta_pic_order_always_zero_flag;
     int32_t offset_for_non_ref_pic;
     int32_t offset_for_top_to_bottom_field;
     uint8_t num_ref_frames_in_pic_order_cnt_cycle;
     int32_t offset_for_ref_frame[255];
     uint32_t num_ref_frames;
-    uint8_t gaps_in_frame_num_value_allowed_flag;
+    bool gaps_in_frame_num_value_allowed_flag;
     uint32_t pic_width_in_mbs_minus1;
     uint32_t pic_height_in_map_units_minus1;
-    uint8_t frame_mbs_only_flag;
-    uint8_t mb_adaptive_frame_field_flag;
-    uint8_t direct_8x8_inference_flag;
-    uint8_t frame_cropping_flag;
+    bool frame_mbs_only_flag;
+    bool mb_adaptive_frame_field_flag;
+    bool direct_8x8_inference_flag;
+    bool frame_cropping_flag;
     uint32_t frame_crop_left_offset;
     uint32_t frame_crop_right_offset;
     uint32_t frame_crop_top_offset;
     uint32_t frame_crop_bottom_offset;
-    uint8_t vui_parameters_present_flag;
+    bool vui_parameters_present_flag;
     VUIParameters m_vui;
 
     //Because these variables calced from other variables instead of
@@ -295,29 +295,29 @@ struct PPS {
 
     SharedPtr<SPS> m_sps;
 
-    uint8_t entropy_coding_mode_flag;
-    uint8_t pic_order_present_flag;
+    bool entropy_coding_mode_flag;
+    bool pic_order_present_flag;
     uint32_t num_slice_groups_minus1;
     uint8_t slice_group_map_type;
     uint32_t run_length_minus1[8];
     uint32_t top_left[8];
     uint32_t bottom_right[8];
-    uint8_t slice_group_change_direction_flag;
+    bool slice_group_change_direction_flag;
     uint32_t slice_group_change_rate_minus1;
     uint32_t pic_size_in_map_units_minus1;
     uint8_t* slice_group_id;
     uint8_t num_ref_idx_l0_active_minus1;
     uint8_t num_ref_idx_l1_active_minus1;
-    uint8_t weighted_pred_flag;
+    bool weighted_pred_flag;
     uint8_t weighted_bipred_idc;
     int8_t pic_init_qp_minus26;
     int8_t pic_init_qs_minus26;
     int8_t chroma_qp_index_offset;
-    uint8_t deblocking_filter_control_present_flag;
-    uint8_t constrained_intra_pred_flag;
-    uint8_t redundant_pic_cnt_present_flag;
-    uint8_t transform_8x8_mode_flag;
-    uint8_t pic_scaling_list_present_flag[12];
+    bool deblocking_filter_control_present_flag;
+    bool constrained_intra_pred_flag;
+    bool redundant_pic_cnt_present_flag;
+    bool transform_8x8_mode_flag;
+    bool pic_scaling_list_present_flag[12];
     uint8_t scaling_lists_4x4[6][16];
     uint8_t scaling_lists_8x8[6][64];
     int8_t second_chroma_qp_index_offset;
@@ -333,17 +333,17 @@ struct RefPicListModification {
 struct PredWeightTable {
     uint8_t luma_log2_weight_denom;
     uint8_t chroma_log2_weight_denom;
-    uint8_t luma_weight_l0_flag;
+    bool luma_weight_l0_flag;
     //32 is the max of num_ref_idx_l0_active_minus1
     int8_t luma_weight_l0[32];
     int8_t luma_offset_l0[32];
-    uint8_t chroma_weight_l0_flag;
+    bool chroma_weight_l0_flag;
     int8_t chroma_weight_l0[32][2];
     int8_t chroma_offset_l0[32][2];
-    uint8_t luma_weight_l1_flag;
+    bool luma_weight_l1_flag;
     int8_t luma_weight_l1[32];
     int8_t luma_offset_l1[32];
-    uint8_t chroma_weight_l1_flag;
+    bool chroma_weight_l1_flag;
     int8_t chroma_weight_l1[32][2];
     int8_t chroma_offset_l1[32][2];
 };
@@ -357,9 +357,9 @@ struct RefPicMarking {
 };
 
 struct DecRefPicMarking {
-    uint8_t no_output_of_prior_pics_flag;
-    uint8_t long_term_reference_flag;
-    uint8_t adaptive_ref_pic_marking_mode_flag;
+    bool no_output_of_prior_pics_flag;
+    bool long_term_reference_flag;
+    bool adaptive_ref_pic_marking_mode_flag;
     RefPicMarking ref_pic_marking[10];
     uint8_t n_ref_pic_marking;
 };
@@ -381,28 +381,28 @@ public:
     SharedPtr<PPS> m_pps;
     uint8_t colour_plane_id;
     uint16_t frame_num;
-    uint8_t field_pic_flag;
-    uint8_t bottom_field_flag;
+    bool field_pic_flag;
+    bool bottom_field_flag;
     uint16_t idr_pic_id;
     uint16_t pic_order_cnt_lsb;
     int32_t delta_pic_order_cnt_bottom;
     int32_t delta_pic_order_cnt[2];
     uint8_t redundant_pic_cnt;
-    uint8_t direct_spatial_mv_pred_flag;
-    uint8_t num_ref_idx_active_override_flag;
+    bool direct_spatial_mv_pred_flag;
+    bool num_ref_idx_active_override_flag;
     uint8_t num_ref_idx_l0_active_minus1;
     uint8_t num_ref_idx_l1_active_minus1;
-    uint8_t ref_pic_list_modification_flag_l0;
+    bool ref_pic_list_modification_flag_l0;
     uint8_t n_ref_pic_list_modification_l0;
     RefPicListModification ref_pic_list_modification_l0[32];
-    uint8_t ref_pic_list_modification_flag_l1;
+    bool ref_pic_list_modification_flag_l1;
     uint8_t n_ref_pic_list_modification_l1;
     RefPicListModification ref_pic_list_modification_l1[32];
     PredWeightTable pred_weight_table;
     DecRefPicMarking dec_ref_pic_marking;
     uint8_t cabac_init_idc;
     int8_t slice_qp_delta;
-    uint8_t sp_for_switch_flag;
+    bool sp_for_switch_flag;
     int8_t slice_qs_delta;
     uint8_t disable_deblocking_filter_idc;
     int8_t slice_alpha_c0_offset_div2;

--- a/codecparsers/nalReader.h
+++ b/codecparsers/nalReader.h
@@ -29,8 +29,10 @@ public:
 
     /*parse Exp-Golomb coding*/
     bool readUe(uint32_t& v);
+    inline bool readUe(uint8_t& v);
     uint32_t readUe();
     bool readSe(int32_t& v);
+    inline bool readSe(int8_t& v);
     int32_t readSe();
 
     bool moreRbspData() const;
@@ -42,6 +44,24 @@ private:
 
     uint32_t m_epb; /*the number of emulation prevention bytes*/
 };
+
+bool NalReader::readUe(uint8_t& v)
+{
+    uint32_t tmp;
+    if (!readUe(tmp))
+        return false;
+    v = tmp;
+    return true;
+}
+
+bool NalReader::readSe(int8_t& v)
+{
+    int32_t tmp;
+    if (!readSe(tmp))
+        return false;
+    v = tmp;
+    return true;
+}
 
 } /*namespace YamiParser*/
 


### PR DESCRIPTION
We need check read beyond boundary. To make sure we can detect error bitstream as early as possible.
If we do not check this, maybe we will encounter a serious error.
#495 is good example
