### PR TITLE
hevcenc: enable deblocking as default

### DIFF
--- a/encoder/vaapiencoder_hevc.cpp
+++ b/encoder/vaapiencoder_hevc.cpp
@@ -1635,7 +1635,7 @@ bool VaapiEncoderHEVC::addSliceHeaders (const PicturePtr& picture) const
         /* set calculation for next slice */
         lastCtuIndex += curSliceCtus;
 
-        sliceParam->slice_fields.bits.slice_deblocking_filter_disabled_flag = 1;
+        sliceParam->slice_fields.bits.slice_deblocking_filter_disabled_flag = 0;
 
         sliceParam->slice_fields.bits.last_slice_of_pic_flag = (lastCtuIndex == numCtus);
 


### PR DESCRIPTION
1. Enable deblocking as default.
2. deblocking_filter_override_flag isn't set, so even
   slice_deblocking_filter_disabled_flag is set to 1, it won't be written
   into bitstream, in this case, slice_deblocking_filter_disabled_flag
   should be same as pps_deblocking_filter_disabled_flag.

Signed-off-by: Zhong Li zhong.li@intel.com
