### PR TITLE
vpp : change the NONE define for the caller.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ m4_define([yami_api_major_version], 0)
 # update this for every release when micro version large than zero
 m4_define([yami_api_minor_version], 2)
 # change this for any api change
-m4_define([yami_api_micro_version], 3)
+m4_define([yami_api_micro_version], 4)
 m4_define([yami_api_version],
     [yami_api_major_version.yami_api_minor_version.yami_api_micro_version])
 

--- a/interface/VideoPostProcessDefs.h
+++ b/interface/VideoPostProcessDefs.h
@@ -56,7 +56,7 @@ typedef struct VppParamMosaic {
 
 #define DENOISE_LEVEL_MIN 0
 #define DENOISE_LEVEL_MAX 100
-#define DENOISE_LEVEL_NONE (DENOISE_LEVEL_MAX + 1)
+#define DENOISE_LEVEL_NONE (DENOISE_LEVEL_MIN - 1)
 
 typedef struct VPPDenoiseParameters {
     size_t size;
@@ -65,7 +65,7 @@ typedef struct VPPDenoiseParameters {
 
 #define SHARPENING_LEVEL_MIN 0
 #define SHARPENING_LEVEL_MAX 100
-#define SHARPENING_LEVEL_NONE (SHARPENING_LEVEL_MAX + 1)
+#define SHARPENING_LEVEL_NONE (SHARPENING_LEVEL_MIN - 1)
 
 typedef struct VPPSharpeningParameters {
     size_t size;


### PR DESCRIPTION
before [MIN, MAX] means enable with the scope, used MAX+1 = NONE means
disable this function, it's strange for the caller. Change to used
MIN-1 = NONE to disable this function, it's more intuitive for the caller.
And bump the version.

Signed-off-by: Jun Zhao jun.zhao@intel.com
