### PR TITLE
h264enc: fix some qp setting issues

### DIFF
--- a/encoder/vaapiencoder_base.h
+++ b/encoder/vaapiencoder_base.h
@@ -148,6 +148,8 @@ protected:
         return m_videoParamCommon.rcParams.initQP;
     }
 
+    uint32_t& initQP() { return m_videoParamCommon.rcParams.initQP; }
+
     uint32_t minQP() const {
         return m_videoParamCommon.rcParams.minQP;
     }

--- a/encoder/vaapiencoder_h264.h
+++ b/encoder/vaapiencoder_h264.h
@@ -106,6 +106,7 @@ private:
     uint32_t m_frameIndex;
     uint32_t m_curFrameNum;
     uint32_t m_keyPeriod;
+    uint32_t m_ppsQp; /*pic_init_qp_minus26 + 26*/
 
     /* reference list */
     std::deque<ReferencePtr> m_refList;


### PR DESCRIPTION
1. Don't change MinQP() if without strong reason.
2. If initQp is changed during a GOP without restarting the encoder,
   encoding will be failed, this patch can fix this bug.
3. remove the slice_qp_delta <= 4 limitation.

Signed-off-by: Zhong Li zhong.li@intel.com
