### PR TITLE
Fix jpeg conformance.

### DIFF
--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -128,7 +128,7 @@ struct ResolutionEntry {
     uint32_t planes;
     //multiple to half width
     //if it equals 1, you need divide width with 2
-    //if it equals 4, you need wultiple width with 2
+    //if it equals 4, you need multiple width with 2
     uint32_t widthMultiple[3];
     uint32_t heightMultiple[3];
 };

--- a/decoder/vaapiDecoderJPEG.cpp
+++ b/decoder/vaapiDecoderJPEG.cpp
@@ -76,8 +76,10 @@ public:
     {
         using namespace ::YamiParser::JPEG;
 
+        //this mainly for codec flush, jpeg/mjpeg do not have to flush.
+        //just return success for this
         if (!data || !size)
-            return YAMI_FAIL;
+            return YAMI_SUCCESS;
 
         /*
          * Reset the parser if we have a new data pointer; this is common for

--- a/decoder/vaapidecsurfacepool.cpp
+++ b/decoder/vaapidecsurfacepool.cpp
@@ -44,7 +44,7 @@ bool VaapiDecSurfacePool::init(const DisplayPtr& display, VideoConfigBuffer* con
     m_allocator = allocator;
     m_allocParams.width = config->surfaceWidth;
     m_allocParams.height = config->surfaceHeight;
-    m_allocParams.fourcc = YAMI_FOURCC_NV12;
+    m_allocParams.fourcc = config->fourcc;
     m_allocParams.size = config->surfaceNumber;
     if (m_allocator->alloc(m_allocator.get(), &m_allocParams) != YAMI_SUCCESS) {
         ERROR("allocate surface failed (%dx%d), size = %d",

--- a/interface/VideoCommonDefs.h
+++ b/interface/VideoCommonDefs.h
@@ -68,11 +68,25 @@ extern "C" {
         ((uint32_t)(uint8_t)(ch0) | ((uint32_t)(uint8_t)(ch1) << 8) | \
          ((uint32_t)(uint8_t)(ch2) << 16)  | ((uint32_t)(uint8_t)(ch3) << 24))
 
+//420
 #define YAMI_FOURCC_NV12 YAMI_FOURCC('N','V','1','2')
+#define YAMI_FOURCC_I420 YAMI_FOURCC('I', '4', '2', '0')
+#define YAMI_FOURCC_YV12 YAMI_FOURCC('Y', 'V', '1', '2')
+#define YAMI_FOURCC_IMC3 YAMI_FOURCC('I', 'M', 'C', '3')
+
+//422
+#define YAMI_FOURCC_422H YAMI_FOURCC('4', '2', '2', 'H')
+#define YAMI_FOURCC_422V YAMI_FOURCC('4', '2', '2', 'V')
+#define YAMI_FOURCC_YUY2 YAMI_FOURCC('Y', 'U', 'Y', '2')
+
+//444
+#define YAMI_FOURCC_444P YAMI_FOURCC('4', '4', '4', 'P')
+
 #define YAMI_FOURCC_RGBX YAMI_FOURCC('R','G','B','X')
 #define YAMI_FOURCC_RGBA YAMI_FOURCC('R','G','B','A')
 #define YAMI_FOURCC_BGRX YAMI_FOURCC('B','G','R','X')
 #define YAMI_FOURCC_BGRA YAMI_FOURCC('B','G','R','A')
+
 
 typedef enum {
     NATIVE_DISPLAY_AUTO,    // decided by yami

--- a/interface/VideoCommonDefs.h
+++ b/interface/VideoCommonDefs.h
@@ -69,7 +69,7 @@ extern "C" {
          ((uint32_t)(uint8_t)(ch2) << 16)  | ((uint32_t)(uint8_t)(ch3) << 24))
 
 //420
-#define YAMI_FOURCC_NV12 YAMI_FOURCC('N','V','1','2')
+#define YAMI_FOURCC_NV12 YAMI_FOURCC('N', 'V', '1', '2')
 #define YAMI_FOURCC_I420 YAMI_FOURCC('I', '4', '2', '0')
 #define YAMI_FOURCC_YV12 YAMI_FOURCC('Y', 'V', '1', '2')
 #define YAMI_FOURCC_IMC3 YAMI_FOURCC('I', 'M', 'C', '3')
@@ -82,11 +82,10 @@ extern "C" {
 //444
 #define YAMI_FOURCC_444P YAMI_FOURCC('4', '4', '4', 'P')
 
-#define YAMI_FOURCC_RGBX YAMI_FOURCC('R','G','B','X')
-#define YAMI_FOURCC_RGBA YAMI_FOURCC('R','G','B','A')
-#define YAMI_FOURCC_BGRX YAMI_FOURCC('B','G','R','X')
-#define YAMI_FOURCC_BGRA YAMI_FOURCC('B','G','R','A')
-
+#define YAMI_FOURCC_RGBX YAMI_FOURCC('R', 'G', 'B', 'X')
+#define YAMI_FOURCC_RGBA YAMI_FOURCC('R', 'G', 'B', 'A')
+#define YAMI_FOURCC_BGRX YAMI_FOURCC('B', 'G', 'R', 'X')
+#define YAMI_FOURCC_BGRA YAMI_FOURCC('B', 'G', 'R', 'A')
 
 typedef enum {
     NATIVE_DISPLAY_AUTO,    // decided by yami

--- a/interface/VideoDecoderDefs.h
+++ b/interface/VideoDecoderDefs.h
@@ -56,6 +56,7 @@ typedef struct {
     int32_t surfaceNumber;
     VAProfile profile;
     uint32_t flag;
+    uint32_t fourcc;
 }VideoConfigBuffer;
 
 typedef struct {
@@ -83,6 +84,7 @@ typedef struct {
     int32_t bitrate;
     int32_t framerateNom;
     int32_t framerateDenom;
+    uint32_t fourcc;
 }VideoFormatInfo;
 
 #ifdef __cplusplus

--- a/vaapi/VaapiUtils.cpp
+++ b/vaapi/VaapiUtils.cpp
@@ -18,6 +18,7 @@
 #include "config.h"
 #endif
 
+#include "interface/VideoCommonDefs.h"
 #include "VaapiUtils.h"
 
 namespace YamiMediaCodec {
@@ -40,5 +41,30 @@ void unmapImage(VADisplay display, const VAImage& image)
 {
     checkVaapiStatus(vaUnmapBuffer(display, image.buf), "vaUnmapBuffer");
     checkVaapiStatus(vaDestroyImage(display, image.image_id), "vaDestroyImage");
+}
+
+//return rt format, 0 for unsupported
+uint32_t getRtFormat(uint32_t fourcc)
+{
+    switch (fourcc) {
+    case YAMI_FOURCC_NV12:
+    case YAMI_FOURCC_I420:
+    case YAMI_FOURCC_YV12:
+    case YAMI_FOURCC_IMC3:
+        return VA_RT_FORMAT_YUV420;
+    case YAMI_FOURCC_422H:
+    case YAMI_FOURCC_422V:
+    case YAMI_FOURCC_YUY2:
+        return VA_RT_FORMAT_YUV422;
+    case YAMI_FOURCC_444P:
+        return VA_RT_FORMAT_YUV444;
+    case YAMI_FOURCC_RGBX:
+    case YAMI_FOURCC_RGBA:
+    case YAMI_FOURCC_BGRX:
+    case YAMI_FOURCC_BGRA:
+        return VA_RT_FORMAT_RGB32;
+    }
+    ERROR("get rt format for %.4s failed", (char*)&fourcc);
+    return 0;
 }
 }

--- a/vaapi/VaapiUtils.h
+++ b/vaapi/VaapiUtils.h
@@ -26,6 +26,9 @@ uint8_t* mapSurfaceToImage(VADisplay display, intptr_t surface, VAImage& image);
 
 void unmapImage(VADisplay display, const VAImage& image);
 
+//return rt format, 0 for unsupported
+uint32_t getRtFormat(uint32_t fourcc);
+
 #define checkVaapiStatus(status, prompt)                     \
     (                                                        \
         {                                                    \

--- a/vaapi/vaapisurfaceallocator.cpp
+++ b/vaapi/vaapisurfaceallocator.cpp
@@ -40,17 +40,23 @@ YamiStatus VaapiSurfaceAllocator::doAlloc(SurfaceAllocParams* params)
     uint32_t height = params->height;
     if (!width || !height || !size)
         return YAMI_INVALID_PARAM;
-    if (params->fourcc != YAMI_FOURCC_NV12) {
-        ERROR("fix me for 10 bits");
-        return YAMI_INVALID_PARAM;
+    uint32_t rtFormat = getRtFormat(params->fourcc);
+    if (!rtFormat) {
+        ERROR("unsupported format %x", params->fourcc);
+        return YAMI_UNSUPPORTED;
     }
 
     size += m_extraSize;
 
     std::vector<VASurfaceID> v(size);
+    VASurfaceAttrib attrib;
+    attrib.flags = VA_SURFACE_ATTRIB_SETTABLE;
+    attrib.type = VASurfaceAttribPixelFormat;
+    attrib.value.type = VAGenericValueTypeInteger;
+    attrib.value.value.i = params->fourcc;
     VAStatus status = vaCreateSurfaces(m_display,
-        VA_RT_FORMAT_YUV420, width, height,
-        &v[0], size, NULL, 0);
+        rtFormat, width, height,
+        &v[0], size, &attrib, 1);
     if (!checkVaapiStatus(status, "vaCreateSurfaces"))
         return YAMI_OUT_MEMORY;
     params->surfaces = new intptr_t[size];


### PR DESCRIPTION
Previous code will convert all output to i420, using software, it assume all decoder output is NV12. However, this not true for jpeg, jpeg will output many formats like IMC3, 422H, 422V, 444P etc. This patch and related patch in libyami-utils will skip the conversion if user do not assign one. So we can compare the yuv with software decoder.
