### PR TITLE
h264enc: add simulcast and svc-t suppport

### DIFF
--- a/codecparsers/bitWriter.cpp
+++ b/codecparsers/bitWriter.cpp
@@ -109,11 +109,17 @@ bool BitWriter::writeBytes(uint8_t* data, uint32_t numBytes)
     return true;
 }
 
-void BitWriter::writeToBytesAligned()
+void BitWriter::writeToBytesAligned(bool bit)
 {
     uint8_t padBits = m_bitsInCache & 0x7;
-    if (padBits)
-        writeBits(0, 8 - padBits);
+    uint32_t value;
+    if (padBits) {
+        if (bit)
+            value = (1 << (8 - padBits)) - 1;
+        else
+            value = 0;
+        writeBits(value, 8 - padBits);
+    }
 }
 
 } /*namespace YamiParser*/

--- a/codecparsers/bitWriter.h
+++ b/codecparsers/bitWriter.h
@@ -38,7 +38,7 @@ public:
     bool writeBytes(uint8_t* data, uint32_t numBytes);
 
     /* Pad some zeros to make sure bitsteam byte aligned */
-    void writeToBytesAligned();
+    void writeToBytesAligned(bool bit = false);
 
     /* get encoded bitstream buffer */
     uint8_t* getBitWriterData();

--- a/common/common_def.h
+++ b/common/common_def.h
@@ -42,6 +42,10 @@
 #define MAX(a, b)  (((a) > (b)) ? (a) : (b))
 #endif
 
+#define CLIP(a, min, max) do { \
+        a = (MIN(max, MAX(a, min)));      \
+} while (0)
+
 #ifndef N_ELEMENTS
 #define N_ELEMENTS(array) (sizeof(array)/sizeof(array[0]))
 #endif

--- a/encoder/vaapiencoder_h264.h
+++ b/encoder/vaapiencoder_h264.h
@@ -72,6 +72,10 @@ private:
     bool ensurePicture (const PicturePtr&, const SurfacePtr&);
     bool ensureSlices(const PicturePtr&);
     bool ensureCodedBufferSize();
+    bool addPackedPrefixNalUnit(const PicturePtr&) const;
+    bool addPackedSliceHeader(
+        const PicturePtr& picture,
+        const VAEncSliceParameterBufferH264* const sliceParam) const;
 
     //reference list related
     YamiStatus reorder(const SurfacePtr& surface, uint64_t timeStamp, bool forceKeyFrame);
@@ -90,6 +94,7 @@ private:
 
     void resetParams();
     void checkProfileLimitation();
+    void checkSvcTempLimitaion();
 
     VideoParamsAVC m_videoParamAVC;
 
@@ -98,6 +103,8 @@ private:
     uint32_t m_numBFrames;
     uint32_t m_mbWidth;
     uint32_t m_mbHeight;
+    bool m_isSvcT;
+    uint32_t m_temporalLayerNum;
 
     /* re-ordering */
     std::list<PicturePtr> m_reorderFrameList;
@@ -124,6 +131,9 @@ private:
     uint32_t m_maxPicOrderCnt;
     uint32_t m_log2MaxPicOrderCnt;
     uint16_t m_idrNum; //used to set idr_pic_id, max value is 65535 as spec
+
+    VAEncSequenceParameterBufferH264* m_seqParam;
+    VAEncPictureParameterBufferH264* m_picParam;
 
     StreamHeaderPtr m_headers;
     Lock m_paramLock; // locker for parameters update, for example: m_sps/m_pps/m_maxCodedbufSize (width/height etc)

--- a/interface/VideoEncoderDefs.h
+++ b/interface/VideoEncoderDefs.h
@@ -272,6 +272,8 @@ typedef struct VideoParamsAVC {
     bool  enableDeblockFilter;
     int8_t deblockAlphaOffsetDiv2; //same as slice_alpha_c0_offset_div2 defined in h264 spec 7.4.3
     int8_t deblockBetaOffsetDiv2; //same as slice_beta_offset_div2 defined in h264 spec 7.4.3
+    uint32_t temporalLayerNum;
+    uint32_t priorityId;
 }VideoParamsAVC;
 
 typedef struct VideoParamsHRD {


### PR DESCRIPTION
1. Support CQP mode of h264 temporal scalability (svc-t) encoding，
   with maximal 4 temporal layers.
2. Only Hierarchical P-pictures structure supported right now,
   which requres GOP should not less than 8, be 2^n, and ipperiod must be
   1.
3. Support simulcast encoding, different priority_id can be set.

Signed-off-by: Zhong Li zhong.li@intel.com
