### PR TITLE
mpeg2_parser: check for nalunit size before starting bitReader

### DIFF
--- a/codecparsers/mpeg2_parser.cpp
+++ b/codecparsers/mpeg2_parser.cpp
@@ -399,14 +399,15 @@ namespace MPEG2 {
         const uint8_t* nalData = shdr->nalData;
         int32_t nalSize = shdr->nalSize;
         QuantMatrices *quantMatrices = &m_quantMatrixExtension.quantizationMatrices;
-        BitReader bitReader(nalData, nalSize);
-        bitReaderInit(&bitReader);
-        skipByte(); // skip start_sequence_code
 
         if (nalSize < kStartCodeSize) {
             ERROR("Incomplete Quant Extension Header");
             return false;
         }
+
+        BitReader bitReader(nalData, nalSize);
+        bitReaderInit(&bitReader);
+        skipByte(); // skip start_sequence_code
 
         memset(&m_quantMatrixExtension, 0, sizeof(QuantMatrixExtension));
 


### PR DESCRIPTION
This is to avoid a potential memory leak when the stream size is not
large enough and function has to return.  bitReader can be created after
such check

Signed-off-by: Daniel Charles daniel.charles@intel.com
