### PR TITLE
mpeg2_dec: simplify start function and do not parse incomplete stream

### DIFF
--- a/decoder/vaapidecoder_mpeg2.h
+++ b/decoder/vaapidecoder_mpeg2.h
@@ -125,7 +125,7 @@ private:
     YamiStatus assignPicture();
     YamiStatus createPicture();
     YamiStatus loadIQMatrix();
-    void updateIQMatrix(const YamiParser::MPEG2::QuantMatrices* refIQMatrix,
+    bool updateIQMatrix(const YamiParser::MPEG2::QuantMatrices* refIQMatrix,
                         bool reset = false);
     YamiStatus decodePicture();
     YamiStatus outputPicture(const PicturePtr& picture);


### PR DESCRIPTION
start function is simplified to avoid processing information that might
come on the configBuffer.  Client should start sending information on the
first decode call after start.  This is to avoid using information that was
parsed by the mpeg2 demuxer in not the correct order.

Also when the stream gives nal units that are not expected those units are
discarded without parsing or sending to the driver for decoding

Finally, avoid IQMatrix updates to be sent to the driver if they didn't really
change

Signed-off-by: Daniel Charles daniel.charles@intel.com
