### PR TITLE
dec_264: return format_change  as resulution changing, to fix #516

### DIFF
--- a/decoder/vaapidecoder_h264.cpp
+++ b/decoder/vaapidecoder_h264.cpp
@@ -1613,16 +1613,25 @@ bool VaapiDecoderH264::isDecodeContextChanged(const SharedPtr<SPS>& sps)
     return m_contextChanged;
 }
 
+bool VaapiDecoderH264::isResolutionChanged(const SharedPtr<SPS>& sps)
+{
+    if (m_configBuffer.surfaceWidth != sps->m_width
+        || m_configBuffer.surfaceHeight != sps->m_height){
+        return true;
+    }
+    return false;
+}
+
 YamiStatus VaapiDecoderH264::ensureContext(const SharedPtr<SPS>& sps)
 {
-    if (isDecodeContextChanged(sps)) {
+    bool contextChange = isDecodeContextChanged(sps);
+    bool resolutionChange = isResolutionChanged(sps);
+
+    if (contextChange || resolutionChange) {
         INFO("frame size changed, reconfig codec. orig size %d x %d, new size: "
              "%d x %d",
              m_configBuffer.width, m_configBuffer.height, sps->m_width,
              sps->m_height);
-        YamiStatus status = VaapiDecoderBase::terminateVA();
-        if (status != YAMI_SUCCESS)
-            return status;
         m_configBuffer.width = sps->frame_cropping_flag ? sps->m_cropRectWidth
                                                         : sps->m_width;
         m_configBuffer.height = sps->frame_cropping_flag ? sps->m_cropRectHeight
@@ -1632,12 +1641,25 @@ YamiStatus VaapiDecoderH264::ensureContext(const SharedPtr<SPS>& sps)
         m_configBuffer.flag |= HAS_SURFACE_NUMBER;
         m_configBuffer.profile
             = VAProfileH264High; // FIXME: set different profile later
-        status = VaapiDecoderBase::start(&m_configBuffer);
-        if (status != YAMI_SUCCESS)
-            return status;
+
+        if(contextChange){
+            YamiStatus status = VaapiDecoderBase::terminateVA();
+            if (status != YAMI_SUCCESS)
+                return status;
+            status = VaapiDecoderBase::start(&m_configBuffer);
+            if (status != YAMI_SUCCESS)
+                return status;
+        } else {
+            m_videoFormatInfo.width = m_configBuffer.width;
+            m_videoFormatInfo.height = m_configBuffer.height;
+            m_videoFormatInfo.surfaceWidth = m_configBuffer.surfaceWidth;
+            m_videoFormatInfo.surfaceHeight = m_configBuffer.surfaceHeight;
+        }
+
         // return YAMI_DECODE_FORMAT_CHANGE to info upper layer va context changed
         return YAMI_DECODE_FORMAT_CHANGE;
     }
+
     return (m_context) ? YAMI_SUCCESS : YAMI_FAIL;
 }
 

--- a/decoder/vaapidecoder_h264.h
+++ b/decoder/vaapidecoder_h264.h
@@ -145,6 +145,7 @@ private:
                                    const SliceHeader* const slice,
                                    RefSet& refSet, bool isList0);
     bool isDecodeContextChanged(const SharedPtr<SPS>& sps);
+    bool isResolutionChanged(const SharedPtr<SPS>& sps);
     bool decodeAvcRecordData(uint8_t* buf, int32_t bufSize);
 
     YamiStatus createPicture(const SliceHeader* const,


### PR DESCRIPTION
return YAMI_DECODE_FORMAT_CHANGE when resolution changing during palying;
if the new resolution is less than the old, just reset the resolution,
without reset libva.

to fix #516 

Signed-off-by: wudping dongpingx.wu@intel.com
