### PR TITLE
h264dec: fix surface number calculation error issue

### DIFF
--- a/decoder/vaapidecoder_h264.cpp
+++ b/decoder/vaapidecoder_h264.cpp
@@ -1605,7 +1605,7 @@ bool VaapiDecoderH264::isDecodeContextChanged(const SharedPtr<SPS>& sps)
     if (m_configBuffer.surfaceWidth < sps->m_width
         || m_configBuffer.surfaceHeight < sps->m_height
         || m_configBuffer.surfaceNumber < (int32_t)maxDecFrameBuffering) {
-        m_configBuffer.surfaceNumber = maxDecFrameBuffering;
+        m_configBuffer.surfaceNumber = maxDecFrameBuffering + 1;
         m_contextChanged = true;
     } else
         m_contextChanged = false;


### PR DESCRIPTION
Surface number needed by h264 decoder should be maxDecFrameBuffering
(used for reference list) + 1 (used for reconstruct frame).

Signed-off-by: Zhong Li zhong.li@intel.com
