### PR TITLE
decoder: remove EXTRA_SURFACE_NUMBER in decoders.

### DIFF
--- a/decoder/vaapidecoder_h265.cpp
+++ b/decoder/vaapidecoder_h265.cpp
@@ -912,7 +912,7 @@ bool VaapiDecoderH265::fillSlice(const PicturePtr& picture,
 
 YamiStatus VaapiDecoderH265::ensureContext(const SPS* const sps)
 {
-    uint8_t surfaceNumber = sps->sps_max_dec_pic_buffering_minus1[0] + 1 + H265_EXTRA_SURFACE_NUMBER;
+    uint8_t surfaceNumber = sps->sps_max_dec_pic_buffering_minus1[0] + 1;
     if (m_configBuffer.surfaceWidth < sps->width
         || m_configBuffer.surfaceHeight <  sps->height
         || m_configBuffer.surfaceNumber < surfaceNumber) {

--- a/decoder/vaapidecoder_h265.h
+++ b/decoder/vaapidecoder_h265.h
@@ -35,10 +35,6 @@ namespace H265 {
 
 namespace YamiMediaCodec {
 
-enum {
-    H265_EXTRA_SURFACE_NUMBER = 5,
-};
-
 class VaapiDecPictureH265;
 class VaapiDecoderH265:public VaapiDecoderBase {
     typedef YamiParser::H265::SPS SPS;

--- a/decoder/vaapidecoder_vp8.cpp
+++ b/decoder/vaapidecoder_vp8.cpp
@@ -471,7 +471,7 @@ YamiStatus VaapiDecoderVP8::start(VideoConfigBuffer* buffer)
     }
 
     buffer->profile = VAProfileVP8Version0_3;
-    buffer->surfaceNumber = 3 + VP8_EXTRA_SURFACE_NUMBER;
+    buffer->surfaceNumber = 3;
 
 
     DEBUG("disable native graphics buffer");

--- a/decoder/vaapidecoder_vp8.h
+++ b/decoder/vaapidecoder_vp8.h
@@ -59,7 +59,6 @@ char (&ArraySizeHelper(const T (&array)[N]))[N];
 #define arraysize(array) (sizeof(ArraySizeHelper(array)))
 
 enum {
-    VP8_EXTRA_SURFACE_NUMBER = 5,
     VP8_MAX_PICTURE_COUNT = 5,  // gold_ref, alt_ref, last_ref, previous (m_currentPicture, optional), and the newly allocated one
 };
 

--- a/decoder/vaapidecoder_vp9.cpp
+++ b/decoder/vaapidecoder_vp9.cpp
@@ -49,8 +49,8 @@ YamiStatus VaapiDecoderVP9::start(VideoConfigBuffer* buffer)
           buffer->height);
 
     buffer->profile = VAProfileVP9Profile0;
-    //8 reference frame + extra number
-    buffer->surfaceNumber = 8 + VP9_EXTRA_SURFACE_NUMBER;
+    //8 reference frame
+    buffer->surfaceNumber = 8;
 
 
     DEBUG("disable native graphics buffer");

--- a/decoder/vaapidecoder_vp9.h
+++ b/decoder/vaapidecoder_vp9.h
@@ -24,9 +24,6 @@
 #include <vector>
 
 namespace YamiMediaCodec{
-enum {
-    VP9_EXTRA_SURFACE_NUMBER = 5,
-};
 
 class VaapiDecoderVP9:public VaapiDecoderBase {
   public:


### PR DESCRIPTION
vaapisurfaceallocator will add extra surfaces, so it is
unnecessary to add it for various decoders.
This patch is benefit to reduce memory burden and decoding latency.

Signed-off-by: Zhong Li zhong.li@intel.com
