### PR TITLE
yami_dec: remove --enable-capi from Makefile, to fix issue #394

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,8 +17,15 @@ if ENABLE_V4L2
 SUBDIRS +=  v4l2
 endif
 
+libyami_source_h = \
+	interface/Yami.h \
+	interface/YamiC.h \
+	$(NULL)
+
 lib_LTLIBRARIES = libyami.la
 libyami_la_SOURCES =
+libyami_includedir = $(includedir)/libyami
+libyami_include_HEADERS = $(libyami_source_h)
 # Dummy C++ source to cause C++ linking
 nodist_EXTRA_libyami_la_SOURCES = dummy.cxx
 libyami_la_LDFLAGS = \

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,9 +11,7 @@ if ENABLE_DOCS
 SUBDIRS += doc
 endif
 
-if ENABLE_CAPI
 SUBDIRS += capi
-endif
 
 if ENABLE_V4L2
 SUBDIRS +=  v4l2
@@ -42,9 +40,7 @@ libyami_la_LIBADD = common/libyami_common.la \
 	vpp/libyami_vpp.la \
 	$(NULL)
 
-if ENABLE_CAPI
 libyami_la_LIBADD += capi/libyami_capi.la
-endif
 
 if ENABLE_X11
 libyami_la_LDFLAGS += $(LIBVA_X11_LIBS) $(X11_LIBS)

--- a/capi/Makefile.am
+++ b/capi/Makefile.am
@@ -17,6 +17,7 @@ libyami_capi_ldflags = \
 
 libyami_capi_cppflags = \
 	$(LIBVA_CFLAGS) \
+	-I$(top_srcdir)/interface \
 	$(NULL)
 
 noinst_LTLIBRARIES          = libyami_capi.la

--- a/capi/Makefile.unittest
+++ b/capi/Makefile.unittest
@@ -17,6 +17,7 @@ unittest_LDADD = \
 unittest_CPPFLAGS = \
 	$(GTEST_CPPFLAGS) \
 	$(AM_CPPFLAGS) \
+	-I$(top_srcdir)/interface \
 	$(NULL)
 
 unittest_CXXFLAGS = \

--- a/capi/VideoDecoderCapi.cpp
+++ b/capi/VideoDecoderCapi.cpp
@@ -18,8 +18,8 @@
 #include "config.h"
 #endif
 #include "VideoDecoderCapi.h"
-#include "interface/VideoDecoderInterface.h"
-#include "interface/VideoDecoderHost.h"
+#include "VideoDecoderInterface.h"
+#include "VideoDecoderHost.h"
 
 #include <stdlib.h>
 

--- a/capi/VideoDecoderCapi.h
+++ b/capi/VideoDecoderCapi.h
@@ -17,8 +17,8 @@
 #ifndef __VIDEO_DECODER_CAPI_H__
 #define __VIDEO_DECODER_CAPI_H__
 
-#include "interface/VideoDecoderDefs.h"
-#include "interface/VideoCommonDefs.h"
+#include <VideoDecoderDefs.h>
+#include <VideoCommonDefs.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/capi/VideoDecoderCapi.h
+++ b/capi/VideoDecoderCapi.h
@@ -17,9 +17,6 @@
 #ifndef __VIDEO_DECODER_CAPI_H__
 #define __VIDEO_DECODER_CAPI_H__
 
-#ifndef __ENABLE_CAPI__
-#define __ENABLE_CAPI__ 1
-#endif
 #include "interface/VideoDecoderDefs.h"
 #include "interface/VideoCommonDefs.h"
 

--- a/capi/VideoEncoderCapi.cpp
+++ b/capi/VideoEncoderCapi.cpp
@@ -18,8 +18,8 @@
 #include "config.h"
 #endif
 #include "VideoEncoderCapi.h"
-#include "interface/VideoEncoderInterface.h"
-#include "interface/VideoEncoderHost.h"
+#include "VideoEncoderInterface.h"
+#include "VideoEncoderHost.h"
 
 using namespace YamiMediaCodec;
 

--- a/capi/VideoEncoderCapi.h
+++ b/capi/VideoEncoderCapi.h
@@ -17,7 +17,7 @@
 #ifndef __VIDEO_ENCODER_CAPI_H__
 #define __VIDEO_ENCODER_CAPI_H__
 
-#include "interface/VideoEncoderDefs.h"
+#include <VideoEncoderDefs.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/capi/VideoEncoderCapi.h
+++ b/capi/VideoEncoderCapi.h
@@ -17,9 +17,6 @@
 #ifndef __VIDEO_ENCODER_CAPI_H__
 #define __VIDEO_ENCODER_CAPI_H__
 
-#ifndef __ENABLE_CAPI__
-#define __ENABLE_CAPI__ 1
-#endif
 #include "interface/VideoEncoderDefs.h"
 
 #ifdef __cplusplus

--- a/codecparsers/Makefile.am
+++ b/codecparsers/Makefile.am
@@ -112,6 +112,7 @@ libyami_codecparser_cppflags = \
 	-Dvp8_norm=libyami_vp8_norm \
 	-Dvp8dx_start_decode=libyami_vp8dx_start_decode \
 	-Dvp8dx_bool_decoder_fill=libyami_vp8dx_bool_decoder_fill \
+	-I$(top_srcdir)/interface \
 	$(NULL)
 
 noinst_LTLIBRARIES                 = libyami_codecparser.la

--- a/codecparsers/Makefile.unittest
+++ b/codecparsers/Makefile.unittest
@@ -57,6 +57,7 @@ unittest_LDADD = \
 unittest_CPPFLAGS = \
 	$(GTEST_CPPFLAGS) \
 	$(AM_CPPFLAGS) \
+	-I$(top_srcdir)/interface \
 	$(NULL)
 
 unittest_CXXFLAGS = \

--- a/codecparsers/h264Parser.h
+++ b/codecparsers/h264Parser.h
@@ -30,7 +30,7 @@
 #define h264parser_h
 
 #include "nalReader.h"
-#include "interface/VideoCommonDefs.h"
+#include "VideoCommonDefs.h"
 
 #include <map>
 #include <string.h>

--- a/codecparsers/h265Parser.h
+++ b/codecparsers/h265Parser.h
@@ -27,7 +27,7 @@
 #define h265Parser_h
 
 #include "nalReader.h"
-#include "interface/VideoCommonDefs.h"
+#include "VideoCommonDefs.h"
 
 #include <map>
 #include <vector>

--- a/codecparsers/mpeg2_parser.h
+++ b/codecparsers/mpeg2_parser.h
@@ -31,7 +31,7 @@
 // local headers
 #include "common/NonCopyable.h"
 #include "bitReader.h"
-#include "interface/VideoCommonDefs.h"
+#include "VideoCommonDefs.h"
 
 // system headers
 #include <stdio.h>

--- a/codecparsers/vp8_bool_decoder.h
+++ b/codecparsers/vp8_bool_decoder.h
@@ -75,7 +75,7 @@
 #define VP8_BOOL_DECODER_H_
 
 #include "common/NonCopyable.h"
-#include "interface/VideoCommonDefs.h"
+#include "VideoCommonDefs.h"
 #include <sys/types.h>
 #include <stdint.h>
 

--- a/codecparsers/vp8_parser.h
+++ b/codecparsers/vp8_parser.h
@@ -41,7 +41,7 @@
 #define VP8_PARSER_H_
 
 #include "common/NonCopyable.h"
-#include "interface/VideoCommonDefs.h"
+#include "VideoCommonDefs.h"
 #include <stdio.h>
 #include <string.h>
 #include "vp8_bool_decoder.h"

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -29,6 +29,7 @@ libyami_common_ldflags = \
 
 libyami_common_cppflags = \
 	$(LIBVA_CFLAGS) \
+	-I$(top_srcdir)/interface \
 	$(NULL)
 
 noinst_LTLIBRARIES            = libyami_common.la

--- a/common/Makefile.unittest
+++ b/common/Makefile.unittest
@@ -21,6 +21,7 @@ unittest_CPPFLAGS = \
 	$(GTEST_CPPFLAGS) \
 	$(LIBVA_CFLAGS) \
 	$(AM_CPPFLAGS) \
+	-I$(top_srcdir)/interface \
 	$(NULL)
 
 unittest_CXXFLAGS = \

--- a/common/YamiVersion.h.in
+++ b/common/YamiVersion.h.in
@@ -19,6 +19,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * YAMI_API_MAJOR_VERSION
  * The major version of yami api
@@ -64,5 +68,9 @@
 * return YAMI_API_VERSION;
 */
 void yamiGetApiVersion(uint32_t *apiVersion);
+
+#ifdef __cplusplus
+};
+#endif
 
 #endif /* YAMI_VERSION_H */

--- a/common/basesurfaceallocator.h
+++ b/common/basesurfaceallocator.h
@@ -16,7 +16,7 @@
 
 #ifndef basesurfaceallocator_h
 #define basesurfaceallocator_h
-#include "interface/VideoCommonDefs.h"
+#include "VideoCommonDefs.h"
 
 namespace YamiMediaCodec{
 

--- a/common/common_def.h
+++ b/common/common_def.h
@@ -82,9 +82,5 @@ do{ \
 }while(0)
 #endif
 
-#ifndef __ENABLE_CAPI__
-    #define PARAMETER_ASSIGN(a, b)  a = b
-#else
-    #define PARAMETER_ASSIGN(a, b)  memcpy(&(a), &(b), sizeof(b))
-#endif
+#define PARAMETER_ASSIGN(a, b)  memcpy(&(a), &(b), sizeof(b))
 #endif //__COMMON_DEF_H__

--- a/common/condition.h
+++ b/common/condition.h
@@ -17,7 +17,7 @@
 #define condition_h
 
 #include "NonCopyable.h"
-#include "interface/VideoCommonDefs.h"
+#include "VideoCommonDefs.h"
 
 #include "lock.h"
 

--- a/common/surfacepool.h
+++ b/common/surfacepool.h
@@ -23,7 +23,7 @@
 
 #include "common/log.h"
 #include "common/videopool.h"
-#include "interface/VideoCommonDefs.h"
+#include "VideoCommonDefs.h"
 /* we should not include vaapi surface here,
  * but we have no choose before we make VaapiSurface more generic,
  * and rename it to Surface

--- a/common/utils.h
+++ b/common/utils.h
@@ -16,7 +16,7 @@
 #ifndef utils_h
 #define utils_h
 
-#include "interface/VideoCommonDefs.h"
+#include "VideoCommonDefs.h"
 
 #include <stdint.h>
 

--- a/common/videopool.h
+++ b/common/videopool.h
@@ -15,7 +15,7 @@
  */
 #ifndef videopool_h
 #define videopool_h
-#include "interface/VideoCommonDefs.h"
+#include "VideoCommonDefs.h"
 #include "common/lock.h"
 #include <deque>
 

--- a/configure.ac
+++ b/configure.ac
@@ -92,18 +92,6 @@ fi
 AM_CONDITIONAL(ENABLE_V4L2,
     [test "x$enable_v4l2" = "xyes"])
 
-AC_ARG_ENABLE(capi,
-    [AC_HELP_STRING([--enable-capi],
-        [wrapper of c api interface @<:@default=no@:>@])],
-    [], [enable_capi="no"])
-
-if test "$enable_capi" = "yes"; then
-    AC_DEFINE([__ENABLE_CAPI__], [1],
-        [Defined to 1 if --enable-capi="yes"])
-fi
-AM_CONDITIONAL(ENABLE_CAPI,
-    [test "x$enable_capi" = "xyes"])
-
 AC_ARG_ENABLE(x11,
     [AC_HELP_STRING([--enable-x11],
         [enable x11 @<:@default=yes@:>@])],

--- a/decoder/Makefile.am
+++ b/decoder/Makefile.am
@@ -96,6 +96,7 @@ endif
 libyami_decoder_cppflags = \
 	$(LIBVA_CFLAGS) \
 	$(LIBVA_DRM_CFLAGS) \
+	-I$(top_srcdir)/interface \
 	$(NULL)
 
 if ENABLE_X11

--- a/decoder/Makefile.unittest
+++ b/decoder/Makefile.unittest
@@ -49,6 +49,7 @@ unittest_CPPFLAGS = \
 	$(GTEST_CPPFLAGS) \
 	$(LIBVA_CFLAGS) \
 	$(AM_CPPFLAGS) \
+	-I$(top_srcdir)/interface \
 	$(NULL)
 
 unittest_CXXFLAGS = \

--- a/decoder/vaapidecoder_base.h
+++ b/decoder/vaapidecoder_base.h
@@ -20,7 +20,7 @@
 
 #include "common/log.h"
 #include "common/common_def.h"
-#include "interface/VideoDecoderInterface.h"
+#include "VideoDecoderInterface.h"
 #include "vaapi/vaapiptrs.h"
 #include "vaapidecpicture.h"
 #include <deque>

--- a/decoder/vaapidecoder_factory.h
+++ b/decoder/vaapidecoder_factory.h
@@ -18,7 +18,7 @@
 #define vaapidecoder_factory_h
 
 #include "common/factory.h"
-#include "interface/VideoDecoderInterface.h"
+#include "VideoDecoderInterface.h"
 
 namespace YamiMediaCodec {
 

--- a/decoder/vaapidecoder_host.cpp
+++ b/decoder/vaapidecoder_host.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #include "common/log.h"
-#include "interface/VideoDecoderHost.h"
+#include "VideoDecoderHost.h"
 #include "vaapidecoder_factory.h"
 
 #if __BUILD_FAKE_DECODER__

--- a/decoder/vaapidecsurfacepool.h
+++ b/decoder/vaapidecsurfacepool.h
@@ -22,8 +22,8 @@
 #include "common/common_def.h"
 #include "common/lock.h"
 #include "vaapi/vaapiptrs.h"
-#include "interface/VideoCommonDefs.h"
-#include "interface/VideoDecoderDefs.h"
+#include "VideoCommonDefs.h"
+#include "VideoDecoderDefs.h"
 #include <deque>
 #include <map>
 #include <vector>

--- a/egl/egl_util.h
+++ b/egl/egl_util.h
@@ -19,7 +19,7 @@
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 
-#include "interface/VideoCommonDefs.h"
+#include "VideoCommonDefs.h"
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */

--- a/egl/egl_vaapi_image.h
+++ b/egl/egl_vaapi_image.h
@@ -22,7 +22,7 @@
 #include <EGL/eglext.h>
 #include <va/va.h>
 
-#include "interface/VideoCommonDefs.h"
+#include "VideoCommonDefs.h"
 
 namespace YamiMediaCodec {
 

--- a/encoder/Makefile.am
+++ b/encoder/Makefile.am
@@ -72,6 +72,7 @@ endif
 libyami_encoder_cppflags = \
 	$(LIBVA_CFLAGS) \
 	$(LIBVA_DRM_CFLAGS) \
+	-I$(top_srcdir)/interface \
 	$(NULL)
 
 if ENABLE_X11

--- a/encoder/Makefile.unittest
+++ b/encoder/Makefile.unittest
@@ -41,6 +41,7 @@ unittest_CPPFLAGS = \
 	$(GTEST_CPPFLAGS) \
 	$(LIBVA_CFLAGS) \
 	$(AM_CPPFLAGS) \
+	-I$(top_srcdir)/interface \
 	$(NULL)
 
 unittest_CXXFLAGS = \

--- a/encoder/vaapiencoder_base.h
+++ b/encoder/vaapiencoder_base.h
@@ -17,8 +17,8 @@
 #ifndef vaapiencoder_base_h
 #define vaapiencoder_base_h
 
-#include "interface/VideoEncoderDefs.h"
-#include "interface/VideoEncoderInterface.h"
+#include "VideoEncoderDefs.h"
+#include "VideoEncoderInterface.h"
 #include "common/lock.h"
 #include "common/log.h"
 #include "common/surfacepool.h"

--- a/encoder/vaapiencoder_factory.h
+++ b/encoder/vaapiencoder_factory.h
@@ -18,7 +18,7 @@
 #define vaapiencoder_factory_h
 
 #include "common/factory.h"
-#include "interface/VideoEncoderInterface.h"
+#include "VideoEncoderInterface.h"
 
 namespace YamiMediaCodec {
 

--- a/encoder/vaapiencoder_host.cpp
+++ b/encoder/vaapiencoder_host.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #include "common/log.h"
-#include "interface/VideoEncoderHost.h"
+#include "VideoEncoderHost.h"
 #include "vaapiencoder_factory.h"
 
 using namespace YamiMediaCodec;

--- a/encoder/vaapiencpicture.h
+++ b/encoder/vaapiencpicture.h
@@ -17,7 +17,7 @@
 #ifndef vaapiencpicture_h
 #define vaapiencpicture_h
 
-#include "interface/VideoEncoderDefs.h"
+#include "VideoEncoderDefs.h"
 
 #include "vaapi/vaapipicture.h"
 

--- a/interface/VideoCommonDefs.h
+++ b/interface/VideoCommonDefs.h
@@ -250,13 +250,11 @@ typedef struct VideoFrame {
      */
     uint32_t    fourcc;
 
-#ifdef __ENABLE_CAPI__
     /**
      * for frame destory, cpp should not touch here
      */
     intptr_t    user_data;
     void        (*free)(struct VideoFrame* );
-#endif
 } VideoFrame;
 
 #define YAMI_MIME_MPEG2 "video/mpeg2"

--- a/interface/VideoDecoderDefs.h
+++ b/interface/VideoDecoderDefs.h
@@ -20,7 +20,7 @@
 
 #include <va/va.h>
 #include <stdint.h>
-#include "VideoCommonDefs.h"
+#include <VideoCommonDefs.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/interface/VideoDecoderHost.h
+++ b/interface/VideoDecoderHost.h
@@ -20,7 +20,7 @@
 
 #include <string>
 #include <vector>
-#include "VideoDecoderInterface.h"
+#include <VideoDecoderInterface.h>
 
 extern "C" { // for dlsym usage
 /** \file VideoDecoderHost.h

--- a/interface/VideoDecoderInterface.h
+++ b/interface/VideoDecoderInterface.h
@@ -19,7 +19,7 @@
 #define VIDEO_DECODER_INTERFACE_H_
 // config.h should NOT be included in header file, especially for the header file used by external
 
-#include "VideoDecoderDefs.h"
+#include <VideoDecoderDefs.h>
 
 namespace YamiMediaCodec {
 /**

--- a/interface/VideoEncoderDefs.h
+++ b/interface/VideoEncoderDefs.h
@@ -21,7 +21,7 @@
 
 #include <va/va.h>
 #include <stdint.h>
-#include "VideoCommonDefs.h"
+#include <VideoCommonDefs.h>
 
 #define STRING_TO_FOURCC(format) ((uint32_t)(((format)[0])|((format)[1]<<8)|((format)[2]<<16)|((format)[3]<<24)))
 

--- a/interface/VideoEncoderDefs.h
+++ b/interface/VideoEncoderDefs.h
@@ -18,7 +18,6 @@
 #define __VIDEO_ENCODER_DEF_H__
 
 // config.h should NOT be included in header file, especially for the header file used by external
-// XXX __ENABLE_CAPI__ still seems ok in this file
 
 #include <va/va.h>
 #include <stdint.h>
@@ -96,11 +95,6 @@ typedef struct VideoEncOutputBuffer {
     uint32_t flag;                   //Key frame, Codec Data etc
     VideoOutputFormat format;   //output format
     uint64_t timeStamp;         //reserved
-#ifndef __ENABLE_CAPI__
-     VideoEncOutputBuffer():data(0), bufferSize(0), dataSize(0)
-    , remainingSize(0), flag(0), format(OUTPUT_BUFFER_LAST), timeStamp(0) {
-    };
-#endif
 }VideoEncOutputBuffer;
 
 #ifdef __BUILD_GET_MV__
@@ -127,10 +121,6 @@ typedef struct VideoEncMVBuffer {
     uint8_t *data;                //memory to store the MV
     uint32_t bufferSize;        //buffer size
     uint32_t dataSize;          //actuall size
-#ifndef __ENABLE_CAPI__
-     VideoEncMVBuffer():data(0), bufferSize(0), dataSize(0) {
-    };
-#endif
 }VideoEncMVBuffer;
 #endif
 
@@ -142,11 +132,6 @@ typedef struct VideoEncRawBuffer {
     uint64_t timeStamp;         //reserved
     bool forceKeyFrame;
     intptr_t id;
-#ifndef __ENABLE_CAPI__
-     VideoEncRawBuffer():data(0), fourcc(0), size(0), bufAvailable(false),
-        timeStamp(0), forceKeyFrame(false), id(-1) {
-    };
-#endif
 }VideoEncRawBuffer;
 
 typedef struct VideoEncSurfaceBuffer {
@@ -155,29 +140,16 @@ typedef struct VideoEncSurfaceBuffer {
     uint32_t index;
     bool bufAvailable;
     struct EncSurfaceBuffer *next;
-#ifndef __ENABLE_CAPI__
-    VideoEncSurfaceBuffer():surface(VA_INVALID_ID), usrptr(0)
-    , index(0), bufAvailable(false) {
-    };
-#endif
 }VideoEncSurfaceBuffer;
 
 typedef struct VideoFrameRate {
     uint32_t frameRateNum;
     uint32_t frameRateDenom;
-#ifndef __ENABLE_CAPI__
-     VideoFrameRate():frameRateNum(0), frameRateDenom(1) {
-    };
-#endif
 }VideoFrameRate;
 
 typedef struct VideoResolution {
     uint32_t width;
     uint32_t height;
-#ifndef __ENABLE_CAPI__
-     VideoResolution():width(0), height(0) {
-    };
-#endif
 }VideoResolution;
 
 typedef struct VideoRateControlParams {
@@ -191,32 +163,16 @@ typedef struct VideoRateControlParams {
     uint32_t disableBitsStuffing;
     int8_t diffQPIP;// P frame qp minus initQP
     int8_t diffQPIB;// B frame qp minus initQP
-
-#ifndef __ENABLE_CAPI__
-     VideoRateControlParams():bitRate(0), initQP(0), minQP(0)
-    , windowSize(0), targetPercentage(0)
-    , disableFrameSkip(0), disableBitsStuffing(0)
-    , diffQPIP(0), diffQPIB(0) {
-    };
-#endif
 }VideoRateControlParams;
 
 typedef struct SliceNum {
     uint32_t iSliceNum;
     uint32_t pSliceNum;
-#ifndef __ENABLE_CAPI__
-     SliceNum():iSliceNum(1), pSliceNum(1) {
-    };
-#endif
 }SliceNum;
 
 typedef struct SamplingAspectRatio {
     uint16_t SarWidth;
     uint16_t SarHeight;
-#ifndef __ENABLE_CAPI__
-     SamplingAspectRatio():SarWidth(0), SarHeight(0) {
-    };
-#endif
 }SamplingAspectRatio;
 
 typedef enum {

--- a/interface/VideoEncoderHost.h
+++ b/interface/VideoEncoderHost.h
@@ -19,7 +19,7 @@
 
 #include <string>
 #include <vector>
-#include "VideoEncoderInterface.h"
+#include <VideoEncoderInterface.h>
 
 extern "C" { // for dlsym usage
 

--- a/interface/VideoEncoderInterface.h
+++ b/interface/VideoEncoderInterface.h
@@ -18,7 +18,7 @@
 #define VIDEO_ENCODER_INTERFACE_H_
 // config.h should NOT be included in header file, especially for the header file used by external
 
-#include "VideoEncoderDefs.h"
+#include <VideoEncoderDefs.h>
 #undef None // work around for compile in chromeos
 
 namespace YamiMediaCodec{

--- a/interface/VideoPostProcessHost.h
+++ b/interface/VideoPostProcessHost.h
@@ -19,7 +19,7 @@
 
 #include <string>
 #include <vector>
-#include "VideoPostProcessInterface.h"
+#include <VideoPostProcessInterface.h>
 
 extern "C" { // for dlsym usage
 

--- a/interface/VideoPostProcessInterface.h
+++ b/interface/VideoPostProcessInterface.h
@@ -17,8 +17,8 @@
 #ifndef VIDEO_POST_PROCESS_INTERFACE_H_
 #define VIDEO_POST_PROCESS_INTERFACE_H_
 
-#include "VideoCommonDefs.h"
-#include "VideoPostProcessDefs.h"
+#include <VideoCommonDefs.h>
+#include <VideoPostProcessDefs.h>
 
 namespace YamiMediaCodec{
 /**

--- a/interface/Yami.h
+++ b/interface/Yami.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2016 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef YAMI_H_
+#define YAMI_H_
+
+#include <YamiVersion.h>
+
+#include <VideoDecoderHost.h>
+
+#include <VideoEncoderHost.h>
+
+#include <VideoPostProcessHost.h>
+
+#endif

--- a/interface/YamiC.h
+++ b/interface/YamiC.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2016 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef YAMI_C_H_
+#define YAMI_C_H_
+
+#include <YamiVersion.h>
+
+#include <VideoDecoderCapi.h>
+#include <VideoEncoderCapi.h>
+
+#endif

--- a/ocl/oclcontext.h
+++ b/ocl/oclcontext.h
@@ -17,7 +17,7 @@
 #define oclcontext_h
 
 
-#include "interface/VideoCommonDefs.h"
+#include "VideoCommonDefs.h"
 #include "common/lock.h"
 #include <CL/opencl.h>
 #include <CL/cl_intel.h>

--- a/v4l2/Makefile.am
+++ b/v4l2/Makefile.am
@@ -28,6 +28,7 @@ libyamiv4l2_ldflags += $(LIBEGL_LIBS)
 libyamiv4l2_cppflags = \
 	$(LIBVA_CFLAGS) \
 	$(LIBV4L2_CFLAGS) \
+	-I$(top_srcdir)/interface \
 	$(NULL)
 
 if ENABLE_DMABUF

--- a/v4l2/v4l2_codecbase.h
+++ b/v4l2/v4l2_codecbase.h
@@ -23,10 +23,10 @@
 #include "common/condition.h"
 #if ANDROID
 #include "VideoPostProcessHost.h"
-#include "interface/VideoDecoderInterface.h"
+#include "VideoDecoderInterface.h"
 #elif __ENABLE_WAYLAND__
-#include "interface/VideoPostProcessHost.h"
-#include "interface/VideoDecoderInterface.h"
+#include "VideoPostProcessHost.h"
+#include "VideoDecoderInterface.h"
 #else
     #if __ENABLE_X11__
     #include <X11/Xlib.h>
@@ -35,7 +35,7 @@
     #define EGL_EGLEXT_PROTOTYPES
     #include "EGL/eglext.h"
 #endif
-#include "interface/VideoCommonDefs.h"
+#include "VideoCommonDefs.h"
 #include "v4l2codec_device_ops.h"
 #if ANDROID
 #include <va/va_android.h>

--- a/v4l2/v4l2_decode.cpp
+++ b/v4l2/v4l2_decode.cpp
@@ -34,7 +34,7 @@
 #include <va/va_wayland.h>
 #endif
 #include "v4l2_decode.h"
-#include "interface/VideoDecoderHost.h"
+#include "VideoDecoderHost.h"
 #include "common/log.h"
 #include "egl/egl_vaapi_image.h"
 

--- a/v4l2/v4l2_decode.h
+++ b/v4l2/v4l2_decode.h
@@ -19,7 +19,7 @@
 #include <vector>
 
 #include "v4l2_codecbase.h"
-#include "interface/VideoDecoderInterface.h"
+#include "VideoDecoderInterface.h"
 
 namespace YamiMediaCodec {
     class EglVaapiImage;

--- a/v4l2/v4l2_encode.cpp
+++ b/v4l2/v4l2_encode.cpp
@@ -24,7 +24,7 @@
 #include <sys/mman.h>
 
 #include "v4l2_encode.h"
-#include "interface/VideoEncoderHost.h"
+#include "VideoEncoderHost.h"
 #include "common/log.h"
 
 V4l2Encoder::V4l2Encoder()

--- a/v4l2/v4l2_encode.h
+++ b/v4l2/v4l2_encode.h
@@ -19,7 +19,7 @@
 #include <vector>
 
 #include "v4l2_codecbase.h"
-#include "interface/VideoEncoderInterface.h"
+#include "VideoEncoderInterface.h"
 
 using namespace YamiMediaCodec;
 typedef SharedPtr < IVideoEncoder > EncoderPtr;

--- a/v4l2/v4l2_wrapper.h
+++ b/v4l2/v4l2_wrapper.h
@@ -23,7 +23,7 @@
     #endif
     #include <EGL/egl.h>
 #endif
-#include "interface/VideoCommonDefs.h"
+#include "VideoCommonDefs.h"
 
 #ifndef v4l2_wrapper_h
 #define v4l2_wrapper_h

--- a/vaapi/Makefile.am
+++ b/vaapi/Makefile.am
@@ -30,6 +30,7 @@ endif
 
 libyami_vaapi_cppflags = \
 	$(LIBVA_CFLAGS) \
+	-I$(top_srcdir)/interface \
 	$(NULL)
 
 noinst_LTLIBRARIES           = libyami_vaapi.la

--- a/vaapi/Makefile.unittest
+++ b/vaapi/Makefile.unittest
@@ -24,6 +24,7 @@ unittest_CPPFLAGS = \
 	$(GTEST_CPPFLAGS) \
 	$(LIBVA_CFLAGS) \
 	$(AM_CPPFLAGS) \
+	-I$(top_srcdir)/interface \
 	$(NULL)
 
 unittest_CXXFLAGS = \

--- a/vaapi/VaapiSurface.h
+++ b/vaapi/VaapiSurface.h
@@ -18,7 +18,7 @@
 #define VaapiSurface_h
 
 #include "common/NonCopyable.h"
-#include "interface/VideoCommonDefs.h"
+#include "VideoCommonDefs.h"
 #include <va/va.h>
 #include <stdint.h>
 

--- a/vaapi/vaapicontext.h
+++ b/vaapi/vaapicontext.h
@@ -18,7 +18,7 @@
 #define vaapicontext_h
 
 #include "common/NonCopyable.h"
-#include "interface/VideoCommonDefs.h"
+#include "VideoCommonDefs.h"
 #include "vaapi/vaapiptrs.h"
 #include <va/va.h>
 

--- a/vaapi/vaapipicture.h
+++ b/vaapi/vaapipicture.h
@@ -17,7 +17,7 @@
 #ifndef vaapipicture_h
 #define vaapipicture_h
 
-#include "interface/VideoCommonDefs.h"
+#include "VideoCommonDefs.h"
 #include "VaapiBuffer.h"
 #include "vaapiptrs.h"
 #include "VaapiSurface.h"

--- a/vaapi/vaapiptrs.h
+++ b/vaapi/vaapiptrs.h
@@ -17,7 +17,7 @@
 #ifndef vaapiptrs_h
 #define vaapiptrs_h
 
-#include "interface/VideoCommonDefs.h"
+#include "VideoCommonDefs.h"
 
 namespace YamiMediaCodec{
 class VaapiSurface;

--- a/vpp/Makefile.am
+++ b/vpp/Makefile.am
@@ -54,6 +54,7 @@ libyami_vpp_ldflags = \
 libyami_vpp_cppflags = \
 	$(LIBVA_CFLAGS) \
 	$(LIBVA_DRM_CFLAGS) \
+	-I$(top_srcdir)/interface \
 	$(NULL)
 
 if BUILD_OCL_BLENDER

--- a/vpp/Makefile.unittest
+++ b/vpp/Makefile.unittest
@@ -22,6 +22,7 @@ unittest_CPPFLAGS = \
 	$(GTEST_CPPFLAGS) \
 	$(LIBVA_CFLAGS) \
 	$(AM_CPPFLAGS) \
+	-I$(top_srcdir)/interface \
 	$(NULL)
 
 unittest_CXXFLAGS = \

--- a/vpp/oclpostprocess_blender.h
+++ b/vpp/oclpostprocess_blender.h
@@ -17,7 +17,7 @@
 #define oclpostprocess_blender_h
 
 
-#include "interface/VideoCommonDefs.h"
+#include "VideoCommonDefs.h"
 #include "oclpostprocess_base.h"
 
 namespace YamiMediaCodec{

--- a/vpp/oclpostprocess_mosaic.h
+++ b/vpp/oclpostprocess_mosaic.h
@@ -16,7 +16,7 @@
 #ifndef oclpostprocess_mosaic_h
 #define oclpostprocess_mosaic_h
 
-#include "interface/VideoCommonDefs.h"
+#include "VideoCommonDefs.h"
 #include "oclpostprocess_base.h"
 
 namespace YamiMediaCodec {

--- a/vpp/oclpostprocess_osd.h
+++ b/vpp/oclpostprocess_osd.h
@@ -17,7 +17,7 @@
 #define oclpostprocess_osd_h
 
 #include <vector>
-#include "interface/VideoCommonDefs.h"
+#include "VideoCommonDefs.h"
 #include "oclpostprocess_base.h"
 
 using std::vector;

--- a/vpp/oclpostprocess_transform.h
+++ b/vpp/oclpostprocess_transform.h
@@ -17,7 +17,7 @@
 #define oclpostprocess_transform_h
 
 #include <vector>
-#include "interface/VideoCommonDefs.h"
+#include "VideoCommonDefs.h"
 #include "oclpostprocess_base.h"
 
 using std::vector;

--- a/vpp/vaapipostprocess_base.h
+++ b/vpp/vaapipostprocess_base.h
@@ -17,7 +17,7 @@
 #ifndef vaapipostprocess_base_h
 #define vaapipostprocess_base_h
 
-#include "interface/VideoPostProcessInterface.h"
+#include "VideoPostProcessInterface.h"
 #include "vaapi/vaapiptrs.h"
 #include <va/va.h>
 #include <va/va_vpp.h>

--- a/vpp/vaapipostprocess_factory.h
+++ b/vpp/vaapipostprocess_factory.h
@@ -18,7 +18,7 @@
 #define vaapipostprocess_factory_h
 
 #include "common/factory.h"
-#include "interface/VideoPostProcessInterface.h"
+#include "VideoPostProcessInterface.h"
 
 namespace YamiMediaCodec {
 

--- a/vpp/vaapipostprocess_host.cpp
+++ b/vpp/vaapipostprocess_host.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #include "common/log.h"
-#include "interface/VideoPostProcessHost.h"
+#include "VideoPostProcessHost.h"
 #include "vaapipostprocess_factory.h"
 
 using namespace YamiMediaCodec;


### PR DESCRIPTION
1, remove --enable-capi option from configure.ac, always compile libyami_capi.la.
2, remove all micro "ENABLE-CAPI" from code.

Signed-off-by: wudping dongpingx.wu@intel.com
