### PR TITLE
bitreader: skip function can skip more bits

### DIFF
--- a/codecparsers/bitReader.cpp
+++ b/codecparsers/bitReader.cpp
@@ -109,9 +109,18 @@ uint32_t BitReader::read(uint32_t nbits)
     return 0;
 }
 
-void BitReader::skip(uint32_t nbits)
+bool BitReader::skip(uint32_t nbits)
 {
-    read(nbits);
+    uint32_t tmp;
+    while (nbits > 8)
+    {
+        if (!read(tmp, 8))
+            return false;
+        nbits -= 8;
+    }
+    if (!read(tmp, nbits))
+        return false;
+    return true;
 }
 
 uint32_t BitReader::peek(uint32_t nbits) const

--- a/codecparsers/bitReader.h
+++ b/codecparsers/bitReader.h
@@ -47,10 +47,7 @@ public:
     /*read the next nbits bits from the bitstream but not advance the bitstream pointer*/
     uint32_t peek(uint32_t nbits) const;
 
-    /* You are allowed to skip less than BitReader::CACHEBYTES bytes
-     * when call this function at a time. And if you need to skip more than
-     * BitReader::CACHEBYTES bytes, you can call skip() repeatedly. */
-    void skip(uint32_t nbits);
+    bool skip(uint32_t nbits);
 
     /* Get the total bits that had been read from bitstream, and the return
      * value also is the position of the next bit to be read. */


### PR DESCRIPTION
now skip returns a bool type and can skip more then CACHEBYTES
