### PR TITLE
fixes for capi

### DIFF
--- a/capi/Makefile.am
+++ b/capi/Makefile.am
@@ -17,6 +17,7 @@ libyami_capi_ldflags = \
 
 libyami_capi_cppflags = \
 	$(LIBVA_CFLAGS) \
+	-I$(top_srcdir)/interface \
 	$(NULL)
 
 noinst_LTLIBRARIES          = libyami_capi.la

--- a/capi/VideoDecoderCapi.cpp
+++ b/capi/VideoDecoderCapi.cpp
@@ -18,8 +18,8 @@
 #include "config.h"
 #endif
 #include "VideoDecoderCapi.h"
-#include "interface/VideoDecoderInterface.h"
-#include "interface/VideoDecoderHost.h"
+#include "VideoDecoderInterface.h"
+#include "VideoDecoderHost.h"
 
 #include <stdlib.h>
 

--- a/capi/VideoDecoderCapi.h
+++ b/capi/VideoDecoderCapi.h
@@ -20,8 +20,8 @@
 #ifndef __ENABLE_CAPI__
 #define __ENABLE_CAPI__ 1
 #endif
-#include "interface/VideoDecoderDefs.h"
-#include "interface/VideoCommonDefs.h"
+#include "VideoDecoderDefs.h"
+#include "VideoCommonDefs.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/capi/VideoEncoderCapi.cpp
+++ b/capi/VideoEncoderCapi.cpp
@@ -18,8 +18,8 @@
 #include "config.h"
 #endif
 #include "VideoEncoderCapi.h"
-#include "interface/VideoEncoderInterface.h"
-#include "interface/VideoEncoderHost.h"
+#include "VideoEncoderInterface.h"
+#include "VideoEncoderHost.h"
 
 using namespace YamiMediaCodec;
 

--- a/capi/VideoEncoderCapi.h
+++ b/capi/VideoEncoderCapi.h
@@ -20,7 +20,7 @@
 #ifndef __ENABLE_CAPI__
 #define __ENABLE_CAPI__ 1
 #endif
-#include "interface/VideoEncoderDefs.h"
+#include "VideoEncoderDefs.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/common/YamiVersion.h.in
+++ b/common/YamiVersion.h.in
@@ -19,6 +19,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * YAMI_API_MAJOR_VERSION
  * The major version of yami api
@@ -64,5 +68,9 @@
 * return YAMI_API_VERSION;
 */
 void yamiGetApiVersion(uint32_t *apiVersion);
+
+#ifdef __cplusplus
+};
+#endif
 
 #endif /* YAMI_VERSION_H */


### PR DESCRIPTION
These changes make the capi usable.  Since the interface directory is not available outside the project it can not be used.
