### PR TITLE
vp9 encoder: enable second reference frame mode

### DIFF
--- a/encoder/vaapiencoder_vp9.h
+++ b/encoder/vaapiencoder_vp9.h
@@ -22,6 +22,8 @@
 #include <va/va_enc_vp9.h>
 #include <deque>
 
+#include "VideoEncoderDefs.h"
+
 namespace YamiMediaCodec {
 
 class VaapiEncPictureVP9;
@@ -51,7 +53,7 @@ private:
     YamiStatus encodePicture(const PicturePtr&);
     bool fill(VAEncSequenceParameterBufferVP9*) const;
     bool fill(VAEncPictureParameterBufferVP9*, const PicturePtr&,
-              const SurfacePtr&) const;
+              const SurfacePtr&);
     bool fill(VAEncMiscParameterTypeVP9PerSegmantParam* segParam) const;
     bool ensureSequence(const PicturePtr&);
     bool ensurePicture(const PicturePtr&, const SurfacePtr&);
@@ -66,7 +68,11 @@ private:
                                               : 1;
     }
 
+    inline uint32_t getReferenceMode() { return m_videoParamsVP9.referenceMode; }
+
+    VideoParamsVP9 m_videoParamsVP9;
     int m_frameCount;
+    int m_currentReferenceIndex;
 
     int m_maxCodedbufSize;
 

--- a/interface/VideoEncoderDefs.h
+++ b/interface/VideoEncoderDefs.h
@@ -181,6 +181,7 @@ typedef enum {
     VideoParamsTypeAVC,
     VideoParamsTypeH263,
     VideoParamsTypeMP4,
+    VideoParamsTypeVP9,
     VideoParamsTypeVC1,
     VideoParamsTypeHRD,
 
@@ -231,6 +232,10 @@ typedef struct VideoParamsAVC {
     uint32_t temporalLayerNum;
     uint32_t priorityId;
 }VideoParamsAVC;
+
+typedef struct VideoParamsVP9 {
+    uint32_t referenceMode;
+}VideoParamsVP9;
 
 typedef struct VideoParamsHRD {
     uint32_t size;


### PR DESCRIPTION
vp9 encoder provides two modes for reference frames

Mode 0: This is using previous frame as last reference and
previous key frame as gold and alternate references.  On this
scheme, the reference_frames array will be cleared by a key frame,
then the key frame will populate all 8 slots and last frame will be
updated on slot 0.

Mode 1: This is using previous frame as last reference, one frame
before that is the gold reference and one more frame before that is the
alternate reference. On this scheme, the reference_frames array will be
cleared by a key frame, then the key frame will populate all 8 slots. Then
the first 3 slots will be used as a circular reference list where last/gold/alt
frames will be kept and will be updated according to the rules given by the
intel driver.

This can be tested with libyami-utils yamiencode patch

Fixes #554

Signed-off-by: Daniel Charles daniel.charles@intel.com
