### PR TITLE
ocl: add suffix to floating point constant

### DIFF
--- a/ocl/kernels/blend.cl
+++ b/ocl/kernels/blend.cl
@@ -44,17 +44,17 @@ __kernel void blend(__write_only image2d_t dst_y,
     rgba[2] = read_imagef(fg, sampler, (int2)(2 * id_z    , id_w + 1));
     rgba[3] = read_imagef(fg, sampler, (int2)(2 * id_z + 1, id_w + 1));
 
-    y_dst = 0.299 * (float4) (rgba[0].x, rgba[1].x, rgba[2].x, rgba[3].x);
-    y_dst = mad(0.587, (float4) (rgba[0].y, rgba[1].y, rgba[2].y, rgba[3].y), y_dst);
-    y_dst = mad(0.114, (float4) (rgba[0].z, rgba[1].z, rgba[2].z, rgba[3].z), y_dst);
+    y_dst = 0.299f * (float4) (rgba[0].x, rgba[1].x, rgba[2].x, rgba[3].x);
+    y_dst = mad(0.587f, (float4) (rgba[0].y, rgba[1].y, rgba[2].y, rgba[3].y), y_dst);
+    y_dst = mad(0.114f, (float4) (rgba[0].z, rgba[1].z, rgba[2].z, rgba[3].z), y_dst);
     y_dst *= (float4) (rgba[0].w, rgba[1].w, rgba[2].w, rgba[3].w);
     y1_dst.x = mad(1 - rgba[0].w, y1.x, y_dst.x);
     y1_dst.y = mad(1 - rgba[1].w, y1.y, y_dst.y);
     y2_dst.x = mad(1 - rgba[2].w, y2.x, y_dst.z);
     y2_dst.y = mad(1 - rgba[3].w, y2.y, y_dst.w);
 
-    uv_dst.x = rgba[0].w * (-0.14713 * rgba[0].x - 0.28886 * rgba[0].y + 0.43600 * rgba[0].z + 0.5);
-    uv_dst.y = rgba[0].w * ( 0.61500 * rgba[0].x - 0.51499 * rgba[0].y - 0.10001 * rgba[0].z + 0.5);
+    uv_dst.x = rgba[0].w * (-0.14713f * rgba[0].x - 0.28886f * rgba[0].y + 0.43600f * rgba[0].z + 0.5f);
+    uv_dst.y = rgba[0].w * ( 0.61500f * rgba[0].x - 0.51499f * rgba[0].y - 0.10001f * rgba[0].z + 0.5f);
     uv_dst.x = mad(1 - rgba[0].w, uv.x, uv_dst.x);
     uv_dst.y = mad(1 - rgba[0].w, uv.y, uv_dst.y);
 

--- a/ocl/kernels/osd.cl
+++ b/ocl/kernels/osd.cl
@@ -79,7 +79,7 @@ __kernel void osd(__write_only image2d_t img_y_dst,
     // blend BW (1.0/0.0, 0.5, 0.5)
     Y0 = alpha0 * bw  + (1 - alpha0) * Y0;
     Y1 = alpha1 * bw  + (1 - alpha1) * Y1;
-    UV = alpha0 * 0.5 + (1 - alpha0) * UV;
+    UV = alpha0 * 0.5f + (1 - alpha0) * UV;
 
     write_imagef(img_y_dst,  (int2)(id_x, id_y), Y0);
     write_imagef(img_y_dst,  (int2)(id_x, id_y + 1), Y1);

--- a/vpp/Makefile.am
+++ b/vpp/Makefile.am
@@ -1,3 +1,5 @@
+INCLUDES = -I$(top_srcdir)/interface
+
 libyami_vpp_source_c = \
 	vaapipostprocess_base.cpp \
 	vaapipostprocess_host.cpp \


### PR DESCRIPTION
this is the fix for issue #515 

without suffix f, floating point constant's type is double, which cause compile error with some strict ocl compilers.

Also, I find apache branch can't compile with ./configure --enable-oclblender. So vpp/Makefile.am is also fixed.
