### PR TITLE
do not use m_videoFormatInfo in getOutput

### DIFF
--- a/common/surfacepool.cpp
+++ b/common/surfacepool.cpp
@@ -53,7 +53,7 @@ YamiStatus SurfacePool::init(const SharedPtr<SurfaceAllocator>& alloc,
     //prepare surfaces for pool
     std::deque<SurfacePtr> surfaces;
     for (uint32_t i = 0; i < m_params.size; i++) {
-        SurfacePtr s(new VaapiSurface(m_params.surfaces[i], width, height));
+        SurfacePtr s(new VaapiSurface(m_params.surfaces[i], width, height, fourcc));
         surfaces.push_back(s);
     }
     m_pool = VideoPool<VaapiSurface>::create(surfaces);

--- a/decoder/vaapidecoder_base.cpp
+++ b/decoder/vaapidecoder_base.cpp
@@ -193,11 +193,8 @@ SharedPtr<VideoFrame> VaapiDecoderBase::getOutput()
         memset(frame.get(), 0, sizeof(VideoFrame));
         frame->surface = (intptr_t)buffer->surface;
         frame->timeStamp = buffer->timeStamp;
-        frame->crop.x = 0;
-        frame->crop.y = 0;
-        frame->crop.width = m_videoFormatInfo.width;
-        frame->crop.height = m_videoFormatInfo.height;
-        frame->fourcc = m_videoFormatInfo.fourcc;
+        frame->crop = buffer->crop;
+        frame->fourcc = buffer->fourcc;
     }
     return frame;
 }

--- a/decoder/vaapidecoder_h264.cpp
+++ b/decoder/vaapidecoder_h264.cpp
@@ -1663,6 +1663,20 @@ YamiStatus VaapiDecoderH264::ensureContext(const SharedPtr<SPS>& sps)
     return (m_context) ? YAMI_SUCCESS : YAMI_FAIL;
 }
 
+SurfacePtr VaapiDecoderH264::createSurface(const SliceHeader* const slice)
+{
+    SurfacePtr s = VaapiDecoderBase::createSurface();
+    if (!s)
+        return s;
+    SharedPtr<SPS>& sps = slice->m_pps->m_sps;
+
+    if (sps->frame_cropping_flag)
+        s->setCrop(0, 0, sps->m_cropRectWidth, sps->m_cropRectHeight);
+    else
+        s->setCrop(0, 0, sps->m_width, sps->m_height);
+    return s;
+}
+
 YamiStatus VaapiDecoderH264::createPicture(const SliceHeader* const slice,
     const NalUnit* const nalu)
 {
@@ -1691,7 +1705,7 @@ YamiStatus VaapiDecoderH264::createPicture(const SliceHeader* const slice,
     }
 
     if (!slice->field_pic_flag || !isSecondField) {
-        m_currSurface = createSurface();
+        m_currSurface = createSurface(slice);
         if (!m_currSurface)
             return YAMI_DECODE_NO_SURFACE;
         m_currPic.reset(

--- a/decoder/vaapidecoder_h264.h
+++ b/decoder/vaapidecoder_h264.h
@@ -153,6 +153,7 @@ private:
         const NalUnit* const nalu);
     YamiStatus decodeCurrent();
     YamiStatus outputPicture(const PicturePtr&);
+    SurfacePtr createSurface(const SliceHeader* const);
 
     YamiParser::H264::Parser m_parser;
     PicturePtr m_currPic;

--- a/decoder/vaapidecoder_h265.cpp
+++ b/decoder/vaapidecoder_h265.cpp
@@ -970,11 +970,25 @@ void VaapiDecoderH265::getPoc(const PicturePtr& picture,
     }
 }
 
+SurfacePtr VaapiDecoderH265::createSurface(const SliceHeader* const slice)
+{
+    SurfacePtr s = VaapiDecoderBase::createSurface();
+    if (!s)
+        return s;
+    SharedPtr<SPS>& sps = slice->pps->sps;
+
+    if (sps->conformance_window_flag)
+        s->setCrop(0, 0, sps->croppedWidth, sps->croppedHeight);
+    else
+        s->setCrop(0, 0, sps->width, sps->height);
+    return s;
+}
+
 PicturePtr VaapiDecoderH265::createPicture(const SliceHeader* const slice,
         const NalUnit* const nalu)
 {
     PicturePtr picture;
-    SurfacePtr surface = createSurface();
+    SurfacePtr surface = createSurface(slice);
     if (!surface)
         return picture;
     picture.reset(new VaapiDecPictureH265(m_context, surface, m_currentPTS));

--- a/decoder/vaapidecoder_h265.h
+++ b/decoder/vaapidecoder_h265.h
@@ -134,6 +134,7 @@ private:
 
     bool decodeHevcRecordData(uint8_t* buf, int32_t bufSize);
 
+    SurfacePtr createSurface(const SliceHeader* const);
     PicturePtr createPicture(const SliceHeader* const, const NalUnit* const nalu);
     void getPoc(const PicturePtr&, const SliceHeader* const,
             const NalUnit* const);

--- a/decoder/vaapidecoder_mpeg2.cpp
+++ b/decoder/vaapidecoder_mpeg2.cpp
@@ -625,6 +625,7 @@ YamiStatus VaapiDecoderMPEG2::assignSurface()
     if (!surface) {
         status = YAMI_OUT_MEMORY;
     } else {
+        surface->setCrop(0, 0, m_configBuffer.width, m_configBuffer.height);
         m_currentPicture.reset(
             new VaapiDecPictureMpeg2(m_context, surface, m_currentPTS));
         m_currentPicture->m_isFirstField_ = true;

--- a/decoder/vaapidecsurfacepool.cpp
+++ b/decoder/vaapidecsurfacepool.cpp
@@ -139,6 +139,10 @@ bool VaapiDecSurfacePool::output(const SurfacePtr& surface, int64_t timeStamp)
     assert(it->second == SURFACE_DECODING);
     it->second |= SURFACE_TO_RENDER;
     VideoRenderBuffer* buffer = m_renderMap[id];
+
+    VideoRect& crop = buffer->crop;
+    surface->getCrop(crop.x, crop.y, crop.width, crop.height);
+
     buffer->timeStamp = timeStamp;
     DEBUG("surface=0x%x is output-able with timeStamp=%ld", surface->getID(), timeStamp);
     m_output.push_back(buffer);

--- a/decoder/vaapidecsurfacepool.cpp
+++ b/decoder/vaapidecsurfacepool.cpp
@@ -54,10 +54,11 @@ bool VaapiDecSurfacePool::init(const DisplayPtr& display, VideoConfigBuffer* con
     uint32_t size = m_allocParams.size;
     uint32_t width = m_allocParams.width;
     uint32_t height = m_allocParams.height;
+    uint32_t fourcc = config->fourcc;
 
     m_renderBuffers.resize(size);
     for (uint32_t i = 0; i < size; i++) {
-        SurfacePtr s(new VaapiSurface(m_allocParams.surfaces[i], width, height));
+        SurfacePtr s(new VaapiSurface(m_allocParams.surfaces[i], width, height, fourcc));
         VASurfaceID id = s->getID();
 
         m_renderBuffers[i].display = m_display->getID();
@@ -142,6 +143,7 @@ bool VaapiDecSurfacePool::output(const SurfacePtr& surface, int64_t timeStamp)
 
     VideoRect& crop = buffer->crop;
     surface->getCrop(crop.x, crop.y, crop.width, crop.height);
+    buffer->fourcc = surface->getFourcc();
 
     buffer->timeStamp = timeStamp;
     DEBUG("surface=0x%x is output-able with timeStamp=%ld", surface->getID(), timeStamp);

--- a/decoder/vaapidecsurfacepool.h
+++ b/decoder/vaapidecsurfacepool.h
@@ -31,6 +31,13 @@
 
 namespace YamiMediaCodec{
 
+typedef struct {
+    VASurfaceID surface;
+    VADisplay display;
+    int64_t timeStamp; // presentation time stamp
+    VideoRect crop;
+} VideoRenderBuffer;
+
 /***
  * \class VaapiDecSurfacePool
  * \brief surface pool used for decoding rendering

--- a/decoder/vaapidecsurfacepool.h
+++ b/decoder/vaapidecsurfacepool.h
@@ -36,6 +36,7 @@ typedef struct {
     VADisplay display;
     int64_t timeStamp; // presentation time stamp
     VideoRect crop;
+    uint32_t fourcc;
 } VideoRenderBuffer;
 
 /***

--- a/encoder/vaapiencoder_base.cpp
+++ b/encoder/vaapiencoder_base.cpp
@@ -301,7 +301,7 @@ SurfacePtr VaapiEncoderBase::createNewSurface(uint32_t fourcc)
         &id, 1, &attrib, 1);
     if (!checkVaapiStatus(status, "vaCreateSurfaces"))
         return surface;
-    surface.reset(new VaapiSurface((intptr_t)id, width, height),
+    surface.reset(new VaapiSurface((intptr_t)id, width, height, fourcc),
         SurfaceDestroyer(m_display));
     return surface;
 }

--- a/interface/VideoDecoderDefs.h
+++ b/interface/VideoDecoderDefs.h
@@ -60,12 +60,6 @@ typedef struct {
 }VideoConfigBuffer;
 
 typedef struct {
-    VASurfaceID surface;
-    VADisplay display;
-    int64_t timeStamp;          // presentation time stamp
-}VideoRenderBuffer;
-
-typedef struct {
     bool valid;                 // indicates whether format info is valid. MimeType is always valid.
     char *mimeType;
     uint32_t width;

--- a/vaapi/VaapiSurface.cpp
+++ b/vaapi/VaapiSurface.cpp
@@ -24,7 +24,7 @@
 
 namespace YamiMediaCodec {
 
-VaapiSurface::VaapiSurface(intptr_t id, uint32_t width, uint32_t height)
+VaapiSurface::VaapiSurface(intptr_t id, uint32_t width, uint32_t height, uint32_t fourcc)
 {
     m_frame.reset(new VideoFrame);
     memset(m_frame.get(), 0, sizeof(VideoFrame));
@@ -32,6 +32,7 @@ VaapiSurface::VaapiSurface(intptr_t id, uint32_t width, uint32_t height)
     m_frame->crop.x = m_frame->crop.y = 0;
     m_frame->crop.width = width;
     m_frame->crop.height = height;
+    m_frame->fourcc = fourcc;
     m_width = width;
     m_height = height;
 }
@@ -71,5 +72,10 @@ void VaapiSurface::getCrop(uint32_t& x, uint32_t& y, uint32_t& width, uint32_t& 
     y = r.y;
     width = r.width;
     height = r.height;
+}
+
+uint32_t VaapiSurface::getFourcc()
+{
+    return m_frame->fourcc;
 }
 }

--- a/vaapi/VaapiSurface.h
+++ b/vaapi/VaapiSurface.h
@@ -26,13 +26,14 @@ namespace YamiMediaCodec {
 
 class VaapiSurface {
 public:
-    VaapiSurface(intptr_t id, uint32_t width, uint32_t height);
+    VaapiSurface(intptr_t id, uint32_t width, uint32_t height, uint32_t fourcc);
     VaapiSurface(const SharedPtr<VideoFrame>&);
 
     VASurfaceID getID();
 
     bool setCrop(uint32_t x, uint32_t y, uint32_t width, uint32_t height);
     void getCrop(uint32_t& x, uint32_t& y, uint32_t& width, uint32_t& height);
+    uint32_t getFourcc();
 
 private:
     SharedPtr<VideoFrame> m_frame;


### PR DESCRIPTION
getOuptut maybe call after format change. Suppose you have a clips with two frame in different resolution, named AB.
Imaging following call sequence:
1.User sent A to yami
2.User sent B to yami
3.Yami generate format change to user
4.User sent B to yami again.
5.Then user get the two frames.
Since the m_videoFormatInfo already changed after step 3, we will get frame A with B’s resolution.
This definitely wrong. This pull request  will fix the issue
