### PR TITLE
[second implementation] vp9 encoder: enable second reference frame mode

### DIFF
--- a/encoder/vaapiencoder_vp9.h
+++ b/encoder/vaapiencoder_vp9.h
@@ -51,12 +51,13 @@ private:
     YamiStatus encodePicture(const PicturePtr&);
     bool fill(VAEncSequenceParameterBufferVP9*) const;
     bool fill(VAEncPictureParameterBufferVP9*, const PicturePtr&,
-              const SurfacePtr&) const;
+              const SurfacePtr&);
     bool fill(VAEncMiscParameterTypeVP9PerSegmantParam* segParam) const;
     bool ensureSequence(const PicturePtr&);
     bool ensurePicture(const PicturePtr&, const SurfacePtr&);
     bool ensureQMatrix(const PicturePtr&);
     bool referenceListUpdate(const PicturePtr&, const SurfacePtr&);
+    void resetReferenceIndex();
 
     void resetParams();
 
@@ -66,7 +67,11 @@ private:
                                               : 1;
     }
 
+    inline uint32_t getReferenceMode() { return m_videoParamCommon.referenceMode; }
+
     int m_frameCount;
+    int m_currentReferenceIndex;
+    std::deque<uint32_t> m_referenceIndex;
 
     int m_maxCodedbufSize;
 

--- a/interface/VideoEncoderDefs.h
+++ b/interface/VideoEncoderDefs.h
@@ -256,6 +256,7 @@ typedef struct VideoParamsCommon {
     uint32_t numRefFrames;
     VideoRateControl rcMode;
     VideoRateControlParams rcParams;
+    uint32_t referenceMode;
     uint32_t leastInputCount;
 }VideoParamsCommon;
 


### PR DESCRIPTION
This second implementation is given to compare against the original patch

vp9 encoder provides two modes for reference frames

Mode 0: This is using previous frame as last reference and
previous key frame as gold and alternate references.  On this
scheme, the reference_frames array will be cleared by a key frame,
then the key frame will populate all 8 slots and last frame will be
updated on slot 0.

Mode 1: This is using previous frame as last reference, one frame
before that is the gold reference and one more frame before that is the
alternate reference. On this scheme, the reference_frames array will be
cleared by a key frame, then the key frame will populate all 8 slots. Then
the first 3 slots will be used as a circular reference list where last/gold/alt
frames will be kept and will be updated according to the rules given by the
intel driver.

This can be tested with libyami-utils yamiencode patch

Fixes #554

Signed-off-by: Daniel Charles daniel.charles@intel.com
