### PR TITLE
h265dec: fix infinite loop in VaapiDecoderH265::DPB::init

### DIFF
--- a/decoder/vaapidecoder_h265.cpp
+++ b/decoder/vaapidecoder_h265.cpp
@@ -365,8 +365,10 @@ bool VaapiDecoderH265::DPB::init(const PicturePtr& picture,
     removeUnused();
     const PPS* const pps = slice->pps.get();
     const SPS* const sps = pps->sps.get();
-    while (checkReorderPics(sps) || checkLatency(sps) || checkDpbSize(sps))
-        bump();
+    while (checkReorderPics(sps) || checkLatency(sps) || checkDpbSize(sps)) {
+        if (!bump())
+            return false;
+    }
 
     return true;
 }


### PR DESCRIPTION
If there are some error bit stream or the dpb logical have some bug,
the checkDpbSize return true and it’s not frame to output,
the bump will return false, and do not remove any thing from dpb.
Again the dpb still full, it trap to an infinite loop. Check the bump
result will break the loop.This fixes https://github.com/01org/libyami/issues/584
