### PR TITLE
vpx-encoder: doEncode to use forceKeyFrame

### DIFF
--- a/encoder/vaapiencoder_vp8.cpp
+++ b/encoder/vaapiencoder_vp8.cpp
@@ -136,8 +136,11 @@ YamiStatus VaapiEncoderVP8::doEncode(const SurfacePtr& surface, uint64_t timeSta
 
     PicturePtr picture(new VaapiEncPictureVP8(m_context, surface, timeStamp));
 
-    m_frameCount %= keyFramePeriod();
-    picture->m_type = (m_frameCount ? VAAPI_PICTURE_P : VAAPI_PICTURE_I);
+    if (!(m_frameCount % keyFramePeriod()) || forceKeyFrame)
+        picture->m_type = VAAPI_PICTURE_I;
+    else
+        picture->m_type = VAAPI_PICTURE_P;
+
     m_frameCount++;
 
     m_qIndex = (initQP() > minQP() && initQP() < maxQP()) ? initQP() : VP8_DEFAULT_QP;

--- a/encoder/vaapiencoder_vp9.cpp
+++ b/encoder/vaapiencoder_vp9.cpp
@@ -159,8 +159,11 @@ YamiStatus VaapiEncoderVP9::doEncode(const SurfacePtr& surface,
 
     PicturePtr picture(new VaapiEncPictureVP9(m_context, surface, timeStamp));
 
-    m_frameCount %= keyFramePeriod();
-    picture->m_type = (m_frameCount ? VAAPI_PICTURE_P : VAAPI_PICTURE_I);
+    if (!(m_frameCount % keyFramePeriod()) || forceKeyFrame)
+        picture->m_type = VAAPI_PICTURE_I;
+    else
+        picture->m_type = VAAPI_PICTURE_P;
+
     m_frameCount++;
 
     CodedBufferPtr codedBuffer


### PR DESCRIPTION
doEncode has to use forceKeyFrame to request a key frame to the driver. There's
no need for the libyami component to calculate the next key frame itself.

Application will set the key frame flag on its own.

Signed-off-by: Daniel Charles daniel.charles@intel.com

Fixes #583 
