### PR TITLE
RFC vp9encoder: set frame width and height to 8 bit aligned

### DIFF
--- a/encoder/vaapiencoder_vp9.cpp
+++ b/encoder/vaapiencoder_vp9.cpp
@@ -257,10 +257,10 @@ bool VaapiEncoderVP9::fill(VAEncPictureParameterBufferVP9* picParam,
         }
     }
 
-    picParam->frame_width_src = width();
-    picParam->frame_height_src = height();
-    picParam->frame_width_dst = width();
-    picParam->frame_height_dst = height();
+    picParam->frame_width_src = ALIGN8(width());
+    picParam->frame_height_src = ALIGN8(height());
+    picParam->frame_width_dst = ALIGN8(width());
+    picParam->frame_height_dst = ALIGN8(height());
 
     picParam->pic_flags.bits.show_frame = 1;
 


### PR DESCRIPTION
When encoding yuv inputs that are not 8 bit aligned, the first
call to vaEndPicture will result in a unrecoverable error.  By
setting the resolution on the VAEncPictureParameterBufferVP9 structure
to be 8 pixel aligned then the driver will create a valid output
stream but with a strip on the bottom and right side when either
resolution was re-aligned.

There's no need to allocate surfaces or reconstructed surface
8 bit aligned to be able to avoid the vaEndPicture error

Both src and dst need to be aligned on this structure otherwise the
vaEndPicture will keep crashing.

Investigation started to try to fix: #582 

Signed-off-by: Daniel Charles daniel.charles@intel.com
