### PR TITLE
265dec: make dec continuing decoding when Invalid_Data

### DIFF
--- a/decoder/vaapidecoder_h265.cpp
+++ b/decoder/vaapidecoder_h265.cpp
@@ -1104,7 +1104,7 @@ YamiStatus VaapiDecoderH265::decode(VideoDecodeBuffer* buffer)
         NalUnit nalu;
         if (nalu.parseNaluHeader(nal, size)) {
             status = decodeNalu(&nalu);
-            if (status != YAMI_SUCCESS)
+            if (status != YAMI_SUCCESS && status != YAMI_DECODE_INVALID_DATA)
                 return status;
         }
     }


### PR DESCRIPTION
In the case that H265 clips start with VPS1,VPS2,PPS1,VPS3,
SPS2 and PPS2, 265 decoder can't find out SPS when parsing
PPS1; As we know that start NAL units(VPS1, VPS2, PPS1) are
invalid data, but VPS3, SPS2 and PPS2 may be correct, so we
should continue decoding when geting error(YAMI_DECODE_IN-
VALID_DATA) from parsing PPS1;

This patch is supposed to perform that.

Signed-off-by: wudping dongpingx.wu@intel.com
