### PR TITLE
configure: fix the h265dec config inconformity issue.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -191,7 +191,7 @@ dnl h265 decoder
 AC_ARG_ENABLE(h265dec,
     [AC_HELP_STRING([--enable-h265dec],
         [build with h265 decoder support @<:@default=yes@:>@])],
-    [], [enable_h265dec="no"])
+    [], [enable_h265dec="yes"])
 
 AM_CONDITIONAL(BUILD_H265_DECODER,
     [test "x$enable_h265dec" = "xyes"])


### PR DESCRIPTION
in the config help, default is enable h265dec,  in fact
is disable the h265dec by default, need to used the --enable-h265dec
enable h265 decoder. Change the h265enc default setting with
"yes" now.

Signed-off-by: Jun Zhao jun.zhao@intel.com
