### PR TITLE
ocl bug fix and wireframe support

### DIFF
--- a/common/common_def.h
+++ b/common/common_def.h
@@ -54,6 +54,10 @@
 #define ALIGN_POW2(a, b) ((a + (b - 1)) & ~(b - 1))
 #endif
 
+#ifndef ALIGN2
+#define ALIGN2(a) ALIGN_POW2(a, 2)
+#endif
+
 #ifndef ALIGN8
 #define ALIGN8(a) ALIGN_POW2(a, 8)
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -280,14 +280,14 @@ fi
 AM_CONDITIONAL(BUILD_GET_MV,
     [test "x$enable_getmv" = "xyes"])
 
-dnl ocl blender
-AC_ARG_ENABLE(oclblender,
-    [AC_HELP_STRING([--enable-oclblender],
+dnl ocl filters
+AC_ARG_ENABLE(oclfilters,
+    [AC_HELP_STRING([--enable-oclfilters],
         [build with opencl based alpha blend support @<:@default=no@:>@])],
-    [], [enable_oclblender="no"])
+    [], [enable_oclfilters="no"])
 
-AM_CONDITIONAL(BUILD_OCL_BLENDER,
-    [test "x$enable_oclblender" = "xyes"])
+AM_CONDITIONAL(BUILD_OCL_FILTERS,
+    [test "x$enable_oclfilters" = "xyes"])
 
 
 # dnl Doxygen
@@ -427,7 +427,7 @@ AS_IF([test x$enable_vp8enc = xyes], [ENCODERS="$ENCODERS vp8"])
 AS_IF([test x$enable_vp9enc = xyes], [ENCODERS="$ENCODERS vp9"])
 
 VPPS=" scaler"
-AS_IF([test x$enable_oclblender = xyes], [VPPS="$VPPS oclblender"])
+AS_IF([test x$enable_oclfilters = xyes], [VPPS="$VPPS oclfilters"])
 
 AC_MSG_RESULT([
     libyami - libyami_version (API: yami_api_version)

--- a/interface/VideoCommonDefs.h
+++ b/interface/VideoCommonDefs.h
@@ -268,6 +268,7 @@ typedef struct VideoFrame {
 #define YAMI_VPP_OCL_OSD "vpp/ocl_osd"
 #define YAMI_VPP_OCL_TRANSFORM "vpp/ocl_transform"
 #define YAMI_VPP_OCL_MOSAIC "vpp/ocl_mosaic"
+#define YAMI_VPP_OCL_WIREFRAME "vpp/ocl_wireframe"
 
 #ifdef __cplusplus
 }

--- a/interface/VideoPostProcessDefs.h
+++ b/interface/VideoPostProcessDefs.h
@@ -28,6 +28,7 @@ typedef enum {
     VppParamTypeDenoise,
     VppParamTypeSharpening,
     VppParamTypeDeinterlace,
+    VppParamTypeWireframe,
 } VppParamType;
 
 typedef struct VppParamOsd {
@@ -82,6 +83,14 @@ typedef struct VPPDeinterlaceParameters {
     size_t size;
     VppDeinterlaceMode mode;
 } VPPDeinterlaceParameters;
+
+typedef struct VppParamWireframe {
+    size_t size;
+    uint32_t borderWidth;
+    uint8_t colorY;
+    uint8_t colorU;
+    uint8_t colorV;
+} VppParamWireframe;
 
 #ifdef __cplusplus
 }

--- a/ocl/kernels/wireframe.cl
+++ b/ocl/kernels/wireframe.cl
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2016 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+__kernel void wireframe(__write_only image2d_t img_y,
+                        __write_only image2d_t img_uv,
+                        uint crop_x,
+                        uint crop_y,
+                        uint crop_w,
+                        uint crop_h,
+                        uint border,
+                        uchar y,
+                        uchar u,
+                        uchar v)
+{
+    sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+    size_t g_id_x = get_global_id(0);
+    size_t g_id_y = get_global_id(1);
+    uint4 Y = (uint4)y;
+    uint4 UV = (uint4)(u, v, 0, 0);
+
+    if ((g_id_x < crop_w && g_id_y < border)
+       || ((g_id_x < border || (g_id_x + border >= crop_w && g_id_x < crop_w))
+           && (g_id_y >= border && g_id_y + border < crop_h))
+       || (g_id_x < crop_w && (g_id_y + border >= crop_h && g_id_y < crop_h))) {
+        write_imageui(img_y, (int2)(g_id_x + crop_x, 2 * (g_id_y + crop_y)), Y);
+        write_imageui(img_y, (int2)(g_id_x + crop_x, 2 * (g_id_y + crop_y) + 1), Y);
+        write_imageui(img_uv, (int2)(g_id_x + crop_x, g_id_y + crop_y), UV);
+    }
+}

--- a/vpp/Makefile.am
+++ b/vpp/Makefile.am
@@ -7,13 +7,13 @@ libyami_vpp_source_c = \
 	vaapivpppicture.cpp \
 	$(NULL)
 
-if BUILD_OCL_BLENDER
+if BUILD_OCL_FILTERS
 libyami_vpp_source_c += ../ocl/oclcontext.cpp
 libyami_vpp_source_c += oclpostprocess_base.cpp
 libyami_vpp_source_c += oclvppimage.cpp
 endif
 
-if BUILD_OCL_BLENDER
+if BUILD_OCL_FILTERS
 libyami_vpp_source_c += oclpostprocess_blender.cpp
 libyami_vpp_source_c += oclpostprocess_osd.cpp
 libyami_vpp_source_c += oclpostprocess_transform.cpp
@@ -34,13 +34,13 @@ libyami_vpp_source_h_priv = \
 	vaapivpppicture.h \
 	$(NULL)
 
-if BUILD_OCL_BLENDER
+if BUILD_OCL_FILTERS
 libyami_vpp_source_h_priv += ../ocl/oclcontext.h
 libyami_vpp_source_h_priv += oclpostprocess_base.h
 libyami_vpp_source_h_priv += oclvppimage.h
 endif
 
-if BUILD_OCL_BLENDER
+if BUILD_OCL_FILTERS
 libyami_vpp_source_h_priv += oclpostprocess_blender.h
 libyami_vpp_source_h_priv += oclpostprocess_osd.h
 libyami_vpp_source_h_priv += oclpostprocess_transform.h
@@ -61,7 +61,7 @@ libyami_vpp_cppflags = \
 	-I$(top_srcdir)/interface \
 	$(NULL)
 
-if BUILD_OCL_BLENDER
+if BUILD_OCL_FILTERS
 libyami_vpp_ocl_kernel = \
 	../ocl/kernels/blend.cl \
 	../ocl/kernels/osd.cl \
@@ -74,7 +74,7 @@ kernel_DATA           = $(libyami_vpp_ocl_kernel)
 libyami_vpp_cppflags += -DKERNEL_DIR=\"$(kerneldir)/\"
 endif
 
-if BUILD_OCL_BLENDER
+if BUILD_OCL_FILTERS
 libyami_vpp_ldflags += -lOpenCL
 endif
 

--- a/vpp/Makefile.am
+++ b/vpp/Makefile.am
@@ -18,6 +18,7 @@ libyami_vpp_source_c += oclpostprocess_blender.cpp
 libyami_vpp_source_c += oclpostprocess_osd.cpp
 libyami_vpp_source_c += oclpostprocess_transform.cpp
 libyami_vpp_source_c += oclpostprocess_mosaic.cpp
+libyami_vpp_source_c += oclpostprocess_wireframe.cpp
 endif
 
 libyami_vpp_source_h = \
@@ -44,6 +45,7 @@ libyami_vpp_source_h_priv += oclpostprocess_blender.h
 libyami_vpp_source_h_priv += oclpostprocess_osd.h
 libyami_vpp_source_h_priv += oclpostprocess_transform.h
 libyami_vpp_source_h_priv += oclpostprocess_mosaic.h
+libyami_vpp_source_h_priv += oclpostprocess_wireframe.h
 endif
 
 libyami_vpp_ldflags = \
@@ -65,6 +67,7 @@ libyami_vpp_ocl_kernel = \
 	../ocl/kernels/osd.cl \
 	../ocl/kernels/transform.cl \
 	../ocl/kernels/mosaic.cl \
+	../ocl/kernels/wireframe.cl \
 	$(NULL)
 kerneldir             = $(datadir)/libyami/kernel
 kernel_DATA           = $(libyami_vpp_ocl_kernel)

--- a/vpp/oclpostprocess_blender.h
+++ b/vpp/oclpostprocess_blender.h
@@ -33,6 +33,7 @@ public:
     explicit OclPostProcessBlender()
         : m_kernelBlend(NULL)
     {
+        ensureContext("blend");
     }
 
 private:

--- a/vpp/oclpostprocess_mosaic.cpp
+++ b/vpp/oclpostprocess_mosaic.cpp
@@ -66,13 +66,15 @@ OclPostProcessMosaic::process(const SharedPtr<VideoFrame>& src,
     size_t localMemSize = localWorkSize[0] * sizeof(float);
 
     if ((CL_SUCCESS != clSetKernelArg(m_kernelMosaic, 0, sizeof(cl_mem), &imagePtr->plane(0)))
-        || (CL_SUCCESS != clSetKernelArg(m_kernelMosaic, 1, sizeof(cl_mem), &bgImageMem[0]))
-        || (CL_SUCCESS != clSetKernelArg(m_kernelMosaic, 2, sizeof(cl_mem), &imagePtr->plane(1)))
-        || (CL_SUCCESS != clSetKernelArg(m_kernelMosaic, 3, sizeof(cl_mem), &bgImageMem[1]))
-        || (CL_SUCCESS != clSetKernelArg(m_kernelMosaic, 4, sizeof(uint32_t), &dst->crop.x))
-        || (CL_SUCCESS != clSetKernelArg(m_kernelMosaic, 5, sizeof(uint32_t), &dst->crop.y))
-        || (CL_SUCCESS != clSetKernelArg(m_kernelMosaic, 6, sizeof(uint32_t), &m_blockSize))
-        || (CL_SUCCESS != clSetKernelArg(m_kernelMosaic, 7, localMemSize, NULL))) {
+         || (CL_SUCCESS != clSetKernelArg(m_kernelMosaic, 1, sizeof(cl_mem), &bgImageMem[0]))
+         || (CL_SUCCESS != clSetKernelArg(m_kernelMosaic, 2, sizeof(cl_mem), &imagePtr->plane(1)))
+         || (CL_SUCCESS != clSetKernelArg(m_kernelMosaic, 3, sizeof(cl_mem), &bgImageMem[1]))
+         || (CL_SUCCESS != clSetKernelArg(m_kernelMosaic, 4, sizeof(uint32_t), &dst->crop.x))
+         || (CL_SUCCESS != clSetKernelArg(m_kernelMosaic, 5, sizeof(uint32_t), &dst->crop.y))
+         || (CL_SUCCESS != clSetKernelArg(m_kernelMosaic, 6, sizeof(uint32_t), &dst->crop.width))
+         || (CL_SUCCESS != clSetKernelArg(m_kernelMosaic, 7, sizeof(uint32_t), &dst->crop.height))
+         || (CL_SUCCESS != clSetKernelArg(m_kernelMosaic, 8, sizeof(uint32_t), &m_blockSize))
+         || (CL_SUCCESS != clSetKernelArg(m_kernelMosaic, 9, localMemSize, NULL))) {
         ERROR("clSetKernelArg failed");
         return YAMI_FAIL;
     }

--- a/vpp/oclpostprocess_mosaic.h
+++ b/vpp/oclpostprocess_mosaic.h
@@ -36,6 +36,7 @@ public:
         : m_blockSize(32)
         , m_kernelMosaic(NULL)
     {
+        ensureContext("mosaic");
     }
 
 private:

--- a/vpp/oclpostprocess_osd.h
+++ b/vpp/oclpostprocess_osd.h
@@ -41,6 +41,7 @@ public:
         , m_kernelOsd(NULL)
         , m_kernelReduceLuma(NULL)
     {
+        ensureContext("osd");
     }
 
 private:

--- a/vpp/oclpostprocess_transform.h
+++ b/vpp/oclpostprocess_transform.h
@@ -45,6 +45,7 @@ public:
         , m_kernelFlipHRot90(NULL)
         , m_kernelFlipVRot90(NULL)
     {
+        ensureContext("transform");
     }
 
 private:

--- a/vpp/oclpostprocess_wireframe.cpp
+++ b/vpp/oclpostprocess_wireframe.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2016 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "oclpostprocess_wireframe.h"
+#include "vaapipostprocess_factory.h"
+#include "common/common_def.h"
+#include "common/log.h"
+#include "ocl/oclcontext.h"
+#include "vpp/oclvppimage.h"
+
+namespace YamiMediaCodec {
+
+YamiStatus
+OclPostProcessWireframe::process(const SharedPtr<VideoFrame>& src,
+    const SharedPtr<VideoFrame>& dst)
+{
+    YamiStatus status = ensureContext("wireframe");
+    if (status != YAMI_SUCCESS)
+        return status;
+
+    if (src != dst) {
+        ERROR("src and dst must be the same for wireframe");
+        return YAMI_INVALID_PARAM;
+    }
+
+    if (dst->fourcc != YAMI_FOURCC_NV12) {
+        ERROR("only support wireframe on NV12 video frame");
+        return YAMI_INVALID_PARAM;
+    }
+
+    if (m_borderWidth == 0
+        || dst->crop.width < 2 * m_borderWidth
+        || dst->crop.height < 2 * m_borderWidth) {
+        ERROR("wireframe invalid param");
+        return YAMI_INVALID_PARAM;
+    }
+
+    cl_image_format format;
+    format.image_channel_order = CL_RG;
+    format.image_channel_data_type = CL_UNSIGNED_INT8;
+    uint32_t pixelSize = getPixelSize(format);
+    uint32_t x = ALIGN_POW2(dst->crop.x, pixelSize) / pixelSize;
+    uint32_t y = ALIGN_POW2(dst->crop.y, pixelSize) / pixelSize;
+    uint32_t w = ALIGN_POW2(dst->crop.width, pixelSize) / pixelSize;
+    uint32_t h = ALIGN_POW2(dst->crop.height, pixelSize) / pixelSize;
+    uint32_t b = ALIGN_POW2(m_borderWidth, pixelSize) / pixelSize;
+    SharedPtr<OclVppCLImage> imagePtr = OclVppCLImage::create(m_display, dst, m_context, format);
+    if (!imagePtr->numPlanes()) {
+        ERROR("failed to create cl image from dst frame");
+        return YAMI_FAIL;
+    }
+
+    size_t globalWorkSize[2], localWorkSize[2];
+    localWorkSize[0] = 8;
+    localWorkSize[1] = 8;
+    globalWorkSize[0] = (w / localWorkSize[0] + 1) * localWorkSize[0];
+    globalWorkSize[1] = (h / localWorkSize[1] + 1) * localWorkSize[1];
+
+    if ((CL_SUCCESS != clSetKernelArg(m_kernelWireframe, 0, sizeof(cl_mem), &imagePtr->plane(0)))
+         || (CL_SUCCESS != clSetKernelArg(m_kernelWireframe, 1, sizeof(cl_mem), &imagePtr->plane(1)))
+         || (CL_SUCCESS != clSetKernelArg(m_kernelWireframe, 2, sizeof(uint32_t), &x))
+         || (CL_SUCCESS != clSetKernelArg(m_kernelWireframe, 3, sizeof(uint32_t), &y))
+         || (CL_SUCCESS != clSetKernelArg(m_kernelWireframe, 4, sizeof(uint32_t), &w))
+         || (CL_SUCCESS != clSetKernelArg(m_kernelWireframe, 5, sizeof(uint32_t), &h))
+         || (CL_SUCCESS != clSetKernelArg(m_kernelWireframe, 6, sizeof(uint32_t), &b))
+         || (CL_SUCCESS != clSetKernelArg(m_kernelWireframe, 7, sizeof(uint8_t), &m_colorY))
+         || (CL_SUCCESS != clSetKernelArg(m_kernelWireframe, 8, sizeof(uint8_t), &m_colorU))
+         || (CL_SUCCESS != clSetKernelArg(m_kernelWireframe, 9, sizeof(uint8_t), &m_colorV))) {
+        ERROR("clSetKernelArg failed");
+        return YAMI_FAIL;
+    }
+
+    if (!checkOclStatus(clEnqueueNDRangeKernel(m_context->m_queue, m_kernelWireframe, 2, NULL,
+                            globalWorkSize, localWorkSize, 0, NULL, NULL),
+            "EnqueueNDRangeKernel")) {
+        return YAMI_FAIL;
+    }
+
+    return status;
+}
+
+YamiStatus OclPostProcessWireframe::setParameters(VppParamType type, void* vppParam)
+{
+    YamiStatus status = YAMI_INVALID_PARAM;
+
+    switch (type) {
+    case VppParamTypeWireframe: {
+        VppParamWireframe* wireframe = (VppParamWireframe*)vppParam;
+        if (wireframe->size == sizeof(VppParamWireframe)) {
+            m_borderWidth = ALIGN2(wireframe->borderWidth);
+            if (m_borderWidth == 0 || m_borderWidth != wireframe->borderWidth)
+                ERROR("wireframe border width must be non-zero and 2-pixel aligned");
+            m_colorY = wireframe->colorY;
+            m_colorU = wireframe->colorU;
+            m_colorV = wireframe->colorV;
+            status = YAMI_SUCCESS;
+        }
+    } break;
+    default:
+        status = OclPostProcessBase::setParameters(type, vppParam);
+        break;
+    }
+    return status;
+}
+
+bool OclPostProcessWireframe::prepareKernels()
+{
+    m_kernelWireframe = prepareKernel("wireframe");
+
+    return m_kernelWireframe != NULL;
+}
+
+const bool OclPostProcessWireframe::s_registered = VaapiPostProcessFactory::register_<OclPostProcessWireframe>(YAMI_VPP_OCL_WIREFRAME);
+}

--- a/vpp/oclpostprocess_wireframe.h
+++ b/vpp/oclpostprocess_wireframe.h
@@ -40,6 +40,7 @@ public:
         , m_colorV(0)
         , m_kernelWireframe(NULL)
     {
+        ensureContext("wireframe");
     }
 
 private:

--- a/vpp/oclpostprocess_wireframe.h
+++ b/vpp/oclpostprocess_wireframe.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2016 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef oclpostprocess_wireframe_h
+#define oclpostprocess_wireframe_h
+
+#include "interface/VideoCommonDefs.h"
+#include "oclpostprocess_base.h"
+
+namespace YamiMediaCodec {
+
+/**
+ * \class OclPostProcessWireframe
+ * \brief OpenCL based wireframe filter
+ */
+class OclPostProcessWireframe : public OclPostProcessBase {
+public:
+    virtual YamiStatus process(const SharedPtr<VideoFrame>& src,
+        const SharedPtr<VideoFrame>& dst);
+
+    virtual YamiStatus setParameters(VppParamType type, void* vppParam);
+
+    explicit OclPostProcessWireframe()
+        : m_borderWidth(4)
+        , m_colorY(0xFF)
+        , m_colorU(0)
+        , m_colorV(0)
+        , m_kernelWireframe(NULL)
+    {
+    }
+
+private:
+    virtual bool prepareKernels();
+
+    static const bool s_registered; // VaapiPostProcessFactory registration result
+    uint32_t m_borderWidth;
+    uint8_t m_colorY;
+    uint8_t m_colorU;
+    uint8_t m_colorV;
+    cl_kernel m_kernelWireframe;
+};
+}
+#endif //oclpostprocess_wireframe_h


### PR DESCRIPTION
ocl: fix mosaic filter out of bound issue
ocl global work size must be evenly divisible by work group size,
so global work size may be larger than the dimension of mosaicked
region.

ocl: implement wireframe
wireframe is a rectangle around the region of interest specified by
user. Also, the width and color of bordercan are both configurable.

ocl: initialize context on create
initialize ocl context on first buffer processing may take longer time
than expected, and block the pipeline. so we move ocl initialization
on create before pipeline is running.
