### PR TITLE
h264parser: change luma_weight_lx from int8_t to int16_t to avoid overflow

### DIFF
--- a/codecparsers/h264Parser.h
+++ b/codecparsers/h264Parser.h
@@ -335,16 +335,16 @@ struct PredWeightTable {
     uint8_t chroma_log2_weight_denom;
     bool luma_weight_l0_flag;
     //32 is the max of num_ref_idx_l0_active_minus1
-    int8_t luma_weight_l0[32];
+    int16_t luma_weight_l0[32];
     int8_t luma_offset_l0[32];
     bool chroma_weight_l0_flag;
-    int8_t chroma_weight_l0[32][2];
+    int16_t chroma_weight_l0[32][2];
     int8_t chroma_offset_l0[32][2];
     bool luma_weight_l1_flag;
-    int8_t luma_weight_l1[32];
+    int16_t luma_weight_l1[32];
     int8_t luma_offset_l1[32];
     bool chroma_weight_l1_flag;
-    int8_t chroma_weight_l1[32][2];
+    int16_t chroma_weight_l1[32][2];
     int8_t chroma_offset_l1[32][2];
 };
 


### PR DESCRIPTION
According to 7.4.3.2, luma_log2_weight_denom range is [0, 7],and default value for luma_weight_l0 is 2^luma_log2_weight_denom.Therefore, 128 is a possible value of luma_weight_l0, it can’t hold by int8_t,
we need int16_t hold it. 
this will fix https://github.com/01org/libyami/issues/607
