### PR TITLE
baseenc: make flush as empty function, add instructions for derive class

### DIFF
--- a/encoder/vaapiencoder_base.cpp
+++ b/encoder/vaapiencoder_base.cpp
@@ -88,7 +88,9 @@ YamiStatus VaapiEncoderBase::start(void)
 
 void VaapiEncoderBase::flush(void)
 {
-    AutoLock l(m_lock);
+    /* Current version of VaapiEncoderBase::flush is empty fucntion
+     * But we may add something in future.All derive class need call this in derive::flush()
+     */
 }
 
 YamiStatus VaapiEncoderBase::stop(void)


### PR DESCRIPTION
Currently we do not have any thin in baseenc::flush, but in future we may add something,
So best have some message for derive class developer
