### PR TITLE
decoder: add flush() for h264 and h265

### DIFF
--- a/decoder/vaapidecoder_h264.cpp
+++ b/decoder/vaapidecoder_h264.cpp
@@ -1819,6 +1819,20 @@ YamiStatus VaapiDecoderH264::decodeNalu(NalUnit* nalu)
     return status;
 }
 
+void VaapiDecoderH264::flush(void)
+{
+    decodeCurrent();
+    m_dpb.flush();
+    m_newStream = true;
+    m_endOfStream = false;
+    m_endOfSequence = false;
+    m_currPic.reset();
+    m_prevPic.reset();
+    m_currSurface.reset();
+    m_contextChanged = false;
+    VaapiDecoderBase::flush();
+}
+
 YamiStatus VaapiDecoderH264::decode(VideoDecodeBuffer* buffer)
 {
     if (!buffer || !buffer->data) {
@@ -1827,6 +1841,10 @@ YamiStatus VaapiDecoderH264::decode(VideoDecodeBuffer* buffer)
         m_newStream = true;
         m_endOfStream = false;
         m_endOfSequence = false;
+        m_currPic.reset();
+        m_prevPic.reset();
+        m_currSurface.reset();
+        m_contextChanged = false;
         return YAMI_SUCCESS;
     }
     m_currentPTS = buffer->timeStamp;

--- a/decoder/vaapidecoder_h264.h
+++ b/decoder/vaapidecoder_h264.h
@@ -41,6 +41,7 @@ public:
     virtual ~VaapiDecoderH264();
     virtual YamiStatus start(VideoConfigBuffer*);
     virtual YamiStatus decode(VideoDecodeBuffer*);
+    virtual void flush(void);
 
 private:
     friend class FactoryTest<IVideoDecoder, VaapiDecoderH264>;

--- a/decoder/vaapidecoder_h265.cpp
+++ b/decoder/vaapidecoder_h265.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -1083,6 +1082,18 @@ YamiStatus VaapiDecoderH265::decodeNalu(NalUnit* nalu)
     return status;
 }
 
+void VaapiDecoderH265::flush(void)
+{
+    decodeCurrent();
+    m_dpb.flush();
+    m_prevPicOrderCntMsb = 0;
+    m_prevPicOrderCntLsb = 0;
+    m_newStream = true;
+    m_endOfSequence = false;
+    m_prevSlice.reset(new SliceHeader());
+    VaapiDecoderBase::flush();
+}
+
 YamiStatus VaapiDecoderH265::decode(VideoDecodeBuffer* buffer)
 {
     if (!buffer || !buffer->data) {
@@ -1092,6 +1103,7 @@ YamiStatus VaapiDecoderH265::decode(VideoDecodeBuffer* buffer)
         m_prevPicOrderCntLsb = 0;
         m_newStream = true;
         m_endOfSequence = false;
+        m_prevSlice.reset(new SliceHeader());
         return YAMI_SUCCESS;
     }
     m_currentPTS = buffer->timeStamp;

--- a/decoder/vaapidecoder_h265.h
+++ b/decoder/vaapidecoder_h265.h
@@ -50,6 +50,7 @@ public:
     virtual ~VaapiDecoderH265();
     virtual YamiStatus start(VideoConfigBuffer*);
     virtual YamiStatus decode(VideoDecodeBuffer*);
+    virtual void flush(void);
 
 private:
     friend class FactoryTest<IVideoDecoder, VaapiDecoderH265>;


### PR DESCRIPTION
add flush() function for h264 and h265, so that we could flush dpb for
them in this function.

Signed-off-by: Linda Yu linda.yu@intel.com
