### PR TITLE
makefile: add top_srcdir into CPPFLAGS

### DIFF
--- a/capi/Makefile.am
+++ b/capi/Makefile.am
@@ -15,9 +15,15 @@ libyami_capi_ldflags = \
 	$(LIBYAMI_LT_LDFLAGS) \
 	$(NULL)
 
+#to compile within yocto
+extra_includes = \
+        -I$(top_srcdir) \
+        $(NULL)
+
 libyami_capi_cppflags = \
 	$(LIBVA_CFLAGS) \
 	-I$(top_srcdir)/interface \
+	$(extra_includes) \
 	$(NULL)
 
 noinst_LTLIBRARIES          = libyami_capi.la

--- a/codecparsers/Makefile.am
+++ b/codecparsers/Makefile.am
@@ -108,11 +108,17 @@ libyami_codecparser_ldflags = \
 	$(LIBYAMI_LT_LDFLAGS) \
 	$(NULL)
 
+#to compile within yocto
+extra_includes = \
+        -I$(top_srcdir) \
+        $(NULL)
+
 libyami_codecparser_cppflags = \
 	-Dvp8_norm=libyami_vp8_norm \
 	-Dvp8dx_start_decode=libyami_vp8dx_start_decode \
 	-Dvp8dx_bool_decoder_fill=libyami_vp8dx_bool_decoder_fill \
 	-I$(top_srcdir)/interface \
+	$(extra_includes) \
 	$(NULL)
 
 noinst_LTLIBRARIES                 = libyami_codecparser.la

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -28,9 +28,15 @@ libyami_common_ldflags = \
 	$(LIBVA_DRM_LIBS) \
 	$(NULL)
 
+#to compile within yocto
+extra_includes = \
+        -I$(top_srcdir) \
+        $(NULL)
+
 libyami_common_cppflags = \
 	$(LIBVA_CFLAGS) \
 	-I$(top_srcdir)/interface \
+	$(extra_includes) \
 	$(NULL)
 
 noinst_LTLIBRARIES            = libyami_common.la

--- a/decoder/Makefile.am
+++ b/decoder/Makefile.am
@@ -93,10 +93,16 @@ if ENABLE_X11
 libyami_decoder_ldflags += $(LIBVA_X11_LIBS) $(X11_LIBS)
 endif
 
+#to compile within yocto
+extra_includes = \
+        -I$(top_srcdir) \
+        $(NULL)
+
 libyami_decoder_cppflags = \
 	$(LIBVA_CFLAGS) \
 	$(LIBVA_DRM_CFLAGS) \
 	-I$(top_srcdir)/interface \
+	$(extra_includes)  \
 	$(NULL)
 
 if ENABLE_X11

--- a/encoder/Makefile.am
+++ b/encoder/Makefile.am
@@ -69,10 +69,16 @@ if ENABLE_X11
 libyami_encoder_ldflags += $(LIBVA_X11_LIBS) $(X11_LIBS)
 endif
 
+#to compile within yocto
+extra_includes = \
+	-I$(top_srcdir) \
+	$(NULL)
+
 libyami_encoder_cppflags = \
 	$(LIBVA_CFLAGS) \
 	$(LIBVA_DRM_CFLAGS) \
 	-I$(top_srcdir)/interface \
+	$(extra_includes) \
 	$(NULL)
 
 if ENABLE_X11

--- a/v4l2/Makefile.am
+++ b/v4l2/Makefile.am
@@ -25,10 +25,16 @@ libyamiv4l2_ldflags = \
 
 libyamiv4l2_ldflags += $(LIBEGL_LIBS)
 
+#to compile within yocto
+extra_includes = \
+        -I$(top_srcdir) \
+        $(NULL)
+
 libyamiv4l2_cppflags = \
 	$(LIBVA_CFLAGS) \
 	$(LIBV4L2_CFLAGS) \
 	-I$(top_srcdir)/interface \
+	$(extra_includes) \
 	$(NULL)
 
 if ENABLE_DMABUF

--- a/vaapi/Makefile.am
+++ b/vaapi/Makefile.am
@@ -28,9 +28,15 @@ if ENABLE_X11
 libyami_vaapi_ldflags += $(LIBVA_X11_LIBS) $(X11_LIBS)
 endif
 
+#to compile within yocto
+extra_includes = \
+        -I$(top_srcdir) \
+        $(NULL)
+
 libyami_vaapi_cppflags = \
 	$(LIBVA_CFLAGS) \
 	-I$(top_srcdir)/interface \
+	$(extra_includes) \
 	$(NULL)
 
 noinst_LTLIBRARIES           = libyami_vaapi.la

--- a/vpp/Makefile.am
+++ b/vpp/Makefile.am
@@ -53,10 +53,16 @@ libyami_vpp_ldflags = \
 	-ldl \
 	$(NULL)
 
+#to compile within yocto
+extra_includes = \
+        -I$(top_srcdir) \
+        $(NULL)
+
 libyami_vpp_cppflags = \
 	$(LIBVA_CFLAGS) \
 	$(LIBVA_DRM_CFLAGS) \
 	-I$(top_srcdir)/interface \
+	$(extra_includes) \
 	$(NULL)
 
 if BUILD_OCL_BLENDER


### PR DESCRIPTION
to integrate libyami into yocto, we should add top_srcdir into cppflags
to make it compiled well.

Signed-off-by: wudping dongpingx.wu@intel.com
