### PR TITLE
scale_vpp: check out odd resolution for VPP

### DIFF
--- a/vpp/vaapipostprocess_scaler.cpp
+++ b/vpp/vaapipostprocess_scaler.cpp
@@ -93,6 +93,11 @@ VaapiPostProcessScaler::process(const SharedPtr<VideoFrame>& src,
     if (!src || !dest) {
         return YAMI_INVALID_PARAM;
     }
+    if(src->crop.width & 0x01 || src->crop.height & 0x01){
+        ERROR("unsupported odd resolution");
+        return YAMI_FAIL;
+    }
+
     copyVideoFrameMeta(src, dest);
     SurfacePtr surface(new VaapiSurface(dest));
     VaapiVppPicture picture(m_context, surface);


### PR DESCRIPTION
check out odd resolution for scaler VPP, if so print error, then return.

Signed-off-by: wudping dongpingx.wu@intel.com
