### PR TITLE
jpegenc: include packed header size in coded buf size

### DIFF
--- a/encoder/vaapiencoder_jpeg.cpp
+++ b/encoder/vaapiencoder_jpeg.cpp
@@ -262,7 +262,7 @@ YamiStatus VaapiEncoderJpeg::getMaxOutSize(uint32_t* maxSize)
 
 void VaapiEncoderJpeg::resetParams()
 {
-    m_maxCodedbufSize = width()*height()*3/2;
+    m_maxCodedbufSize = (width()*height()*3/2) + JPEG_HEADER_SIZE;
 }
 
 YamiStatus VaapiEncoderJpeg::start()


### PR DESCRIPTION
The coded buffer needs to include enough space for the packed
header data, too.  Previously, the encode would fail for
smaller resolutions where w_h_3/2 is less than the packed
header size + the encoded slice size.

Fixes #570

Signed-off-by: U. Artie Eoff ullysses.a.eoff@intel.com
