### PR TITLE
vaapidecoder_h265 : refresh fourcc information in vaapidecoder_h265.

### DIFF
--- a/decoder/vaapidecoder_h265.cpp
+++ b/decoder/vaapidecoder_h265.cpp
@@ -929,6 +929,9 @@ YamiStatus VaapiDecoderH265::ensureContext(const SPS* const sps)
         m_configBuffer.flag |= HAS_SURFACE_NUMBER;
         m_configBuffer.profile = VAProfileHEVCMain;
         m_configBuffer.surfaceNumber = surfaceNumber;
+        if (sps->bit_depth_chroma_minus8 == 2 || sps->bit_depth_luma_minus8 == 2) {
+            m_configBuffer.fourcc = VA_FOURCC_P010;
+        }
         status = VaapiDecoderBase::start(&m_configBuffer);
         if (status != YAMI_SUCCESS)
             return status;


### PR DESCRIPTION
intel_driver will change fourcc to VA_FOURCC_P010 when bit_depth_chroma_minus8 or
bit_depth_luma_minus8 value is 2 , so did libyami.

Signed-off-by: Yun Zhou yunx.z.zhou@intel.com
