### PR TITLE
Vp8Parser: Zero-initialize segment feature data when required

### DIFF
--- a/codecparsers/vp8_parser.cpp
+++ b/codecparsers/vp8_parser.cpp
@@ -274,6 +274,8 @@ bool Vp8Parser::ParseSegmentationHeader(bool keyframe) {
       BD_READ_BOOL_OR_RETURN(&quantizer_update);
       if (quantizer_update)
         BD_READ_SIGNED_OR_RETURN(7, &shdr->quantizer_update_value[i]);
+      else
+	  shdr->quantizer_update_value[i] = 0;
     }
 
     for (size_t i = 0; i < kMaxMBSegments; ++i) {
@@ -281,6 +283,8 @@ bool Vp8Parser::ParseSegmentationHeader(bool keyframe) {
       BD_READ_BOOL_OR_RETURN(&loop_filter_update);
       if (loop_filter_update)
         BD_READ_SIGNED_OR_RETURN(6, &shdr->lf_update_value[i]);
+      else
+	  shdr->lf_update_value[i] = 0;
     }
   }
 


### PR DESCRIPTION
When segmentation is enabled and update_segment_feature_data flag is
true, but no actual update value is provided in the stream, the value
should be assigned the default "0", instead of what was carried over
from previous frame. This applies to both quantizer and loop filter
update values.

Patch taken from Chromium and reviewed.
Review-Url: https://codereview.chromium.org/1992663002

Original autor is mentioned on the link above and it was adapted
to libyami

Signed-off-by: Daniel Charles daniel.charles@intel.com

Fixes #620
