### PR TITLE
265_enc: set a flag to output the prior B frames

### DIFF
--- a/encoder/vaapiencoder_hevc.cpp
+++ b/encoder/vaapiencoder_hevc.cpp
@@ -1549,7 +1549,7 @@ bool VaapiEncoderHEVC::addPackedSliceHeader(const PicturePtr& picture,
 
     /* no_output_of_prior_pics_flag */
     if (nalUnitType >=  BLA_W_LP && nalUnitType <= RSV_IRAP_VCL23 )
-        bs.writeBits(1, 1);
+        bs.writeBits(0, 1);
 
     /* slice_pic_parameter_set_id */
     bit_writer_put_ue(&bs, 0);


### PR DESCRIPTION
assign 0 to no_output_of_prior_pics_flag, to output previously-decoded pictures
in the decoded picture buffer after the decoding of an IDR or a BLA picture.

reference: specification 7.4.7.1

Signed-off-by: wudping dongpingx.wu@intel.com
