### PR TITLE
fix vp8 decoder for networking streams.

### DIFF
--- a/decoder/vaapidecoder_vp8.cpp
+++ b/decoder/vaapidecoder_vp8.cpp
@@ -452,6 +452,7 @@ VaapiDecoderVP8::VaapiDecoderVP8()
     // m_uvModeProbs[3];
     m_sizeChanged = 0;
     m_hasContext = false;
+    m_gotKeyFrame = false;
 }
 
 VaapiDecoderVP8::~VaapiDecoderVP8()
@@ -508,6 +509,7 @@ void VaapiDecoderVP8::flush(void)
     m_lastPicture.reset();
     m_goldenRefPicture.reset();
     m_altRefPicture.reset();
+    m_gotKeyFrame = false;
 
     VaapiDecoderBase::flush();
 }
@@ -542,6 +544,13 @@ YamiStatus VaapiDecoderVP8::decode(VideoDecodeBuffer* buffer)
             status = ensureContext();
             if (status != YAMI_SUCCESS)
                 return status;
+            m_gotKeyFrame = true;
+        }
+        else {
+            if (!m_gotKeyFrame) {
+                WARNING("we can't decode p frame without key");
+                return YAMI_DECODE_INVALID_DATA;
+            }
         }
 #if __PSB_CACHE_DRAIN_FOR_FIRST_FRAME__
         int ii = 0;

--- a/decoder/vaapidecoder_vp8.cpp
+++ b/decoder/vaapidecoder_vp8.cpp
@@ -48,11 +48,9 @@ static YamiStatus getStatus(Vp8ParserResult result)
     case YamiParser::VP8_PARSER_OK:
         status = YAMI_SUCCESS;
         break;
-    case YamiParser::VP8_PARSER_ERROR:
-        status = YAMI_DECODE_PARSER_FAIL;
-        break;
     default:
-        status = YAMI_FAIL;
+        /* we should return no faltal error for parser failed */
+        status = YAMI_DECODE_INVALID_DATA;
         break;
     }
     return status;

--- a/decoder/vaapidecoder_vp8.h
+++ b/decoder/vaapidecoder_vp8.h
@@ -107,6 +107,8 @@ class VaapiDecoderVP8:public VaapiDecoderBase {
     uint8_t m_yModeProbs[4];
     uint8_t m_uvModeProbs[3];
     uint32_t m_sizeChanged:1;
+    //we can not decode P frame if we do not get key.
+    bool m_gotKeyFrame;
 
 #if __PSB_CACHE_DRAIN_FOR_FIRST_FRAME__
     bool m_isFirstFrame;


### PR DESCRIPTION
two fixes here:
1. do not treat parser error as fatal error, in network condition, it always have error bitstream, we'd better not treat it as faltal error just skip current frame.
2. skip P frames if we do not see key frame. networking stream many  not start from a key frame, we should skip all P frame until we got a key 
