### PR TITLE
h264enc: add bitrate control for svc-t

### DIFF
--- a/encoder/vaapiencoder_base.cpp
+++ b/encoder/vaapiencoder_base.cpp
@@ -59,7 +59,6 @@ VaapiEncoderBase::VaapiEncoderBase():
     m_videoParamCommon.leastInputCount = 0;
     m_videoParamCommon.rcParams.diffQPIP = 0;
     m_videoParamCommon.rcParams.diffQPIB = 0;
-
     updateMaxOutputBufferCount();
 }
 

--- a/encoder/vaapiencoder_base.h
+++ b/encoder/vaapiencoder_base.h
@@ -101,8 +101,8 @@ protected:
     //rate control related things
     void fill(VAEncMiscParameterHRD*) const ;
     void fill(VAEncMiscParameterRateControl*) const ;
-    void fill(VAEncMiscParameterFrameRate*) const;	
-    bool ensureMiscParams (VaapiEncPicture*);
+    void fill(VAEncMiscParameterFrameRate*) const;
+    virtual bool ensureMiscParams(VaapiEncPicture*);
 
     //properties
     VideoProfile profile() const;

--- a/encoder/vaapiencoder_h264.cpp
+++ b/encoder/vaapiencoder_h264.cpp
@@ -963,6 +963,35 @@ void VaapiEncoderH264::checkSvcTempLimitaion()
         m_videoParamCommon.intraPeriod
             = 1 << (uint32_t)ceil(log2(intraPeriod())); // make sure Gop is 2^n.
     }
+
+    // check every layer bitrate is set for BRC
+    if (bitRate()) {
+        uint32_t* layerBitRate = m_videoParamCommon.rcParams.layerBitRate;
+
+        if (layerBitRate[m_temporalLayerNum - 1] != bitRate())
+            layerBitRate[m_temporalLayerNum - 1] = bitRate();
+
+#if VA_CHECK_VERSION(0, 39, 4)
+        bool resetLayerBitRate = false;
+        uint32_t i;
+        for (i = 0; i < m_temporalLayerNum - 1; i++) {
+            if (!layerBitRate[i] || layerBitRate[i] >= layerBitRate[i + 1]) {
+                ERROR(" layer bit rate setting error, need to be reset ");
+                resetLayerBitRate = true;
+                break;
+            }
+        }
+
+        if (resetLayerBitRate) {
+            for (i = 0; i < m_temporalLayerNum - 1; i++)
+                layerBitRate[i] = bitRate()
+                                  / (1 << (m_temporalLayerNum - 1 - i));
+        }
+#else
+        if (m_isSvcT)
+            ERROR("For SVC-T BRC, please make sure libva version >= 0.39.4");
+#endif
+    }
 }
 
 void VaapiEncoderH264::resetParams ()
@@ -1273,6 +1302,82 @@ YamiStatus VaapiEncoderH264::getCodecConfig(VideoEncOutputBuffer* outBuffer)
     if (!m_headers)
         return YAMI_ENCODE_NO_REQUEST_DATA;
     return m_headers->getCodecConfig(outBuffer);
+}
+
+#if VA_CHECK_VERSION(0, 39, 4)
+void VaapiEncoderH264::fill(
+    VAEncMiscParameterTemporalLayerStructure* layerParam) const
+{
+    layerParam->number_of_layers = m_temporalLayerNum;
+    layerParam->periodicity = H264_MIN_TEMPORAL_GOP;
+
+    for (uint32_t i = 0; i < layerParam->periodicity; i++)
+        layerParam->layer_id[i] = getTemporalId(m_temporalLayerNum, i + 1);
+}
+#endif
+
+void VaapiEncoderH264::fill(VAEncMiscParameterRateControl* rateControl,
+                            uint32_t temporalId) const
+{
+    VaapiEncoderBase::fill(rateControl);
+
+    rateControl->bits_per_second
+        = m_videoParamCommon.rcParams.layerBitRate[temporalId];
+#if VA_CHECK_VERSION(0, 39, 4)
+    rateControl->rc_flags.bits.temporal_id = temporalId;
+#endif
+}
+
+void VaapiEncoderH264::fill(VAEncMiscParameterFrameRate* frameRate,
+                            uint32_t temporalId) const
+{
+    uint32_t expTemId = (1 << (m_temporalLayerNum - 1 - temporalId));
+    if (fps() % expTemId == 0)
+        frameRate->framerate = fps() / expTemId;
+    else
+        frameRate->framerate = (expTemId << 16 | fps());
+
+#if VA_CHECK_VERSION(0, 39, 4)
+    frameRate->framerate_flags.bits.temporal_id = temporalId;
+#endif
+}
+
+/* Generates additional control parameters */
+bool VaapiEncoderH264::ensureMiscParams(VaapiEncPicture* picture)
+{
+    VAEncMiscParameterHRD* hrd = NULL;
+    if (!picture->newMisc(VAEncMiscParameterTypeHRD, hrd))
+        return false;
+    if (hrd)
+        VaapiEncoderBase::fill(hrd);
+    VideoRateControl mode = rateControlMode();
+    if (mode == RATE_CONTROL_CBR || mode == RATE_CONTROL_VBR) {
+#if VA_CHECK_VERSION(0, 39, 4)
+        if (m_isSvcT) {
+            VAEncMiscParameterTemporalLayerStructure* layerParam = NULL;
+            if (!picture->newMisc(VAEncMiscParameterTypeTemporalLayerStructure,
+                                  layerParam))
+                return false;
+            if (layerParam)
+                fill(layerParam);
+        }
+#endif
+        for (uint32_t i = 0; i < m_temporalLayerNum; i++) {
+            VAEncMiscParameterRateControl* rateControl = NULL;
+            if (!picture->newMisc(VAEncMiscParameterTypeRateControl,
+                                  rateControl))
+                return false;
+            if (rateControl)
+                fill(rateControl, i);
+
+            VAEncMiscParameterFrameRate* frameRate = NULL;
+            if (!picture->newMisc(VAEncMiscParameterTypeFrameRate, frameRate))
+                return false;
+            if (frameRate)
+                fill(frameRate, i);
+        }
+    }
+    return true;
 }
 
 /* Handle new GOP starts */

--- a/encoder/vaapiencoder_h264.h
+++ b/encoder/vaapiencoder_h264.h
@@ -56,6 +56,7 @@ public:
 protected:
     virtual YamiStatus doEncode(const SurfacePtr&, uint64_t timeStamp, bool forceKeyFrame);
     virtual YamiStatus getCodecConfig(VideoEncOutputBuffer* outBuffer);
+    virtual bool ensureMiscParams(VaapiEncPicture*);
 
 private:
     friend class FactoryTest<IVideoEncoder, VaapiEncoderH264>;
@@ -63,6 +64,12 @@ private:
 
     //following code is a template for other encoder implementation
     YamiStatus encodePicture(const PicturePtr&);
+
+#if VA_CHECK_VERSION(0, 39, 4)
+    void fill(VAEncMiscParameterTemporalLayerStructure*) const;
+#endif
+    void fill(VAEncMiscParameterRateControl*, uint32_t temporalId) const;
+    void fill(VAEncMiscParameterFrameRate*, uint32_t temporalId) const;
     bool fill(VAEncSequenceParameterBufferH264*) const;
     bool fill(VAEncPictureParameterBufferH264*, const PicturePtr&, const SurfacePtr&) const ;
     bool ensureSequenceHeader(const PicturePtr&, const VAEncSequenceParameterBufferH264* const);

--- a/interface/VideoEncoderDefs.h
+++ b/interface/VideoEncoderDefs.h
@@ -163,6 +163,7 @@ typedef struct VideoRateControlParams {
     uint32_t disableBitsStuffing;
     int8_t diffQPIP;// P frame qp minus initQP
     int8_t diffQPIB;// B frame qp minus initQP
+    uint32_t layerBitRate[32]; // specify each scalable layer bitrate
 }VideoRateControlParams;
 
 typedef struct SliceNum {


### PR DESCRIPTION
1. Add CBR support for svc-t.
2. Maximum 4 layer supported now, each layer can be set with different
   bitrate.

Signed-off-by: Zhong Li zhong.li@intel.com
