### PR TITLE
h264enc: remove redundant start code withou sei header

### DIFF
--- a/encoder/vaapiencoder_h264.cpp
+++ b/encoder/vaapiencoder_h264.cpp
@@ -693,7 +693,8 @@ private:
     void generateCodecConfigAnnexB()
     {
         std::vector<Header*> headers;
-        headers.push_back(&m_sei);
+        if (m_sei.size())
+            headers.push_back(&m_sei);
         headers.push_back(&m_sps);
         headers.push_back(&m_pps);
         uint8_t sync[] = {0, 0, 0, 1};


### PR DESCRIPTION
SEI info is not always necessary. When it is not set, no need
to push it to header queue, else there are some redundant start
code in the encoded bitstream.

It is to fix https://github.com/01org/libyami/issues/634
