### PR TITLE
HEVC ENC:10bit support merged

### DIFF
--- a/encoder/vaapiencoder_hevc.cpp
+++ b/encoder/vaapiencoder_hevc.cpp
@@ -156,6 +156,7 @@ static uint8_t hevc_get_profile_idc(VideoProfile profile)
         break;
     case PROFILE_H265_MAIN10:
         idc = 2;
+        break;
     default:
         assert(0);
     }
@@ -1372,9 +1373,9 @@ bool VaapiEncoderHEVC::fill(VAEncSequenceParameterBufferHEVC* seqParam) const
     /* separate color plane_flag*/
     seqParam->seq_fields.bits.separate_colour_plane_flag = 0;
     /* bit_depth_luma_minus8. Only 0 is supported for main profile */
-    seqParam->seq_fields.bits.bit_depth_luma_minus8 = 0;
+    seqParam->seq_fields.bits.bit_depth_luma_minus8 = m_videoParamCommon.bitDepth - 8;
     /* bit_depth_chroma_minus8. Only 0 is supported for main profile*/
-    seqParam->seq_fields.bits.bit_depth_chroma_minus8 = 0;
+    seqParam->seq_fields.bits.bit_depth_chroma_minus8 = m_videoParamCommon.bitDepth - 8;
     /* scaling_list_enabled_flag. Use the default value  */
     seqParam->seq_fields.bits.scaling_list_enabled_flag = 0;
     /* strong_intra_smoothing_enabled_flag. Not use the bi-linear interpolation */

--- a/interface/VideoCommonDefs.h
+++ b/interface/VideoCommonDefs.h
@@ -84,6 +84,9 @@ extern "C" {
 #define YAMI_FOURCC_BGRX YAMI_FOURCC('B', 'G', 'R', 'X')
 #define YAMI_FOURCC_BGRA YAMI_FOURCC('B', 'G', 'R', 'A')
 
+//10bit
+#define YAMI_FOURCC_P010 YAMI_FOURCC('P', '0', '1', '0')
+
 typedef enum {
     NATIVE_DISPLAY_AUTO,    // decided by yami
     NATIVE_DISPLAY_X11,

--- a/interface/VideoEncoderDefs.h
+++ b/interface/VideoEncoderDefs.h
@@ -215,6 +215,7 @@ typedef struct VideoParamsCommon {
     VideoRateControl rcMode;
     VideoRateControlParams rcParams;
     uint32_t leastInputCount;
+    uint8_t bitDepth;
 }VideoParamsCommon;
 
 typedef struct VideoParamsAVC {

--- a/vaapi/VaapiUtils.cpp
+++ b/vaapi/VaapiUtils.cpp
@@ -63,6 +63,8 @@ uint32_t getRtFormat(uint32_t fourcc)
     case YAMI_FOURCC_BGRX:
     case YAMI_FOURCC_BGRA:
         return VA_RT_FORMAT_RGB32;
+    case YAMI_FOURCC_P010:
+        return VA_RT_FORMAT_YUV420_10BPP;
     }
     ERROR("get rt format for %.4s failed", (char*)&fourcc);
     return 0;


### PR DESCRIPTION
add the P010 input
add support for HEVC 10bit encoding
add pixelwidthinbyte to help caculate the width of image when 8/10 bit

Signed-off-by: Pengfei Qu <Pengfei.Qu@intel.com>