### PR TITLE
h265dec: workaround profile 0 as main profile 

### DIFF
--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -140,6 +140,7 @@ const static ResolutionEntry resolutionEntrys[] = {
     { YAMI_FOURCC_422H, 3, { 2, 1, 1 }, { 2, 2, 2 } },
     { YAMI_FOURCC_422V, 3, { 2, 2, 2 }, { 2, 1, 1 } },
     { YAMI_FOURCC_444P, 3, { 2, 2, 2 }, { 2, 2, 2 } },
+    { YAMI_FOURCC_P010, 2, { 4, 4 }, { 2, 1 } },
     { YAMI_FOURCC_YUY2, 1, { 4 }, { 2 } },
     { YAMI_FOURCC_UYVY, 1, { 4 }, { 2 } },
     { YAMI_FOURCC_RGBX, 1, { 8 }, { 2 } },

--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -48,14 +48,14 @@ uint32_t guessFourcc(const char* fileName)
         for (size_t i = 0; i < N_ELEMENTS(possibleFourcc); i++) {
             const char* fourcc = possibleFourcc[i];
             if (!strcasecmp(fourcc, extension)) {
-                uint32_t ret = VA_FOURCC(fourcc[0], fourcc[1], fourcc[2], fourcc[3]);
+                uint32_t ret = YAMI_FOURCC(fourcc[0], fourcc[1], fourcc[2], fourcc[3]);
                 DEBUG_FOURCC("guessed input fourcc:", ret);
                 return ret;
             }
         }
     }
 
-    return VA_FOURCC_I420;
+    return YAMI_FOURCC_I420;
 }
 
 bool guessResolution(const char* filename, int& w, int& h)
@@ -134,18 +134,18 @@ struct ResolutionEntry {
 };
 
 const static ResolutionEntry resolutionEntrys[] = {
-    { VA_FOURCC_I420, 3, { 2, 1, 1 }, { 2, 1, 1 } },
-    { VA_FOURCC_YV12, 3, { 2, 1, 1 }, { 2, 1, 1 } },
-    { VA_FOURCC_IMC3, 3, { 2, 1, 1 }, { 2, 1, 1 } },
-    { VA_FOURCC_422H, 3, { 2, 1, 1 }, { 2, 2, 2 } },
-    { VA_FOURCC_422V, 3, { 2, 2, 2 }, { 2, 1, 1 } },
-    { VA_FOURCC_444P, 3, { 2, 2, 2 }, { 2, 2, 2 } },
-    { VA_FOURCC_YUY2, 1, { 4 }, { 2 } },
-    { VA_FOURCC_UYVY, 1, { 4 }, { 2 } },
-    { VA_FOURCC_RGBX, 1, { 8 }, { 2 } },
-    { VA_FOURCC_RGBA, 1, { 8 }, { 2 } },
-    { VA_FOURCC_BGRX, 1, { 8 }, { 2 } },
-    { VA_FOURCC_BGRA, 1, { 8 }, { 2 } },
+    { YAMI_FOURCC_I420, 3, { 2, 1, 1 }, { 2, 1, 1 } },
+    { YAMI_FOURCC_YV12, 3, { 2, 1, 1 }, { 2, 1, 1 } },
+    { YAMI_FOURCC_IMC3, 3, { 2, 1, 1 }, { 2, 1, 1 } },
+    { YAMI_FOURCC_422H, 3, { 2, 1, 1 }, { 2, 2, 2 } },
+    { YAMI_FOURCC_422V, 3, { 2, 2, 2 }, { 2, 1, 1 } },
+    { YAMI_FOURCC_444P, 3, { 2, 2, 2 }, { 2, 2, 2 } },
+    { YAMI_FOURCC_YUY2, 1, { 4 }, { 2 } },
+    { YAMI_FOURCC_UYVY, 1, { 4 }, { 2 } },
+    { YAMI_FOURCC_RGBX, 1, { 8 }, { 2 } },
+    { YAMI_FOURCC_RGBA, 1, { 8 }, { 2 } },
+    { YAMI_FOURCC_BGRX, 1, { 8 }, { 2 } },
+    { YAMI_FOURCC_BGRA, 1, { 8 }, { 2 } },
 };
 
 /* l is length in pixel*/
@@ -164,7 +164,7 @@ bool getPlaneResolution(uint32_t fourcc, uint32_t pixelWidth, uint32_t pixelHeig
     uint32_t* width = byteWidth;
     uint32_t* height = byteHeight;
     //NV12 is special since it  need add one for width[1] when w is odd
-    if (fourcc == VA_FOURCC_NV12) {
+    if (fourcc == YAMI_FOURCC_NV12) {
         width[0] = w;
         height[0] = h;
         width[1] = w + (w & 1);

--- a/common/utils_unittest.cpp
+++ b/common/utils_unittest.cpp
@@ -36,28 +36,28 @@
 using namespace YamiMediaCodec;
 
 UTILS_TEST(guessFourcc) {
-    EXPECT_EQ(guessFourcc("test.i420"), (uint32_t)VA_FOURCC_I420);
-    EXPECT_EQ(guessFourcc("test.nv12"), (uint32_t)VA_FOURCC_NV12);
-    EXPECT_EQ(guessFourcc("test.yv12"), (uint32_t)VA_FOURCC_YV12);
-    EXPECT_EQ(guessFourcc("test.yuy2"), (uint32_t)VA_FOURCC_YUY2);
-    EXPECT_EQ(guessFourcc("test.uyvy"), (uint32_t)VA_FOURCC_UYVY);
-    EXPECT_EQ(guessFourcc("test.rgbx"), (uint32_t)VA_FOURCC_RGBX);
-    EXPECT_EQ(guessFourcc("test.bgrx"), (uint32_t)VA_FOURCC_BGRX);
-    EXPECT_EQ(guessFourcc("test.xrgb"), (uint32_t)VA_FOURCC_XRGB);
-    EXPECT_EQ(guessFourcc("test.xbgr"), (uint32_t)VA_FOURCC_XBGR);
+    EXPECT_EQ(guessFourcc("test.i420"), (uint32_t)YAMI_FOURCC_I420);
+    EXPECT_EQ(guessFourcc("test.nv12"), (uint32_t)YAMI_FOURCC_NV12);
+    EXPECT_EQ(guessFourcc("test.yv12"), (uint32_t)YAMI_FOURCC_YV12);
+    EXPECT_EQ(guessFourcc("test.yuy2"), (uint32_t)YAMI_FOURCC_YUY2);
+    EXPECT_EQ(guessFourcc("test.uyvy"), (uint32_t)YAMI_FOURCC_UYVY);
+    EXPECT_EQ(guessFourcc("test.rgbx"), (uint32_t)YAMI_FOURCC_RGBX);
+    EXPECT_EQ(guessFourcc("test.bgrx"), (uint32_t)YAMI_FOURCC_BGRX);
+    EXPECT_EQ(guessFourcc("test.xrgb"), (uint32_t)YAMI_FOURCC_XRGB);
+    EXPECT_EQ(guessFourcc("test.xbgr"), (uint32_t)YAMI_FOURCC_XBGR);
 
-    EXPECT_EQ(guessFourcc("test.txt"), (uint32_t)VA_FOURCC_I420);
-    EXPECT_EQ(guessFourcc("test"), (uint32_t)VA_FOURCC_I420);
+    EXPECT_EQ(guessFourcc("test.txt"), (uint32_t)YAMI_FOURCC_I420);
+    EXPECT_EQ(guessFourcc("test"), (uint32_t)YAMI_FOURCC_I420);
 
-    EXPECT_EQ(guessFourcc("test.I420"), (uint32_t)VA_FOURCC_I420);
-    EXPECT_EQ(guessFourcc("test.NV12"), (uint32_t)VA_FOURCC_NV12);
-    EXPECT_EQ(guessFourcc("test.YV12"), (uint32_t)VA_FOURCC_YV12);
-    EXPECT_EQ(guessFourcc("test.YUY2"), (uint32_t)VA_FOURCC_YUY2);
-    EXPECT_EQ(guessFourcc("test.UYVY"), (uint32_t)VA_FOURCC_UYVY);
-    EXPECT_EQ(guessFourcc("test.RGBX"), (uint32_t)VA_FOURCC_RGBX);
-    EXPECT_EQ(guessFourcc("test.BGRX"), (uint32_t)VA_FOURCC_BGRX);
-    EXPECT_EQ(guessFourcc("test.XRGB"), (uint32_t)VA_FOURCC_XRGB);
-    EXPECT_EQ(guessFourcc("test.XBGR"), (uint32_t)VA_FOURCC_XBGR);
+    EXPECT_EQ(guessFourcc("test.I420"), (uint32_t)YAMI_FOURCC_I420);
+    EXPECT_EQ(guessFourcc("test.NV12"), (uint32_t)YAMI_FOURCC_NV12);
+    EXPECT_EQ(guessFourcc("test.YV12"), (uint32_t)YAMI_FOURCC_YV12);
+    EXPECT_EQ(guessFourcc("test.YUY2"), (uint32_t)YAMI_FOURCC_YUY2);
+    EXPECT_EQ(guessFourcc("test.UYVY"), (uint32_t)YAMI_FOURCC_UYVY);
+    EXPECT_EQ(guessFourcc("test.RGBX"), (uint32_t)YAMI_FOURCC_RGBX);
+    EXPECT_EQ(guessFourcc("test.BGRX"), (uint32_t)YAMI_FOURCC_BGRX);
+    EXPECT_EQ(guessFourcc("test.XRGB"), (uint32_t)YAMI_FOURCC_XRGB);
+    EXPECT_EQ(guessFourcc("test.XBGR"), (uint32_t)YAMI_FOURCC_XBGR);
 }
 
 UTILS_TEST(guessResolutionBasic) {
@@ -138,28 +138,28 @@ struct BppEntry {
 };
 
 const static BppEntry bppEntrys[] = {
-    { VA_FOURCC_NV12, 2, 1.5 },
-    { VA_FOURCC_I420, 3, 1.5 },
-    { VA_FOURCC_YV12, 3, 1.5 },
-    { VA_FOURCC_IMC3, 3, 1.5 },
-    { VA_FOURCC_422H, 3, 2 },
-    { VA_FOURCC_422V, 3, 2 },
-    { VA_FOURCC_444P, 3, 3 },
-    { VA_FOURCC_YUY2, 1, 2 },
-    { VA_FOURCC_UYVY, 1, 2 },
-    { VA_FOURCC_RGBX, 1, 4 },
-    { VA_FOURCC_RGBA, 1, 4 },
-    { VA_FOURCC_BGRX, 1, 4 },
-    { VA_FOURCC_BGRA, 1, 4 },
+    { YAMI_FOURCC_NV12, 2, 1.5 },
+    { YAMI_FOURCC_I420, 3, 1.5 },
+    { YAMI_FOURCC_YV12, 3, 1.5 },
+    { YAMI_FOURCC_IMC3, 3, 1.5 },
+    { YAMI_FOURCC_422H, 3, 2 },
+    { YAMI_FOURCC_422V, 3, 2 },
+    { YAMI_FOURCC_444P, 3, 3 },
+    { YAMI_FOURCC_YUY2, 1, 2 },
+    { YAMI_FOURCC_UYVY, 1, 2 },
+    { YAMI_FOURCC_RGBX, 1, 4 },
+    { YAMI_FOURCC_RGBA, 1, 4 },
+    { YAMI_FOURCC_BGRX, 1, 4 },
+    { YAMI_FOURCC_BGRA, 1, 4 },
 };
 
 //check selected unsupported format.
 //we do not want check all unsupported formats, it will introduce too many dependency on libva
 const static uint32_t unsupported[] = {
     0,
-    VA_FOURCC_Y800,
-    VA_FOURCC_411P,
-    VA_FOURCC_ARGB,
+    YAMI_FOURCC_Y800,
+    YAMI_FOURCC_411P,
+    YAMI_FOURCC_ARGB,
 };
 
 UTILS_TEST(getPlaneResolution)

--- a/common/utils_unittest.cpp
+++ b/common/utils_unittest.cpp
@@ -145,6 +145,7 @@ const static BppEntry bppEntrys[] = {
     { YAMI_FOURCC_422H, 3, 2 },
     { YAMI_FOURCC_422V, 3, 2 },
     { YAMI_FOURCC_444P, 3, 3 },
+    { YAMI_FOURCC_P010, 2, 3 },
     { YAMI_FOURCC_YUY2, 1, 2 },
     { YAMI_FOURCC_UYVY, 1, 2 },
     { YAMI_FOURCC_RGBX, 1, 4 },

--- a/decoder/vaapidecoder_h265.cpp
+++ b/decoder/vaapidecoder_h265.cpp
@@ -929,6 +929,16 @@ bool VaapiDecoderH265::fillSlice(const PicturePtr& picture,
 
 VAProfile VaapiDecoderH265::getVaProfile(const SPS* const sps)
 {
+    if (sps->profile_tier_level.general_profile_idc == 0
+        || sps->profile_tier_level.general_profile_compatibility_flag[0] == 1) {
+        //general_profile_idc = 0 is not defined in spec, but some stream have this
+        //we treat it as Main profile
+        CHECK(sps->chroma_format_idc, 1);
+        CHECK(sps->bit_depth_luma_minus8, 0);
+        CHECK(sps->bit_depth_chroma_minus8, 0);
+        return VAProfileHEVCMain;
+    }
+
     if (sps->profile_tier_level.general_profile_idc == 1
         || sps->profile_tier_level.general_profile_compatibility_flag[1] == 1) {
         //A.3.2, but we only check some important values

--- a/decoder/vaapidecoder_h265.h
+++ b/decoder/vaapidecoder_h265.h
@@ -115,6 +115,7 @@ private:
     YamiStatus decodeParamSet(NalUnit*);
     YamiStatus decodeSlice(NalUnit*);
 
+    static VAProfile getVaProfile(const SPS* const sps);
     YamiStatus ensureContext(const SPS* const);
     bool fillPicture(const PicturePtr& , const SliceHeader* const );
     bool fillSlice(const PicturePtr&, const SliceHeader* const, const NalUnit* const );

--- a/interface/VideoCommonDefs.h
+++ b/interface/VideoCommonDefs.h
@@ -64,6 +64,11 @@ extern "C" {
 #define YAMI_FOURCC(ch0, ch1, ch2, ch3) \
         ((uint32_t)(uint8_t)(ch0) | ((uint32_t)(uint8_t)(ch1) << 8) | \
          ((uint32_t)(uint8_t)(ch2) << 16)  | ((uint32_t)(uint8_t)(ch3) << 24))
+//Y only
+#define YAMI_FOURCC_Y800 YAMI_FOURCC('Y', '8', '0', '0')
+
+//411
+#define YAMI_FOURCC_411P YAMI_FOURCC('4', '1', '1', 'P')
 
 //420
 #define YAMI_FOURCC_NV12 YAMI_FOURCC('N', 'V', '1', '2')
@@ -75,14 +80,25 @@ extern "C" {
 #define YAMI_FOURCC_422H YAMI_FOURCC('4', '2', '2', 'H')
 #define YAMI_FOURCC_422V YAMI_FOURCC('4', '2', '2', 'V')
 #define YAMI_FOURCC_YUY2 YAMI_FOURCC('Y', 'U', 'Y', '2')
+#define YAMI_FOURCC_UYVY YAMI_FOURCC('U', 'Y', 'V', 'Y')
 
 //444
 #define YAMI_FOURCC_444P YAMI_FOURCC('4', '4', '4', 'P')
 
+//10 bits
+#define YAMI_FOURCC_P010 YAMI_FOURCC('P', '0', '1', '0')
+
+//RGB
 #define YAMI_FOURCC_RGBX YAMI_FOURCC('R', 'G', 'B', 'X')
 #define YAMI_FOURCC_RGBA YAMI_FOURCC('R', 'G', 'B', 'A')
 #define YAMI_FOURCC_BGRX YAMI_FOURCC('B', 'G', 'R', 'X')
 #define YAMI_FOURCC_BGRA YAMI_FOURCC('B', 'G', 'R', 'A')
+#define YAMI_FOURCC_XRGB YAMI_FOURCC('X', 'R', 'G', 'B')
+#define YAMI_FOURCC_ARGB YAMI_FOURCC('A', 'R', 'G', 'B')
+#define YAMI_FOURCC_XBGR YAMI_FOURCC('X', 'B', 'G', 'R')
+#define YAMI_FOURCC_ABGR YAMI_FOURCC('A', 'B', 'G', 'R')
+
+#define YAMI_FOURCC_R210 YAMI_FOURCC('R', '2', '1', '0')
 
 typedef enum {
     NATIVE_DISPLAY_AUTO,    // decided by yami

--- a/vaapi/VaapiUtils.cpp
+++ b/vaapi/VaapiUtils.cpp
@@ -58,6 +58,10 @@ uint32_t getRtFormat(uint32_t fourcc)
         return VA_RT_FORMAT_YUV422;
     case YAMI_FOURCC_444P:
         return VA_RT_FORMAT_YUV444;
+#if VA_CHECK_VERSION(0, 38, 1)
+    case YAMI_FOURCC_P010:
+        return VA_RT_FORMAT_YUV420_10BPP;
+#endif
     case YAMI_FOURCC_RGBX:
     case YAMI_FOURCC_RGBA:
     case YAMI_FOURCC_BGRX:


### PR DESCRIPTION
general_profile_idc equals 0 is not defined in spec, but some clips do have this.
We treat it as 8 bits.
This is a fix for https://github.com/01org/libyami/pull/638. Only need reivew last commit(c8299ca
). Other patches have been reviewed in https://github.com/01org/libyami/pull/638