### PR TITLE
encoder: enable AVC VDENC

### DIFF
--- a/encoder/vaapiencoder_base.cpp
+++ b/encoder/vaapiencoder_base.cpp
@@ -493,6 +493,15 @@ bool VaapiEncoderBase::initVA()
         pAttrib = &attrib;
         attribCount = 1;
     }
+
+    if (m_videoParamCommon.enableLowPower) {
+         if (ipPeriod() > 1) {
+            WARNING("Low power mode can not support B frame encoding");
+            m_videoParamCommon.ipPeriod = 1; // without B frame
+        }
+        m_entrypoint = VAEntrypointEncSliceLP;
+    }
+
     ConfigPtr config = VaapiConfig::create(m_display, m_videoParamCommon.profile, m_entrypoint, pAttrib, attribCount);
     if (!config) {
         ERROR("failed to create config");

--- a/interface/VideoEncoderDefs.h
+++ b/interface/VideoEncoderDefs.h
@@ -215,6 +215,7 @@ typedef struct VideoParamsCommon {
     VideoRateControl rcMode;
     VideoRateControlParams rcParams;
     uint32_t leastInputCount;
+    bool enableLowPower;
 }VideoParamsCommon;
 
 typedef struct VideoParamsAVC {


### PR DESCRIPTION
if AVC VDENC is enabled, the VAEntrypointEncSliceLP will be selected.

Signed-off-by: jkyu <jiankang.yu@intel.com>