### PR TITLE
Change INCLUDES to AM_CPPFLAGS

### DIFF
--- a/vpp/Makefile.am
+++ b/vpp/Makefile.am
@@ -1,5 +1,3 @@
-INCLUDES = -I$(top_srcdir)/interface
-
 libyami_vpp_source_c = \
 	vaapipostprocess_base.cpp \
 	vaapipostprocess_host.cpp \


### PR DESCRIPTION
This fixes the following warning from automake:

vpp/Makefile.am:1: warning: 'INCLUDES' is the old name for 'AM_CPPFLAGS' (or '*_CPPFLAGS')