### PR TITLE
Factory registration fixes, unittests and other programmer logic fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -271,6 +271,11 @@ AC_ARG_ENABLE(h264enc,
         [build with h264 encoder support @<:@default=yes@:>@])],
     [], [enable_h264enc="yes"])
 
+if test "$enable_h264enc" = "yes"; then
+    AC_DEFINE([__BUILD_H264_ENCODER__], [1],
+        [Defined to 1 if --enable-h264enc="yes"])
+fi
+
 AM_CONDITIONAL(BUILD_H264_ENCODER,
     [test "x$enable_h264enc" = "xyes"])
 
@@ -279,6 +284,11 @@ AC_ARG_ENABLE(jpegenc,
     [AC_HELP_STRING([--enable-jpegenc],
         [build with jpeg encoder support @<:@default=no@:>@])],
     [], [enable_jpegenc="no"])
+
+if test "$enable_jpegenc" = "yes"; then
+    AC_DEFINE([__BUILD_JPEG_ENCODER__], [1],
+        [Defined to 1 if --enable-jpegenc="yes"])
+fi
 
 AM_CONDITIONAL(BUILD_JPEG_ENCODER,
     [test "x$enable_jpegenc" = "xyes"])
@@ -289,6 +299,11 @@ AC_ARG_ENABLE(vp8enc,
         [build with vp8 encoder support @<:@default=no@:>@])],
     [], [enable_vp8enc="no"])
 
+if test "$enable_vp8enc" = "yes"; then
+    AC_DEFINE([__BUILD_VP8_ENCODER__], [1],
+        [Defined to 1 if --enable-vp8enc="yes"])
+fi
+
 AM_CONDITIONAL(BUILD_VP8_ENCODER,
     [test "x$enable_vp8enc" = "xyes"])
 
@@ -298,6 +313,11 @@ AC_ARG_ENABLE(vp9enc,
         [build with vp9 encoder support @<:@default=no@:>@])],
     [], [enable_vp9enc="no"])
 
+if test "$enable_vp9enc" = "yes"; then
+    AC_DEFINE([__BUILD_VP9_ENCODER__], [1],
+        [Defined to 1 if --enable-vp9enc="yes"])
+fi
+
 AM_CONDITIONAL(BUILD_VP9_ENCODER,
     [test "x$enable_vp9enc" = "xyes"])
 
@@ -306,6 +326,11 @@ AC_ARG_ENABLE(h265enc,
     [AC_HELP_STRING([--enable-h265enc],
         [build with h265 encoder support @<:@default=no@:>@])],
     [], [enable_h265enc="no"])
+
+if test "$enable_h265enc" = "yes"; then
+    AC_DEFINE([__BUILD_H265_ENCODER__], [1],
+        [Defined to 1 if --enable-h265enc="yes"])
+fi
 
 AM_CONDITIONAL(BUILD_H265_ENCODER,
     [test "x$enable_h265enc" = "xyes"])

--- a/configure.ac
+++ b/configure.ac
@@ -358,6 +358,11 @@ AC_ARG_ENABLE(oclfilters,
         [build with opencl based alpha blend support @<:@default=no@:>@])],
     [], [enable_oclfilters="no"])
 
+if test "$enable_oclfilters" = "yes"; then
+    AC_DEFINE([__BUILD_OCL_FILTERS__], [1],
+        [Defined to 1 if --enable-oclfilters="yes"])
+fi
+
 AM_CONDITIONAL(BUILD_OCL_FILTERS,
     [test "x$enable_oclfilters" = "xyes"])
 

--- a/configure.ac
+++ b/configure.ac
@@ -160,6 +160,11 @@ AC_ARG_ENABLE(mpeg2dec,
         [build with mpeg2 decoder support @<:@default=no@:>@])],
     [], [enable_mpeg2dec="no"])
 
+if test "$enable_mpeg2dec" = "yes"; then
+    AC_DEFINE([__BUILD_MPEG2_DECODER__], [1],
+        [Defined to 1 if --enable-mpeg2dec="yes"])
+fi
+
 AM_CONDITIONAL(BUILD_MPEG2_DECODER,
     [test "x$enable_mpeg2dec" = "xyes"])
 
@@ -168,6 +173,11 @@ AC_ARG_ENABLE(vp8dec,
     [AC_HELP_STRING([--enable-vp8dec],
         [build with vp8 decoder support @<:@default=yes@:>@])],
     [], [enable_vp8dec="yes"])
+
+if test "$enable_vp8dec" = "yes"; then
+    AC_DEFINE([__BUILD_VP8_DECODER__], [1],
+        [Defined to 1 if --enable-vp8dec="yes"])
+fi
 
 AM_CONDITIONAL(BUILD_VP8_DECODER,
     [test "x$enable_vp8dec" = "xyes"])
@@ -178,6 +188,11 @@ AC_ARG_ENABLE(vp9dec,
         [build with vp9 decoder support @<:@default=no@:>@])],
     [], [enable_vp9dec="no"])
 
+if test "$enable_vp9dec" = "yes"; then
+    AC_DEFINE([__BUILD_VP9_DECODER__], [1],
+        [Defined to 1 if --enable-vp9dec="yes"])
+fi
+
 AM_CONDITIONAL(BUILD_VP9_DECODER,
     [test "x$enable_vp9dec" = "xyes"])
 
@@ -186,6 +201,11 @@ AC_ARG_ENABLE(jpegdec,
     [AC_HELP_STRING([--enable-jpegdec],
         [build with jpeg decoder support @<:@default=yes@:>@])],
     [], [enable_jpegdec="yes"])
+
+if test "$enable_jpegdec" = "yes"; then
+    AC_DEFINE([__BUILD_JPEG_DECODER__], [1],
+        [Defined to 1 if --enable-jpegdec="yes"])
+fi
 
 AM_CONDITIONAL(BUILD_JPEG_DECODER,
     [test "x$enable_jpegdec" = "xyes"])
@@ -196,6 +216,11 @@ AC_ARG_ENABLE(h264dec,
         [build with h264 decoder support @<:@default=yes@:>@])],
     [], [enable_h264dec="yes"])
 
+if test "$enable_h264dec" = "yes"; then
+    AC_DEFINE([__BUILD_H264_DECODER__], [1],
+        [Defined to 1 if --enable-h264dec="yes"])
+fi
+
 AM_CONDITIONAL(BUILD_H264_DECODER,
     [test "x$enable_h264dec" = "xyes"])
 
@@ -205,6 +230,11 @@ AC_ARG_ENABLE(h265dec,
         [build with h265 decoder support @<:@default=yes@:>@])],
     [], [enable_h265dec="yes"])
 
+if test "$enable_h265dec" = "yes"; then
+    AC_DEFINE([__BUILD_H265_DECODER__], [1],
+        [Defined to 1 if --enable-h265dec="yes"])
+fi
+
 AM_CONDITIONAL(BUILD_H265_DECODER,
     [test "x$enable_h265dec" = "xyes"])
 
@@ -213,6 +243,11 @@ AC_ARG_ENABLE(vc1dec,
     [AC_HELP_STRING([--enable-vc1dec],
         [build with vc1 decoder support @<:@default=no@:>@])],
     [], [enable_vc1dec="no"])
+
+if test "$enable_vc1dec" = "yes"; then
+    AC_DEFINE([__BUILD_VC1_DECODER__], [1],
+        [Defined to 1 if --enable-vc1dec="yes"])
+fi
 
 AM_CONDITIONAL(BUILD_VC1_DECODER,
     [test "x$enable_vc1dec" = "xyes"])

--- a/decoder/Makefile.unittest
+++ b/decoder/Makefile.unittest
@@ -57,6 +57,41 @@ unittest_CXXFLAGS = \
 	$(AM_CXXFLAGS) \
 	$(NULL)
 
-check-local: unittest
-	$(builddir)/unittest
+# Separate the vaapidecoder_host_unittest so that we can detect static
+# initialization bugs with the decoder factory.  Separation is required
+# since any derived decoder that is explicitly constructed in another test
+# would hide such bugs.
+noinst_PROGRAMS += unittest_host
+unittest_host_SOURCES = \
+	unittest_main.cpp \
+	vaapidecoder_host_unittest.cpp \
+	$(NULL)
 
+unittest_host_LDFLAGS = \
+	$(GTEST_LDFLAGS) \
+	$(AM_LDFLAGS) \
+	$(NULL)
+
+unittest_host_LDADD = \
+	libyami_decoder.la \
+	$(top_builddir)/codecparsers/libyami_codecparser.la \
+	$(top_builddir)/vaapi/libyami_vaapi.la \
+	$(top_builddir)/common/libyami_common.la \
+	$(GTEST_LIBS) \
+	$(NULL)
+
+unittest_host_CPPFLAGS = \
+	$(GTEST_CPPFLAGS) \
+	$(LIBVA_CFLAGS) \
+	$(AM_CPPFLAGS) \
+	-I$(top_srcdir)/interface \
+	$(NULL)
+
+unittest_host_CXXFLAGS = \
+	$(GTEST_CXXFLAGS) \
+	$(AM_CXXFLAGS) \
+	$(NULL)
+
+check-local: unittest unittest_host
+	$(builddir)/unittest
+	$(builddir)/unittest_host

--- a/decoder/vaapiDecoderJPEG.cpp
+++ b/decoder/vaapiDecoderJPEG.cpp
@@ -24,7 +24,6 @@
 // library headers
 #include "codecparsers/jpegParser.h"
 #include "common/common_def.h"
-#include "vaapidecoder_factory.h"
 
 // system headers
 #include <cassert>
@@ -509,6 +508,4 @@ YamiStatus VaapiDecoderJPEG::reset(VideoConfigBuffer* buffer)
     return VaapiDecoderBase::reset(buffer);
 }
 
-const bool VaapiDecoderJPEG::s_registered =
-    VaapiDecoderFactory::register_<VaapiDecoderJPEG>(YAMI_MIME_JPEG);
 }

--- a/decoder/vaapiDecoderJPEG.h
+++ b/decoder/vaapiDecoderJPEG.h
@@ -50,7 +50,11 @@ private:
     SharedPtr<VaapiDecoderJPEG::Impl> m_impl;
     PicturePtr m_picture;
 
-    static const bool s_registered; // VaapiDecoderFactory registration result
+    /**
+     * VaapiDecoderFactory registration result. This decoder is registered in
+     * vaapidecoder_host.cpp
+     */
+    static const bool s_registered;
 
     DISALLOW_COPY_AND_ASSIGN(VaapiDecoderJPEG);
 };

--- a/decoder/vaapidecoder_h264.cpp
+++ b/decoder/vaapidecoder_h264.cpp
@@ -22,7 +22,6 @@
 
 #include "common/log.h"
 #include "common/nalreader.h"
-#include "vaapidecoder_factory.h"
 
 #include "vaapi/vaapiptrs.h"
 #include "vaapi/vaapicontext.h"
@@ -1864,7 +1863,4 @@ YamiStatus VaapiDecoderH264::decode(VideoDecodeBuffer* buffer)
     return YAMI_SUCCESS;
 }
 
-const bool VaapiDecoderH264::s_registered
-    = VaapiDecoderFactory::register_<VaapiDecoderH264>(YAMI_MIME_AVC)
-      && VaapiDecoderFactory::register_<VaapiDecoderH264>(YAMI_MIME_H264);
 }

--- a/decoder/vaapidecoder_h264.h
+++ b/decoder/vaapidecoder_h264.h
@@ -166,8 +166,13 @@ private:
     uint32_t m_nalLengthSize;
     SurfacePtr m_currSurface;
     bool m_contextChanged;
-    static const bool s_registered; // VaapiDecoderFactory registration result
+
+    /**
+     * VaapiDecoderFactory registration result. This decoder is registered in
+     * vaapidecoder_host.cpp
+     */
+    static const bool s_registered;
 };
-};
+} // namespace YamiMediaCodec
 
 #endif

--- a/decoder/vaapidecoder_h265.cpp
+++ b/decoder/vaapidecoder_h265.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2014 Intel Corporation. All rights reserved.
+ * Copyright (C) 2013-2016 Intel Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@
 #include "codecparsers/h265Parser.h"
 #include "common/log.h"
 #include "common/nalreader.h"
-#include "vaapidecoder_factory.h"
 
 #include "vaapi/vaapiptrs.h"
 #include "vaapi/vaapicontext.h"
@@ -1229,9 +1228,6 @@ bool VaapiDecoderH265::decodeHevcRecordData(uint8_t* buf, int32_t bufSize)
     m_nalLengthSize = nalLengthSize;
     return true;
 }
-
-const bool VaapiDecoderH265::s_registered =
-    VaapiDecoderFactory::register_<VaapiDecoderH265>(YAMI_MIME_H265);
 
 }
 

--- a/decoder/vaapidecoder_h265.h
+++ b/decoder/vaapidecoder_h265.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Intel Corporation. All rights reserved.
+ * Copyright (C) 2013-2016 Intel Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -156,11 +156,14 @@ private:
     std::map<int32_t, uint8_t> m_pocToIndex;
     SharedPtr<SliceHeader> m_prevSlice;
 
-
-    static const bool s_registered; // VaapiDecoderFactory registration result
+    /**
+     * VaapiDecoderFactory registration result. This decoder is registered in
+     * vaapidecoder_host.cpp
+     */
+    static const bool s_registered;
 };
 
-};
+} // namespace YamiMediaCodec
 
 #endif
 

--- a/decoder/vaapidecoder_host.cpp
+++ b/decoder/vaapidecoder_host.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Intel Corporation. All rights reserved.
+ * Copyright (C) 2013-2016 Intel Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,49 @@
 #endif
 
 using namespace YamiMediaCodec;
+
+#if __BUILD_H264_DECODER__
+#include "vaapidecoder_h264.h"
+const bool VaapiDecoderH264::s_registered
+    = VaapiDecoderFactory::register_<VaapiDecoderH264>(YAMI_MIME_AVC)
+      && VaapiDecoderFactory::register_<VaapiDecoderH264>(YAMI_MIME_H264);
+#endif
+
+#if __BUILD_H265_DECODER__
+#include "vaapidecoder_h265.h"
+const bool VaapiDecoderH265::s_registered =
+    VaapiDecoderFactory::register_<VaapiDecoderH265>(YAMI_MIME_H265);
+#endif
+
+#if __BUILD_MPEG2_DECODER__
+#include "vaapidecoder_mpeg2.h"
+const bool VaapiDecoderMPEG2::s_registered
+    = VaapiDecoderFactory::register_<VaapiDecoderMPEG2>(YAMI_MIME_MPEG2);
+#endif
+
+#if __BUILD_VC1_DECODER__
+#include "vaapidecoder_vc1.h"
+const bool VaapiDecoderVC1::s_registered
+    = VaapiDecoderFactory::register_<VaapiDecoderVC1>(YAMI_MIME_VC1);
+#endif
+
+#if __BUILD_VP8_DECODER__
+#include "vaapidecoder_vp8.h"
+const bool VaapiDecoderVP8::s_registered =
+    VaapiDecoderFactory::register_<VaapiDecoderVP8>(YAMI_MIME_VP8);
+#endif
+
+#if __BUILD_VP9_DECODER__
+#include "vaapidecoder_vp9.h"
+const bool VaapiDecoderVP9::s_registered =
+    VaapiDecoderFactory::register_<VaapiDecoderVP9>(YAMI_MIME_VP9);
+#endif
+
+#if __BUILD_JPEG_DECODER__
+#include "vaapiDecoderJPEG.h"
+const bool VaapiDecoderJPEG::s_registered =
+    VaapiDecoderFactory::register_<VaapiDecoderJPEG>(YAMI_MIME_JPEG);
+#endif
 
 extern "C" {
 

--- a/decoder/vaapidecoder_host.cpp
+++ b/decoder/vaapidecoder_host.cpp
@@ -38,7 +38,8 @@ const bool VaapiDecoderH264::s_registered
 #if __BUILD_H265_DECODER__
 #include "vaapidecoder_h265.h"
 const bool VaapiDecoderH265::s_registered =
-    VaapiDecoderFactory::register_<VaapiDecoderH265>(YAMI_MIME_H265);
+    VaapiDecoderFactory::register_<VaapiDecoderH265>(YAMI_MIME_H265)
+    && VaapiDecoderFactory::register_<VaapiDecoderH265>(YAMI_MIME_HEVC);
 #endif
 
 #if __BUILD_MPEG2_DECODER__

--- a/decoder/vaapidecoder_mpeg2.cpp
+++ b/decoder/vaapidecoder_mpeg2.cpp
@@ -22,7 +22,6 @@
 #include "common/nalreader.h"
 #include "vaapidecpicture.h"
 #include "vaapidecoder_mpeg2.h"
-#include "vaapidecoder_factory.h"
 
 #include <string.h>
 
@@ -1071,6 +1070,4 @@ void VaapiDecoderMPEG2::flush()
     VaapiDecoderBase::flush();
 }
 
-const bool VaapiDecoderMPEG2::s_registered
-    = VaapiDecoderFactory::register_<VaapiDecoderMPEG2>(YAMI_MIME_MPEG2);
 }

--- a/decoder/vaapidecoder_mpeg2.h
+++ b/decoder/vaapidecoder_mpeg2.h
@@ -158,7 +158,11 @@ private:
     std::list<PicturePtr> m_topFieldPictures;
     std::list<PicturePtr> m_bottomFieldPictures;
 
-    static const bool s_registered; // VaapiDecoderFactory registration result
+    /**
+     * VaapiDecoderFactory registration result. This decoder is registered in
+     * vaapidecoder_host.cpp
+     */
+    static const bool s_registered;
 };
 } // namespace YamiMediaCodec
 

--- a/decoder/vaapidecoder_vc1.cpp
+++ b/decoder/vaapidecoder_vc1.cpp
@@ -22,7 +22,6 @@
 
 #include "common/log.h"
 #include "vaapidecoder_vc1.h"
-#include "vaapidecoder_factory.h"
 
 namespace YamiMediaCodec {
 using namespace ::YamiParser::VC1;
@@ -427,6 +426,4 @@ YamiStatus VaapiDecoderVC1::decode(VideoDecodeBuffer* buffer)
     return decode(data, size, buffer->timeStamp);
 }
 
-const bool VaapiDecoderVC1::s_registered
-    = VaapiDecoderFactory::register_<VaapiDecoderVC1>(YAMI_MIME_VC1);
 }

--- a/decoder/vaapidecoder_vc1.h
+++ b/decoder/vaapidecoder_vc1.h
@@ -60,7 +60,12 @@ private:
     PicturePtr m_dpb[2];
     int32_t m_dpbIdx;
     bool m_sliceFlag;
+
+    /**
+     * VaapiDecoderFactory registration result. This decoder is registered in
+     * vaapidecoder_host.cpp
+     */
     static const bool s_registered;
 };
-}
+} // namespace YamiMediaCodec
 #endif

--- a/decoder/vaapidecoder_vp8.cpp
+++ b/decoder/vaapidecoder_vp8.cpp
@@ -21,7 +21,6 @@
 #include <string.h>
 #include "common/log.h"
 #include "vaapidecoder_vp8.h"
-#include "vaapidecoder_factory.h"
 
 using ::YamiParser::Vp8Parser;
 using ::YamiParser::Vp8FrameHeader;
@@ -590,8 +589,5 @@ YamiStatus VaapiDecoderVP8::decode(VideoDecodeBuffer* buffer)
 
     return status;
 }
-
-const bool VaapiDecoderVP8::s_registered =
-    VaapiDecoderFactory::register_<VaapiDecoderVP8>(YAMI_MIME_VP8);
 
 }

--- a/decoder/vaapidecoder_vp8.h
+++ b/decoder/vaapidecoder_vp8.h
@@ -114,8 +114,12 @@ class VaapiDecoderVP8:public VaapiDecoderBase {
     bool m_isFirstFrame;
 #endif
 
-    static const bool s_registered; // VaapiDecoderFactory registration result
+    /**
+     * VaapiDecoderFactory registration result. This decoder is registered in
+     * vaapidecoder_host.cpp
+     */
+    static const bool s_registered;
 };
-}
+} // namespace YamiMediaCodec
 
 #endif

--- a/decoder/vaapidecoder_vp9.cpp
+++ b/decoder/vaapidecoder_vp9.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2014 Intel Corporation. All rights reserved.
+ * Copyright (C) 2013-2016 Intel Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@
 
 #include "common/log.h"
 #include "vaapidecoder_vp9.h"
-#include "vaapidecoder_factory.h"
 
 namespace YamiMediaCodec{
 typedef VaapiDecoderVP9::PicturePtr PicturePtr;
@@ -340,8 +339,5 @@ YamiStatus VaapiDecoderVP9::decode(const uint8_t* data, uint32_t size, uint64_t 
         return YAMI_DECODE_INVALID_DATA;
     return decode(&hdr, data, size, timeStamp);
 }
-
-const bool VaapiDecoderVP9::s_registered =
-    VaapiDecoderFactory::register_<VaapiDecoderVP9>(YAMI_MIME_VP9);
 
 }

--- a/decoder/vaapidecoder_vp9.h
+++ b/decoder/vaapidecoder_vp9.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Intel Corporation. All rights reserved.
+ * Copyright (C) 2013-2016 Intel Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,9 +53,13 @@ class VaapiDecoderVP9:public VaapiDecoderBase {
     ParserPtr m_parser;
     std::vector<SurfacePtr> m_reference;
 
-    static const bool s_registered; // VaapiDecoderFactory registration result
+    /**
+     * VaapiDecoderFactory registration result. This decoder is registered in
+     * vaapidecoder_host.cpp
+     */
+    static const bool s_registered;
 };
 
-};
+} // namespace YamiMediaCodec
 
 #endif

--- a/encoder/Makefile.unittest
+++ b/encoder/Makefile.unittest
@@ -49,6 +49,41 @@ unittest_CXXFLAGS = \
 	$(AM_CXXFLAGS) \
 	$(NULL)
 
-check-local: unittest
-	$(builddir)/unittest
+# Separate the vaapiencoder_host_unittest so that we can detect static
+# initialization bugs with the encoder factory.  Separation is required
+# since any derived encoder that is explicitly constructed in another test
+# would hide such bugs.
+noinst_PROGRAMS += unittest_host
+unittest_host_SOURCES = \
+	unittest_main.cpp \
+	vaapiencoder_host_unittest.cpp \
+	$(NULL)
 
+unittest_host_LDFLAGS = \
+	$(GTEST_LDFLAGS) \
+	$(AM_LDFLAGS) \
+	$(NULL)
+
+unittest_host_LDADD = \
+	libyami_encoder.la \
+	$(top_builddir)/common/libyami_common.la \
+	$(top_builddir)/vaapi/libyami_vaapi.la \
+	$(top_builddir)/codecparsers/libyami_codecparser.la \
+	$(GTEST_LIBS) \
+	$(NULL)
+
+unittest_host_CPPFLAGS = \
+	$(GTEST_CPPFLAGS) \
+	$(LIBVA_CFLAGS) \
+	$(AM_CPPFLAGS) \
+	-I$(top_srcdir)/interface \
+	$(NULL)
+
+unittest_host_CXXFLAGS = \
+	$(GTEST_CXXFLAGS) \
+	$(AM_CXXFLAGS) \
+	$(NULL)
+
+check-local: unittest unittest_host
+	$(builddir)/unittest
+	$(builddir)/unittest_host

--- a/encoder/vaapiencoder_h264.cpp
+++ b/encoder/vaapiencoder_h264.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2014 Intel Corporation. All rights reserved.
+ * Copyright (C) 2013-2016 Intel Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@
 #include "vaapi/vaapidisplay.h"
 #include "vaapicodedbuffer.h"
 #include "vaapiencpicture.h"
-#include "vaapiencoder_factory.h"
 #include <algorithm>
 #include <math.h>
 
@@ -2003,9 +2002,5 @@ YamiStatus VaapiEncoderH264::encodePicture(const PicturePtr& picture)
 
     return YAMI_SUCCESS;
 }
-
-const bool VaapiEncoderH264::s_registered =
-    VaapiEncoderFactory::register_<VaapiEncoderH264>(YAMI_MIME_AVC)
-    && VaapiEncoderFactory::register_<VaapiEncoderH264>(YAMI_MIME_H264);
 
 }

--- a/encoder/vaapiencoder_h264.h
+++ b/encoder/vaapiencoder_h264.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2014 Intel Corporation. All rights reserved.
+ * Copyright (C) 2013-2016 Intel Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -149,7 +149,11 @@ private:
     StreamHeaderPtr m_headers;
     Lock m_paramLock; // locker for parameters update, for example: m_sps/m_pps/m_maxCodedbufSize (width/height etc)
 
-    static const bool s_registered; // VaapiEncoderFactory registration result
+    /**
+     * VaapiEncoderFactory registration result. This encoder is registered in
+     * vaapiencoder_host.cpp
+     */
+    static const bool s_registered;
 };
 }
 #endif /* vaapiencoder_h264_h */

--- a/encoder/vaapiencoder_hevc.cpp
+++ b/encoder/vaapiencoder_hevc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2015 Intel Corporation. All rights reserved.
+ * Copyright (C) 2014-2016 Intel Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@
 #include "vaapi/vaapidisplay.h"
 #include "vaapicodedbuffer.h"
 #include "vaapiencpicture.h"
-#include "vaapiencoder_factory.h"
 #include <algorithm>
 
 namespace YamiMediaCodec{
@@ -1764,9 +1763,5 @@ YamiStatus VaapiEncoderHEVC::encodePicture(const PicturePtr& picture)
 
     return YAMI_SUCCESS;
 }
-
-const bool VaapiEncoderHEVC::s_registered =
-    VaapiEncoderFactory::register_<VaapiEncoderHEVC>(YAMI_MIME_HEVC)
-    && VaapiEncoderFactory::register_<VaapiEncoderHEVC>(YAMI_MIME_H265);
 
 }

--- a/encoder/vaapiencoder_hevc.h
+++ b/encoder/vaapiencoder_hevc.h
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (C) 2014-2015 Intel Corporation. All rights reserved.
+ * Copyright (C) 2014-2016 Intel Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -164,7 +164,11 @@ private:
     StreamHeaderPtr m_headers;
     Lock m_paramLock; // locker for parameters update, for example: m_sps/m_pps/m_maxCodedbufSize (width/height etc)
 
-    static const bool s_registered; // VaapiEncoderFactory registration result
+    /**
+     * VaapiEncoderFactory registration result. This encoder is registered in
+     * vaapiencoder_host.cpp
+     */
+    static const bool s_registered;
 };
 }
 #endif /* vaapiencoder_hevc_h */

--- a/encoder/vaapiencoder_host.cpp
+++ b/encoder/vaapiencoder_host.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2014 Intel Corporation. All rights reserved.
+ * Copyright (C) 2013-2016 Intel Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,38 @@
 #include "vaapiencoder_factory.h"
 
 using namespace YamiMediaCodec;
+
+#if __BUILD_H264_ENCODER__
+#include "vaapiencoder_h264.h"
+const bool VaapiEncoderH264::s_registered =
+    VaapiEncoderFactory::register_<VaapiEncoderH264>(YAMI_MIME_AVC)
+    && VaapiEncoderFactory::register_<VaapiEncoderH264>(YAMI_MIME_H264);
+#endif
+
+#if __BUILD_H265_ENCODER__
+#include "vaapiencoder_hevc.h"
+const bool VaapiEncoderHEVC::s_registered =
+    VaapiEncoderFactory::register_<VaapiEncoderHEVC>(YAMI_MIME_HEVC)
+    && VaapiEncoderFactory::register_<VaapiEncoderHEVC>(YAMI_MIME_H265);
+#endif
+
+#if __BUILD_JPEG_ENCODER__
+#include "vaapiencoder_jpeg.h"
+const bool VaapiEncoderJpeg::s_registered =
+    VaapiEncoderFactory::register_<VaapiEncoderJpeg>(YAMI_MIME_JPEG);
+#endif
+
+#if __BUILD_VP8_ENCODER__
+#include "vaapiencoder_vp8.h"
+const bool VaapiEncoderVP8::s_registered =
+    VaapiEncoderFactory::register_<VaapiEncoderVP8>(YAMI_MIME_VP8);
+#endif
+
+#if __BUILD_VP9_ENCODER__
+#include "vaapiencoder_vp9.h"
+const bool VaapiEncoderVP9::s_registered
+    = VaapiEncoderFactory::register_<VaapiEncoderVP9>(YAMI_MIME_VP9);
+#endif
 
 extern "C" {
 

--- a/encoder/vaapiencoder_host_unittest.cpp
+++ b/encoder/vaapiencoder_host_unittest.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2016 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+//
+// The unittest header must be included before va_x11.h (which might be included
+// indirectly).  The va_x11.h includes Xlib.h and X.h.  And the X headers
+// define 'Bool' and 'None' preprocessor types.  Gtest uses the same names
+// to define some struct placeholders.  Thus, this creates a compile conflict
+// if X defines them before gtest.  Hence, the include order requirement here
+// is the only fix for this right now.
+//
+// See bug filed on gtest at https://github.com/google/googletest/issues/371
+// for more details.
+//
+#include "common/unittest.h"
+
+// primary header
+#include "VideoEncoderHost.h"
+
+// system headers
+#include <algorithm>
+#include <string>
+#include <set>
+
+namespace YamiMediaCodec {
+
+std::set<std::string>& expectations()
+{
+    static std::set<std::string> e;
+
+#if __BUILD_H264_ENCODER__
+    e.insert(YAMI_MIME_H264);
+    e.insert(YAMI_MIME_AVC);
+#endif
+
+#if __BUILD_H265_ENCODER__
+    e.insert(YAMI_MIME_H265);
+    e.insert(YAMI_MIME_HEVC);
+#endif
+
+#if __BUILD_VP8_ENCODER__
+    e.insert(YAMI_MIME_VP8);
+#endif
+
+#if __BUILD_VP9_ENCODER__
+    e.insert(YAMI_MIME_VP9);
+#endif
+
+#if __BUILD_JPEG_ENCODER__
+    e.insert(YAMI_MIME_JPEG);
+#endif
+
+    return e;
+}
+
+class VaapiEncoderHostTest
+    : public ::testing::TestWithParam<std::string>
+{ };
+
+TEST_P(VaapiEncoderHostTest, createVideoEncoder)
+{
+    std::string mime = GetParam();
+    IVideoEncoder *encoder = createVideoEncoder(mime.c_str());
+    bool expect = expectations().count(mime) != 0;
+
+    EXPECT_EQ(expect, (encoder != NULL))
+        << "createVideoEncoder(" << mime << "): "
+        << "did not " << (expect ? "SUCCEED" : "FAIL")
+        << " as it should have.";
+
+    releaseVideoEncoder(encoder);
+}
+
+TEST_P(VaapiEncoderHostTest, getVideoEncoderMimeTypesContains)
+{
+    std::string mime = GetParam();
+    std::vector<std::string> avail = getVideoEncoderMimeTypes();
+
+    bool expect = expectations().count(mime) != 0;
+    bool actual = std::find(avail.begin(), avail.end(), mime) != avail.end();
+
+    EXPECT_EQ( expect, actual );
+}
+
+INSTANTIATE_TEST_CASE_P(
+    MimeType, VaapiEncoderHostTest,
+    ::testing::Values(
+        YAMI_MIME_H264, YAMI_MIME_AVC, YAMI_MIME_H265, YAMI_MIME_HEVC,
+        YAMI_MIME_MPEG2, YAMI_MIME_VC1, YAMI_MIME_VP8, YAMI_MIME_VP9,
+        YAMI_MIME_JPEG));
+}

--- a/encoder/vaapiencoder_jpeg.cpp
+++ b/encoder/vaapiencoder_jpeg.cpp
@@ -25,7 +25,6 @@
 #include "common/scopedlogger.h"
 #include "vaapicodedbuffer.h"
 #include "vaapiencpicture.h"
-#include "vaapiencoder_factory.h"
 #include "common/log.h"
 #include <stdio.h>
 
@@ -511,8 +510,5 @@ YamiStatus VaapiEncoderJpeg::encodePicture(const PicturePtr& picture)
         return ret;
     return YAMI_SUCCESS;
 }
-
-const bool VaapiEncoderJpeg::s_registered =
-    VaapiEncoderFactory::register_<VaapiEncoderJpeg>(YAMI_MIME_JPEG);
 
 }

--- a/encoder/vaapiencoder_jpeg.h
+++ b/encoder/vaapiencoder_jpeg.h
@@ -62,7 +62,11 @@ private:
 
     unsigned char quality;
 
-    static const bool s_registered; // VaapiEncoderFactory registration result
+    /**
+     * VaapiEncoderFactory registration result. This encoder is registered in
+     * vaapiencoder_host.cpp
+     */
+    static const bool s_registered;
 };
 }
 #endif

--- a/encoder/vaapiencoder_vp8.cpp
+++ b/encoder/vaapiencoder_vp8.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Intel Corporation. All rights reserved.
+ * Copyright (C) 2014-2016 Intel Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@
 #include "vaapi/vaapidisplay.h"
 #include "vaapicodedbuffer.h"
 #include "vaapiencpicture.h"
-#include "vaapiencoder_factory.h"
 #include <algorithm>
 
 namespace YamiMediaCodec{
@@ -304,8 +303,5 @@ YamiStatus VaapiEncoderVP8::encodePicture(const PicturePtr& picture)
 
     return YAMI_SUCCESS;
 }
-
-const bool VaapiEncoderVP8::s_registered =
-    VaapiEncoderFactory::register_<VaapiEncoderVP8>(YAMI_MIME_VP8);
 
 }

--- a/encoder/vaapiencoder_vp8.h
+++ b/encoder/vaapiencoder_vp8.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Intel Corporation. All rights reserved.
+ * Copyright (C) 2014-2016 Intel Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,11 @@ private:
     typedef std::deque<SurfacePtr> ReferenceQueue;
     std::deque<SurfacePtr> m_reference;
 
-    static const bool s_registered; // VaapiEncoderFactory registration result
+    /**
+     * VaapiEncoderFactory registration result. This encoder is registered in
+     * vaapiencoder_host.cpp
+     */
+    static const bool s_registered;
 };
 }
 #endif /* vaapiencoder_vp8_h */

--- a/encoder/vaapiencoder_vp9.cpp
+++ b/encoder/vaapiencoder_vp9.cpp
@@ -25,7 +25,6 @@
 #include "vaapi/vaapidisplay.h"
 #include "vaapicodedbuffer.h"
 #include "vaapiencpicture.h"
-#include "vaapiencoder_factory.h"
 #include <algorithm>
 
 namespace YamiMediaCodec {
@@ -394,7 +393,4 @@ YamiStatus VaapiEncoderVP9::encodePicture(const PicturePtr& picture)
     return YAMI_SUCCESS;
 }
 
-
-const bool VaapiEncoderVP9::s_registered
-    = VaapiEncoderFactory::register_<VaapiEncoderVP9>(YAMI_MIME_VP9);
 }

--- a/encoder/vaapiencoder_vp9.h
+++ b/encoder/vaapiencoder_vp9.h
@@ -79,7 +79,11 @@ private:
     typedef std::deque<SurfacePtr> ReferenceQueue;
     std::deque<SurfacePtr> m_reference;
 
-    static const bool s_registered; // VaapiEncoderFactory registration result
+    /**
+     * VaapiEncoderFactory registration result. This encoder is registered in
+     * vaapiencoder_host.cpp
+     */
+    static const bool s_registered;
 };
 } // namespace YamiMediaCodec
 #endif // vaapiencoder_vp9_h

--- a/vpp/Makefile.unittest
+++ b/vpp/Makefile.unittest
@@ -6,6 +6,16 @@ unittest_SOURCES = \
 
 unittest_SOURCES += vaapipostprocess_scaler_unittest.cpp
 
+if BUILD_OCL_FILTERS
+unittest_SOURCES += \
+	oclpostprocess_blender_unittest.cpp \
+	oclpostprocess_mosaic_unittest.cpp \
+	oclpostprocess_osd_unittest.cpp \
+	oclpostprocess_transform_unittest.cpp \
+	oclpostprocess_wireframe_unittest.cpp \
+	$(NULL)
+endif
+
 unittest_LDFLAGS = \
 	$(GTEST_LDFLAGS) \
 	$(AM_LDFLAGS) \

--- a/vpp/Makefile.unittest
+++ b/vpp/Makefile.unittest
@@ -40,6 +40,42 @@ unittest_CXXFLAGS = \
 	$(AM_CXXFLAGS) \
 	$(NULL)
 
-check-local: unittest
+# Separate the vaapipostprocess_host_unittest so that we can detect static
+# initialization bugs with the vpp factory.  Separation is required
+# since any derived vpp that is explicitly constructed in another test
+# would hide such bugs.
+noinst_PROGRAMS += unittest_host
+unittest_host_SOURCES = \
+	unittest_main.cpp \
+	vaapipostprocess_host_unittest.cpp \
+	$(NULL)
+
+unittest_host_LDFLAGS = \
+	$(GTEST_LDFLAGS) \
+	$(AM_LDFLAGS) \
+	$(NULL)
+
+unittest_host_LDADD = \
+	libyami_vpp.la \
+	$(top_builddir)/vaapi/libyami_vaapi.la \
+	$(top_builddir)/common/libyami_common.la \
+	$(GTEST_LIBS) \
+	$(NULL)
+
+unittest_host_CPPFLAGS = \
+	$(GTEST_CPPFLAGS) \
+	$(LIBVA_CFLAGS) \
+	$(AM_CPPFLAGS) \
+	-I$(top_srcdir)/interface \
+	$(NULL)
+
+unittest_host_CXXFLAGS = \
+	$(GTEST_CXXFLAGS) \
+	$(AM_CXXFLAGS) \
+	$(NULL)
+
+check-local: unittest unittest_host
 	$(builddir)/unittest
+	$(builddir)/unittest_host
+
 

--- a/vpp/oclpostprocess_base.h
+++ b/vpp/oclpostprocess_base.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef vaapipostprocess_base_h
-#define vaapipostprocess_base_h
+#ifndef oclpostprocess_base_h
+#define oclpostprocess_base_h
 
 #include "VideoPostProcessInterface.h"
 #include <CL/opencl.h>

--- a/vpp/oclpostprocess_base.h
+++ b/vpp/oclpostprocess_base.h
@@ -22,6 +22,9 @@
 #include <ocl/oclcontext.h>
 #include <va/va.h>
 
+template <class B, class C>
+class FactoryTest;
+
 namespace YamiMediaCodec{
 class OclContext;
 /**

--- a/vpp/oclpostprocess_blender.cpp
+++ b/vpp/oclpostprocess_blender.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ * Copyright (C) 2015-2016 Intel Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@
 #include "ocl/oclcontext.h"
 #include "oclpostprocess_blender.h"
 #include "oclvppimage.h"
-#include "vaapipostprocess_factory.h"
 
 namespace YamiMediaCodec{
 
@@ -111,9 +110,6 @@ bool OclPostProcessBlender::prepareKernels()
 
     return m_kernelBlend != NULL;
 }
-
-const bool OclPostProcessBlender::s_registered =
-    VaapiPostProcessFactory::register_<OclPostProcessBlender>(YAMI_VPP_OCL_BLENDER);
 
 }
 

--- a/vpp/oclpostprocess_blender.h
+++ b/vpp/oclpostprocess_blender.h
@@ -37,6 +37,9 @@ public:
     }
 
 private:
+    friend class FactoryTest<IVideoPostProcess, OclPostProcessBlender>;
+    friend class OclPostProcessBlenderTest;
+
     virtual bool prepareKernels();
     YamiStatus blend(const SharedPtr<VideoFrame>& src,
                      const SharedPtr<VideoFrame>& dst);

--- a/vpp/oclpostprocess_blender.h
+++ b/vpp/oclpostprocess_blender.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ * Copyright (C) 2015-2016 Intel Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,12 @@ private:
     YamiStatus blend(const SharedPtr<VideoFrame>& src,
                      const SharedPtr<VideoFrame>& dst);
 
-    static const bool s_registered; // VaapiPostProcessFactory registration result
+    /**
+     * VaapiPostProcessFactory registration result. This postprocess is
+     * registered in vaapipostprocess_host.cpp
+     */
+    static const bool s_registered;
+
     cl_kernel m_kernelBlend;
 };
 

--- a/vpp/oclpostprocess_blender_unittest.cpp
+++ b/vpp/oclpostprocess_blender_unittest.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+//
+// The unittest header must be included before va_x11.h (which might be included
+// indirectly).  The va_x11.h includes Xlib.h and X.h.  And the X headers
+// define 'Bool' and 'None' preprocessor types.  Gtest uses the same names
+// to define some struct placeholders.  Thus, this creates a compile conflict
+// if X defines them before gtest.  Hence, the include order requirement here
+// is the only fix for this right now.
+//
+// See bug filed on gtest at https://github.com/google/googletest/issues/371
+// for more details.
+//
+#include "common/factory_unittest.h"
+
+// primary header
+#include "oclpostprocess_blender.h"
+
+namespace YamiMediaCodec {
+
+class OclPostProcessBlenderTest
+  : public FactoryTest<IVideoPostProcess, OclPostProcessBlender>
+{ };
+
+#define OCLPOSTPROCESS_BLENDER_TEST(name) \
+    TEST_F(OclPostProcessBlenderTest, name)
+
+OCLPOSTPROCESS_BLENDER_TEST(Factory) {
+    FactoryKeys mimeTypes;
+    mimeTypes.push_back(YAMI_VPP_OCL_BLENDER);
+    doFactoryTest(mimeTypes);
+}
+
+}

--- a/vpp/oclpostprocess_mosaic.cpp
+++ b/vpp/oclpostprocess_mosaic.cpp
@@ -18,7 +18,6 @@
 #endif
 
 #include "oclpostprocess_mosaic.h"
-#include "vaapipostprocess_factory.h"
 #include "common/common_def.h"
 #include "common/log.h"
 #include "ocl/oclcontext.h"
@@ -116,5 +115,4 @@ bool OclPostProcessMosaic::prepareKernels()
     return m_kernelMosaic != NULL;
 }
 
-const bool OclPostProcessMosaic::s_registered = VaapiPostProcessFactory::register_<OclPostProcessMosaic>(YAMI_VPP_OCL_MOSAIC);
 }

--- a/vpp/oclpostprocess_mosaic.h
+++ b/vpp/oclpostprocess_mosaic.h
@@ -45,7 +45,12 @@ private:
 
     virtual bool prepareKernels();
 
-    static const bool s_registered; // VaapiPostProcessFactory registration result
+    /**
+     * VaapiPostProcessFactory registration result. This postprocess is
+     * registered in vaapipostprocess_host.cpp
+     */
+    static const bool s_registered;
+
     int m_blockSize;
     cl_kernel m_kernelMosaic;
 };

--- a/vpp/oclpostprocess_mosaic.h
+++ b/vpp/oclpostprocess_mosaic.h
@@ -40,6 +40,9 @@ public:
     }
 
 private:
+    friend class FactoryTest<IVideoPostProcess, OclPostProcessMosaic>;
+    friend class OclPostProcessMosaicTest;
+
     virtual bool prepareKernels();
 
     static const bool s_registered; // VaapiPostProcessFactory registration result

--- a/vpp/oclpostprocess_mosaic_unittest.cpp
+++ b/vpp/oclpostprocess_mosaic_unittest.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+//
+// The unittest header must be included before va_x11.h (which might be included
+// indirectly).  The va_x11.h includes Xlib.h and X.h.  And the X headers
+// define 'Bool' and 'None' preprocessor types.  Gtest uses the same names
+// to define some struct placeholders.  Thus, this creates a compile conflict
+// if X defines them before gtest.  Hence, the include order requirement here
+// is the only fix for this right now.
+//
+// See bug filed on gtest at https://github.com/google/googletest/issues/371
+// for more details.
+//
+#include "common/factory_unittest.h"
+
+// primary header
+#include "oclpostprocess_mosaic.h"
+
+namespace YamiMediaCodec {
+
+class OclPostProcessMosaicTest
+  : public FactoryTest<IVideoPostProcess, OclPostProcessMosaic>
+{ };
+
+#define OCLPOSTPROCESS_MOSAIC_TEST(name) \
+    TEST_F(OclPostProcessMosaicTest, name)
+
+OCLPOSTPROCESS_MOSAIC_TEST(Factory) {
+    FactoryKeys mimeTypes;
+    mimeTypes.push_back(YAMI_VPP_OCL_MOSAIC);
+    doFactoryTest(mimeTypes);
+}
+
+}

--- a/vpp/oclpostprocess_osd.cpp
+++ b/vpp/oclpostprocess_osd.cpp
@@ -18,7 +18,6 @@
 #endif
 
 #include "oclpostprocess_osd.h"
-#include "vaapipostprocess_factory.h"
 #include "common/common_def.h"
 #include "common/log.h"
 #include "ocl/oclcontext.h"
@@ -228,5 +227,4 @@ bool OclPostProcessOsd::prepareKernels()
         && (m_kernelReduceLuma != NULL);
 }
 
-const bool OclPostProcessOsd::s_registered = VaapiPostProcessFactory::register_<OclPostProcessOsd>(YAMI_VPP_OCL_OSD);
 }

--- a/vpp/oclpostprocess_osd.h
+++ b/vpp/oclpostprocess_osd.h
@@ -45,6 +45,9 @@ public:
     }
 
 private:
+    friend class FactoryTest<IVideoPostProcess, OclPostProcessOsd>;
+    friend class OclPostProcessOsdTest;
+
     virtual bool prepareKernels();
     YamiStatus computeBlockLuma(const SharedPtr<VideoFrame> frame);
 

--- a/vpp/oclpostprocess_osd.h
+++ b/vpp/oclpostprocess_osd.h
@@ -51,7 +51,12 @@ private:
     virtual bool prepareKernels();
     YamiStatus computeBlockLuma(const SharedPtr<VideoFrame> frame);
 
-    static const bool s_registered; // VaapiPostProcessFactory registration result
+    /**
+     * VaapiPostProcessFactory registration result. This postprocess is
+     * registered in vaapipostprocess_host.cpp
+     */
+    static const bool s_registered;
+
     vector<float> m_osdLuma;
     vector<uint32_t> m_lineBuf;
     int m_blockCount;

--- a/vpp/oclpostprocess_osd_unittest.cpp
+++ b/vpp/oclpostprocess_osd_unittest.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+//
+// The unittest header must be included before va_x11.h (which might be included
+// indirectly).  The va_x11.h includes Xlib.h and X.h.  And the X headers
+// define 'Bool' and 'None' preprocessor types.  Gtest uses the same names
+// to define some struct placeholders.  Thus, this creates a compile conflict
+// if X defines them before gtest.  Hence, the include order requirement here
+// is the only fix for this right now.
+//
+// See bug filed on gtest at https://github.com/google/googletest/issues/371
+// for more details.
+//
+#include "common/factory_unittest.h"
+
+// primary header
+#include "oclpostprocess_osd.h"
+
+namespace YamiMediaCodec {
+
+class OclPostProcessOsdTest
+  : public FactoryTest<IVideoPostProcess, OclPostProcessOsd>
+{ };
+
+#define OCLPOSTPROCESS_OSD_TEST(name) \
+    TEST_F(OclPostProcessOsdTest, name)
+
+OCLPOSTPROCESS_OSD_TEST(Factory) {
+    FactoryKeys mimeTypes;
+    mimeTypes.push_back(YAMI_VPP_OCL_OSD);
+    doFactoryTest(mimeTypes);
+}
+
+}

--- a/vpp/oclpostprocess_transform.cpp
+++ b/vpp/oclpostprocess_transform.cpp
@@ -18,7 +18,6 @@
 #endif
 
 #include "oclpostprocess_transform.h"
-#include "vaapipostprocess_factory.h"
 #include "common/common_def.h"
 #include "common/log.h"
 #include "ocl/oclcontext.h"
@@ -298,5 +297,4 @@ bool OclPostProcessTransform::prepareKernels()
         && (m_kernelFlipVRot90 != NULL);
 }
 
-const bool OclPostProcessTransform::s_registered = VaapiPostProcessFactory::register_<OclPostProcessTransform>(YAMI_VPP_OCL_TRANSFORM);
 }

--- a/vpp/oclpostprocess_transform.h
+++ b/vpp/oclpostprocess_transform.h
@@ -61,7 +61,12 @@ private:
         const SharedPtr<OclVppCLImage>& dst,
         const cl_kernel& kernel);
 
-    static const bool s_registered; // VaapiPostProcessFactory registration result
+    /**
+     * VaapiPostProcessFactory registration result. This postprocess is
+     * registered in vaapipostprocess_host.cpp
+     */
+    static const bool s_registered;
+
     uint32_t m_transform;
     cl_kernel m_kernelFlipH;
     cl_kernel m_kernelFlipV;

--- a/vpp/oclpostprocess_transform.h
+++ b/vpp/oclpostprocess_transform.h
@@ -49,6 +49,9 @@ public:
     }
 
 private:
+    friend class FactoryTest<IVideoPostProcess, OclPostProcessTransform>;
+    friend class OclPostProcessTransformTest;
+
     virtual bool prepareKernels();
     YamiStatus flip(const SharedPtr<OclVppCLImage>& src,
         const SharedPtr<OclVppCLImage>& dst);

--- a/vpp/oclpostprocess_transform_unittest.cpp
+++ b/vpp/oclpostprocess_transform_unittest.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+//
+// The unittest header must be included before va_x11.h (which might be included
+// indirectly).  The va_x11.h includes Xlib.h and X.h.  And the X headers
+// define 'Bool' and 'None' preprocessor types.  Gtest uses the same names
+// to define some struct placeholders.  Thus, this creates a compile conflict
+// if X defines them before gtest.  Hence, the include order requirement here
+// is the only fix for this right now.
+//
+// See bug filed on gtest at https://github.com/google/googletest/issues/371
+// for more details.
+//
+#include "common/factory_unittest.h"
+
+// primary header
+#include "oclpostprocess_transform.h"
+
+namespace YamiMediaCodec {
+
+class OclPostProcessTransformTest
+  : public FactoryTest<IVideoPostProcess, OclPostProcessTransform>
+{ };
+
+#define OCLPOSTPROCESS_TRANSFORM_TEST(name) \
+    TEST_F(OclPostProcessTransformTest, name)
+
+OCLPOSTPROCESS_TRANSFORM_TEST(Factory) {
+    FactoryKeys mimeTypes;
+    mimeTypes.push_back(YAMI_VPP_OCL_TRANSFORM);
+    doFactoryTest(mimeTypes);
+}
+
+}

--- a/vpp/oclpostprocess_wireframe.cpp
+++ b/vpp/oclpostprocess_wireframe.cpp
@@ -19,7 +19,6 @@
 #endif
 
 #include "oclpostprocess_wireframe.h"
-#include "vaapipostprocess_factory.h"
 #include "common/common_def.h"
 #include "common/log.h"
 #include "ocl/oclcontext.h"
@@ -127,5 +126,4 @@ bool OclPostProcessWireframe::prepareKernels()
     return m_kernelWireframe != NULL;
 }
 
-const bool OclPostProcessWireframe::s_registered = VaapiPostProcessFactory::register_<OclPostProcessWireframe>(YAMI_VPP_OCL_WIREFRAME);
 }

--- a/vpp/oclpostprocess_wireframe.h
+++ b/vpp/oclpostprocess_wireframe.h
@@ -49,7 +49,12 @@ private:
 
     virtual bool prepareKernels();
 
-    static const bool s_registered; // VaapiPostProcessFactory registration result
+    /**
+     * VaapiPostProcessFactory registration result. This postprocess is
+     * registered in vaapipostprocess_host.cpp
+     */
+    static const bool s_registered;
+
     uint32_t m_borderWidth;
     uint8_t m_colorY;
     uint8_t m_colorU;

--- a/vpp/oclpostprocess_wireframe.h
+++ b/vpp/oclpostprocess_wireframe.h
@@ -44,6 +44,9 @@ public:
     }
 
 private:
+    friend class FactoryTest<IVideoPostProcess, OclPostProcessWireframe>;
+    friend class OclPostProcessWireframeTest;
+
     virtual bool prepareKernels();
 
     static const bool s_registered; // VaapiPostProcessFactory registration result

--- a/vpp/oclpostprocess_wireframe_unittest.cpp
+++ b/vpp/oclpostprocess_wireframe_unittest.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+//
+// The unittest header must be included before va_x11.h (which might be included
+// indirectly).  The va_x11.h includes Xlib.h and X.h.  And the X headers
+// define 'Bool' and 'None' preprocessor types.  Gtest uses the same names
+// to define some struct placeholders.  Thus, this creates a compile conflict
+// if X defines them before gtest.  Hence, the include order requirement here
+// is the only fix for this right now.
+//
+// See bug filed on gtest at https://github.com/google/googletest/issues/371
+// for more details.
+//
+#include "common/factory_unittest.h"
+
+// primary header
+#include "oclpostprocess_wireframe.h"
+
+namespace YamiMediaCodec {
+
+class OclPostProcessWireframeTest
+  : public FactoryTest<IVideoPostProcess, OclPostProcessWireframe>
+{ };
+
+#define OCLPOSTPROCESS_WIREFRAME_TEST(name) \
+    TEST_F(OclPostProcessWireframeTest, name)
+
+OCLPOSTPROCESS_WIREFRAME_TEST(Factory) {
+    FactoryKeys mimeTypes;
+    mimeTypes.push_back(YAMI_VPP_OCL_WIREFRAME);
+    doFactoryTest(mimeTypes);
+}
+
+}

--- a/vpp/vaapipostprocess_host.cpp
+++ b/vpp/vaapipostprocess_host.cpp
@@ -22,6 +22,33 @@
 #include "VideoPostProcessHost.h"
 #include "vaapipostprocess_factory.h"
 
+#if __BUILD_OCL_FILTERS__
+#include "oclpostprocess_blender.h"
+#include "oclpostprocess_mosaic.h"
+#include "oclpostprocess_osd.h"
+#include "oclpostprocess_transform.h"
+#include "oclpostprocess_wireframe.h"
+
+namespace YamiMediaCodec {
+const bool OclPostProcessBlender::s_registered =
+    VaapiPostProcessFactory::register_<OclPostProcessBlender>(YAMI_VPP_OCL_BLENDER);
+const bool OclPostProcessMosaic::s_registered =
+    VaapiPostProcessFactory::register_<OclPostProcessMosaic>(YAMI_VPP_OCL_MOSAIC);
+const bool OclPostProcessOsd::s_registered =
+    VaapiPostProcessFactory::register_<OclPostProcessOsd>(YAMI_VPP_OCL_OSD);
+const bool OclPostProcessTransform::s_registered =
+    VaapiPostProcessFactory::register_<OclPostProcessTransform>(YAMI_VPP_OCL_TRANSFORM);
+const bool OclPostProcessWireframe::s_registered =
+    VaapiPostProcessFactory::register_<OclPostProcessWireframe>(YAMI_VPP_OCL_WIREFRAME);
+}
+#endif
+
+#include "vaapipostprocess_scaler.h"
+namespace YamiMediaCodec {
+const bool VaapiPostProcessScaler::s_registered =
+    VaapiPostProcessFactory::register_<VaapiPostProcessScaler>(YAMI_VPP_SCALER);
+}
+
 using namespace YamiMediaCodec;
 
 extern "C" {

--- a/vpp/vaapipostprocess_host_unittest.cpp
+++ b/vpp/vaapipostprocess_host_unittest.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+//
+// The unittest header must be included before va_x11.h (which might be included
+// indirectly).  The va_x11.h includes Xlib.h and X.h.  And the X headers
+// define 'Bool' and 'None' preprocessor types.  Gtest uses the same names
+// to define some struct placeholders.  Thus, this creates a compile conflict
+// if X defines them before gtest.  Hence, the include order requirement here
+// is the only fix for this right now.
+//
+// See bug filed on gtest at https://github.com/google/googletest/issues/371
+// for more details.
+//
+#include "common/unittest.h"
+
+// primary header
+#include "VideoPostProcessHost.h"
+
+// system headers
+#include <algorithm>
+#include <string>
+#include <set>
+
+namespace YamiMediaCodec {
+
+std::set<std::string>& expectations()
+{
+    static std::set<std::string> e;
+
+#if __BUILD_OCL_FILTERS__
+    e.insert(YAMI_VPP_OCL_BLENDER);
+    e.insert(YAMI_VPP_OCL_OSD);
+    e.insert(YAMI_VPP_OCL_TRANSFORM);
+    e.insert(YAMI_VPP_OCL_MOSAIC);
+    e.insert(YAMI_VPP_OCL_WIREFRAME);
+#endif
+
+    e.insert(YAMI_VPP_SCALER);
+
+    return e;
+}
+
+class VaapiPostProcessHostTest
+    : public ::testing::TestWithParam<std::string>
+{ };
+
+TEST_P(VaapiPostProcessHostTest, createVideoPostProcess)
+{
+    std::string mime = GetParam();
+    IVideoPostProcess *vpp = createVideoPostProcess(mime.c_str());
+    bool expect = expectations().count(mime) != 0;
+
+    EXPECT_EQ(expect, (vpp != NULL))
+        << "createVideoPostProcess(" << mime << "): "
+        << "did not " << (expect ? "SUCCEED" : "FAIL")
+        << " as it should have.";
+
+    releaseVideoPostProcess(vpp);
+}
+
+TEST_P(VaapiPostProcessHostTest, getVideoPostProcessMimeTypesContains)
+{
+    std::string mime = GetParam();
+    std::vector<std::string> avail = getVideoPostProcessMimeTypes();
+
+    bool expect = expectations().count(mime) != 0;
+    bool actual = std::find(avail.begin(), avail.end(), mime) != avail.end();
+
+    EXPECT_EQ( expect, actual );
+}
+
+INSTANTIATE_TEST_CASE_P(
+    MimeType, VaapiPostProcessHostTest,
+    ::testing::Values(
+        YAMI_VPP_SCALER, YAMI_VPP_OCL_BLENDER, YAMI_VPP_OCL_OSD,
+        YAMI_VPP_OCL_TRANSFORM, YAMI_VPP_OCL_MOSAIC, YAMI_VPP_OCL_WIREFRAME));
+}

--- a/vpp/vaapipostprocess_scaler.cpp
+++ b/vpp/vaapipostprocess_scaler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2014 Intel Corporation. All rights reserved.
+ * Copyright (C) 2013-2016 Intel Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@
 #include "vaapi/vaapidisplay.h"
 #include "vaapi/vaapicontext.h"
 #include "vaapivpppicture.h"
-#include "vaapipostprocess_factory.h"
 #include "common/log.h"
 #include <va/va_vpp.h>
 
@@ -281,5 +280,4 @@ VaapiPostProcessScaler::setParameters(VppParamType type, void* vppParam)
     return VaapiPostProcessBase::setParameters(type, vppParam);
 }
 
-const bool VaapiPostProcessScaler::s_registered = VaapiPostProcessFactory::register_<VaapiPostProcessScaler>(YAMI_VPP_SCALER);
 }

--- a/vpp/vaapipostprocess_scaler.h
+++ b/vpp/vaapipostprocess_scaler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Intel Corporation. All rights reserved.
+ * Copyright (C) 2013-2016 Intel Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,11 @@ private:
     ProcParams m_sharpening;
     DeinterlaceParams m_deinterlace;
 
-    static const bool s_registered; // VaapiPostProcessFactory registration result
+    /**
+     * VaapiPostProcessFactory registration result. This postprocess is
+     * registered in vaapipostprocess_host.cpp
+     */
+    static const bool s_registered;
 };
 }
 #endif                          /* vaapipostprocess_scaler_h */


### PR DESCRIPTION
Move factory registration for enc/dec/vpp to the host files.  This ensures the static registration is invoked before any public host interface method calls are executed by library users.

Define host (i.e. host interface) tests for encode, decode, and vpp to demonstrate the issue.  The tests are compiled into a separate unittest_host binary for each codec type.

Also fixes for a few other programmer errors.