### PR TITLE
h264enc: disable prefix nal unit as default.

### DIFF
--- a/encoder/vaapiencoder_h264.cpp
+++ b/encoder/vaapiencoder_h264.cpp
@@ -866,6 +866,7 @@ VaapiEncoderH264::VaapiEncoderH264()
     m_videoParamAVC.deblockBetaOffsetDiv2 = 2;
     m_videoParamAVC.temporalLayerNum = 1;
     m_videoParamAVC.priorityId = 0;
+    m_videoParamAVC.enablePrefixNalUnit = false;
     m_maxOutputBuffer = H264_MIN_TEMPORAL_GOP;
 }
 
@@ -1004,6 +1005,10 @@ void VaapiEncoderH264::resetParams ()
     ensureCodedBufferSize();
 
     m_temporalLayerNum = m_videoParamAVC.temporalLayerNum;
+
+    // enable prefix nal unit for simulcast or svc-t
+    if (m_temporalLayerNum > 1 || m_videoParamAVC.priorityId)
+        m_videoParamAVC.enablePrefixNalUnit = true;
 
     checkProfileLimitation();
     checkSvcTempLimitaion();
@@ -1917,7 +1922,8 @@ bool VaapiEncoderH264::addSliceHeaders (const PicturePtr& picture) const
         /* set calculation for next slice */
         lastMbIndex += curSliceMbs;
 
-        if (!addPackedPrefixNalUnit(picture))
+        if (m_videoParamAVC.enablePrefixNalUnit
+            && !addPackedPrefixNalUnit(picture))
             return false;
         if (!addPackedSliceHeader(picture, sliceParam))
             return false;

--- a/interface/VideoEncoderDefs.h
+++ b/interface/VideoEncoderDefs.h
@@ -233,6 +233,9 @@ typedef struct VideoParamsAVC {
     int8_t deblockBetaOffsetDiv2; //same as slice_beta_offset_div2 defined in h264 spec 7.4.3
     uint32_t temporalLayerNum;
     uint32_t priorityId;
+    // enable prefix NAL unit defined as h264 spec G.3.42.
+    // It can be used for h264 simucast or svc-t encoding.
+    bool enablePrefixNalUnit;
 }VideoParamsAVC;
 
 typedef struct VideoParamsVP9 {


### PR DESCRIPTION
Some h264 decoders may don't support prefix nal unit.
So disable it only if it is required (simulcast or svc-t for example).
