### PR TITLE
h264enc: fix baseline profile decoding failure bug

### DIFF
--- a/encoder/vaapiencoder_h264.cpp
+++ b/encoder/vaapiencoder_h264.cpp
@@ -1661,11 +1661,12 @@ bool VaapiEncoderH264::addPackedPrefixNalUnit(const PicturePtr& picture) const
 
     bit_writer_write_trailing_bits(&bs);
 
+    uint32_t codedBits = bs.getCodedBitsCount();
     uint8_t* codedData = bs.getBitWriterData();
-    ASSERT(codedData);
+    ASSERT(codedData && codedBits);
 
     if (!picture->addPackedHeader(VAEncPackedHeaderRawData, codedData,
-                                  bs.getCodedBitsCount())) {
+                                  codedBits)) {
         ret = false;
     }
 
@@ -1828,11 +1829,12 @@ bool VaapiEncoderH264::addPackedSliceHeader(
         bs.writeToBytesAligned(true);
     }
 
+    uint32_t codedBits = bs.getCodedBitsCount();
     uint8_t* codedData = bs.getBitWriterData();
-    ASSERT(codedData);
+    ASSERT(codedData && codedBits);
 
     if (!picture->addPackedHeader(VAEncPackedHeaderSlice, codedData,
-                                  bs.getCodedBitsCount())) {
+                                  codedBits)) {
         ret = false;
     }
 


### PR DESCRIPTION
svc-t requires to set slice header by yami instead of driver,
but yami always pads some 1/0 bits to make sure slice header is bytes
aligned. Actually, we need to pad some bits 1 to cabac mode, but no need to
pad 0 to cavlc mode, getBitWriterData() may pad some bits 0 when fluch
cached data. That is why
main/high profile work well because cabac is default mode, and baseline
failed due to cabac mode.

Signed-off-by: Zhong Li <zhong.li@intel.com>