### PR TITLE
vpp_unittest: use mocro ASSERT_TRUE() to check caps  to fix #572

### DIFF
--- a/vpp/vaapipostprocess_scaler_unittest.cpp
+++ b/vpp/vaapipostprocess_scaler_unittest.cpp
@@ -127,7 +127,7 @@ protected:
         float value;
 
         EXPECT_TRUE(scaler.mapToRange(value, level, minLevel, maxLevel, filterType, caps));
-        EXPECT_TRUE(bool(caps));
+        ASSERT_TRUE(bool(caps));
         EXPECT_LT(caps->range.min_value, caps->range.max_value);
         EXPECT_LE(caps->range.min_value, value);
         EXPECT_LE(value, caps->range.max_value);


### PR DESCRIPTION
in function checkFilterCaps(), replace EXPECT_TRUE() with ASSERT_TRUE() to
force this function return when pointer 'caps' is NULL.
If use EXPECT_TRUE(bool(caps)), the function will continue when caps is NULL,
then it will access NULL pointer, rase up segmentation fault.

Signed-off-by: wudping <dongpingx.wu@intel.com>