### PR TITLE
[v4l2]: change "#if MACRO_A" to "#if defined(MACRO_A)"

### DIFF
--- a/v4l2/v4l2_codecbase.cpp
+++ b/v4l2/v4l2_codecbase.cpp
@@ -37,11 +37,11 @@
 #include <va/va_android.h>
 #include <ufo/gralloc.h>
 #include <ufo/graphics.h>
-#elif __ENABLE_WAYLAND__
+#elif defined(__ENABLE_WAYLAND__)
 #include <va/va_wayland.h>
 #endif
 
-#if ANDROID
+#ifdef ANDROID
 #if !defined(EFD_SEMAPHORE)
 #define EFD_SEMAPHORE (1 << 0)
 #endif
@@ -83,9 +83,9 @@ typedef SharedPtr < V4l2CodecBase > V4l2CodecPtr;
 V4l2CodecBase::V4l2CodecBase()
     : m_memoryType(VIDEO_DATA_MEMORY_TYPE_RAW_COPY)
     , m_started(false)
-#if ANDROID
+#ifdef ANDROID
     , m_reqBuffCnt(0)
-#elif(__ENABLE_WAYLAND__ || __ENABLE_X11__)
+#elif defined(__ENABLE_WAYLAND__) || defined(__ENABLE_X11__)
     , m_Display(NULL)
 #else
 #endif
@@ -112,7 +112,7 @@ V4l2CodecBase::V4l2CodecBase()
     m_frameCount[OUTPUT] = 0;
 #endif
 
-#if ANDROID
+#ifdef ANDROID
     // it's better done inside vaapi driver (retrieve buffer picth etc)
     hw_get_module(GRALLOC_HARDWARE_MODULE_ID, (hw_module_t const**)&m_pGralloc);
     ASSERT(m_pGralloc);
@@ -280,7 +280,7 @@ static void* _workerThread(void *arg)
     return NULL;
 }
 
-#if __ENABLE_DEBUG__
+#if defined(__ENABLE_DEBUG__)
 const char* V4l2CodecBase::IoctlCommandString(int command)
 {
     static const char* unknown = "Unkonwn command";
@@ -661,7 +661,7 @@ private:
     VADisplay m_display;
 };
 
-#if ANDROID
+#ifdef ANDROID
 bool V4l2CodecBase::setVaDisplay()
 {
     unsigned int display = ANDROID_DISPLAY;
@@ -754,7 +754,7 @@ bool V4l2CodecBase::mapVideoFrames(int32_t width, int32_t height)
     }
     return true;
 }
-#elif __ENABLE_WAYLAND__
+#elif defined(__ENABLE_WAYLAND__)
 bool V4l2CodecBase::setVaDisplay()
 {
     VAStatus status;

--- a/v4l2/v4l2_codecbase.h
+++ b/v4l2/v4l2_codecbase.h
@@ -21,17 +21,17 @@
 #include <vector>
 #include <list>
 #include "common/condition.h"
-#if ANDROID
+#ifdef ANDROID
 #include "VideoPostProcessHost.h"
 #include "VideoDecoderInterface.h"
-#elif __ENABLE_WAYLAND__
+#elif defined(__ENABLE_WAYLAND__)
 #include "VideoPostProcessHost.h"
 #include "VideoDecoderInterface.h"
 #else
-    #if __ENABLE_X11__
+    #ifdef __ENABLE_X11__
     #include <X11/Xlib.h>
     #endif
-    #if __ENABLE_EGL__
+    #ifdef __ENABLE_EGL__
     #include <EGL/egl.h>
     #define EGL_EGLEXT_PROTOTYPES
     #include "EGL/eglext.h"
@@ -39,7 +39,7 @@
 #endif
 #include "VideoCommonDefs.h"
 #include "v4l2codec_device_ops.h"
-#if ANDROID
+#ifdef ANDROID
 #include <va/va_android.h>
 #endif
 
@@ -83,10 +83,10 @@ class V4l2CodecBase {
                          int prot, int flags, unsigned int offset) {return NULL;};
     // virtual int32_t munmap(void* addr, size_t length) {return 0;};
     virtual bool stop() = 0;
-#if ANDROID
+#ifdef ANDROID
     bool setVaDisplay();
     bool createVpp();
-#elif __ENABLE_WAYLAND__
+#elif defined(__ENABLE_WAYLAND__)
     bool setWaylandDisplay(struct wl_display* wlDisplay)
     {
         m_Display = wlDisplay;
@@ -95,7 +95,7 @@ class V4l2CodecBase {
     bool setVaDisplay();
     bool createVpp();
 #else
-    #if __ENABLE_X11__
+    #if defined(__ENABLE_X11__)
     bool setXDisplay(Display* x11Display)
     {
         m_Display = x11Display;
@@ -103,7 +103,7 @@ class V4l2CodecBase {
     };
     virtual int32_t usePixmap(uint32_t bufferIndex, Pixmap pixmap) {return 0;};
     #endif
-    #if __ENABLE_EGL__
+    #if defined(__ENABLE_EGL__)
     virtual int32_t useEglImage(EGLDisplay eglDisplay, EGLContext eglContext, uint32_t buffer_index, void* egl_image) {return 0;};
     #endif
 #endif
@@ -128,10 +128,10 @@ class V4l2CodecBase {
     virtual void clearCodecEvent();
     virtual void releaseCodecLock(bool lockable) {};
     virtual void flush() {}
-#if ANDROID
+#ifdef ANDROID
     SharedPtr<VideoFrame> createVaSurface(const buffer_handle_t buf_handle, int32_t width, int32_t height);
     bool mapVideoFrames(int32_t width, int32_t height);
-#elif __ENABLE_WAYLAND__
+#elif defined(__ENABLE_WAYLAND__)
     SharedPtr<VideoFrame> createVaSurface(uint32_t width, uint32_t height);
     bool mapVideoFrames(uint32_t width, uint32_t height);
 #endif
@@ -145,14 +145,14 @@ class V4l2CodecBase {
     bool m_threadOn[2];
     int32_t m_fd[2]; // 0 for device event, 1 for interrupt
     bool m_started;
-#if __ENABLE_X11__ || __ENABLE_WAYLAND__
+#if defined(__ENABLE_X11__) || defined(__ENABLE_WAYLAND__)
     void* m_Display;
 #endif
-#if ANDROID
+#ifdef ANDROID
     std::vector<buffer_handle_t> m_bufferHandle;
     gralloc_module_t* m_pGralloc;
 #endif
-#if ANDROID || __ENABLE_WAYLAND__
+#if defined(ANDROID) || defined(__ENABLE_WAYLAND__)
     VADisplay m_vaDisplay;
     SharedPtr<IVideoPostProcess> m_vpp;
     uint32_t m_reqBuffCnt;

--- a/v4l2/v4l2_decode.cpp
+++ b/v4l2/v4l2_decode.cpp
@@ -30,13 +30,13 @@
 #ifdef ANDROID
 #include <ufo/gralloc.h>
 #include <ufo/graphics.h>
-#elif __ENABLE_WAYLAND__
+#elif defined(__ENABLE_WAYLAND__)
 #include <va/va_wayland.h>
 #endif
 #include "v4l2_decode.h"
 #include "VideoDecoderHost.h"
 #include "common/log.h"
-#if __ENABLE_EGL__
+#if defined(__ENABLE_EGL__)
 #include "egl/egl_vaapi_image.h"
 #endif
 
@@ -130,12 +130,12 @@ bool V4l2Decoder::start()
     NativeDisplay nativeDisplay;
     nativeDisplay.type = NATIVE_DISPLAY_AUTO;
 
-#if ANDROID || __ENABLE_WAYLAND__
+#if defined(ANDROID) || defined(__ENABLE_WAYLAND__)
     if (m_vaDisplay) {
         nativeDisplay.type = NATIVE_DISPLAY_VA;
         nativeDisplay.handle = (intptr_t)m_vaDisplay;
     }
-#elif __ENABLE_X11__
+#elif defined(__ENABLE_X11__)
     DEBUG("m_Display: %p", m_Display);
     if (m_Display) {
         nativeDisplay.type = NATIVE_DISPLAY_X11;
@@ -328,10 +328,10 @@ bool V4l2Decoder::giveOutputBuffer(struct v4l2_buffer *dqbuf)
 
     dqbuf->flags = m_outputRawFrames[dqbuf->index].flags;
 
-#if ANDROID
+#if defined(ANDROID)
     INT64_TO_TIMEVAL(m_videoFrames[dqbuf->index]->timeStamp, dqbuf->timestamp);
     dqbuf->flags = m_videoFrames[dqbuf->index]->flags;
-#elif __ENABLE_WAYLAND__
+#elif defined(__ENABLE_WAYLAND__)
     VAStatus vaStatus;
     struct wl_buffer* buffer;
     INT64_TO_TIMEVAL(m_videoFrames[dqbuf->index]->timeStamp, dqbuf->timestamp);
@@ -388,7 +388,7 @@ int32_t V4l2Decoder::ioctl(int command, void* arg)
             if (m_outputBufferCountOnInit == m_reqBuffCnt)
                 mapVideoFrames(m_videoWidth, m_videoHeight);
         }
-#elif __ENABLE_WAYLAND__
+#elif defined(__ENABLE_WAYLAND__)
         // FIXME, m_outputBufferCountOnInit should be reset on output buffer change (for example: resolution change)
         // it is not must to init video frame here since we don't accepted external buffer for wayland yet.
         // however, external buffer may be used in the future
@@ -428,7 +428,7 @@ int32_t V4l2Decoder::ioctl(int command, void* arg)
                 m_reqBuffCnt = reqbufs->count;
             else
                 m_videoFrames.clear();
-#elif __ENABLE_EGL__
+#elif defined(__ENABLE_EGL__)
             if (!reqbufs->count) {
                 m_eglVaapiImages.clear();
             } else {
@@ -662,7 +662,7 @@ void V4l2Decoder::flush()
         m_decoder->flush();
 }
 
-#if __ENABLE_EGL__
+#ifdef __ENABLE_EGL__
 int32_t V4l2Decoder::useEglImage(EGLDisplay eglDisplay, EGLContext eglContext, uint32_t bufferIndex, void* eglImage)
 {
     m_bindEglImage = true;

--- a/v4l2/v4l2_decode.h
+++ b/v4l2/v4l2_decode.h
@@ -21,7 +21,7 @@
 #include "v4l2_codecbase.h"
 #include "VideoDecoderInterface.h"
 
-#if __ENABLE_EGL__
+#ifdef __ENABLE_EGL__
 namespace YamiMediaCodec {
     class EglVaapiImage;
 }
@@ -38,7 +38,7 @@ class V4l2Decoder : public V4l2CodecBase
     virtual int32_t ioctl(int request, void* arg);
     virtual void* mmap(void* addr, size_t length,
                          int prot, int flags, unsigned int offset);
-#if __ENABLE_EGL__
+#ifdef __ENABLE_EGL__
     virtual int32_t useEglImage(EGLDisplay eglDisplay, EGLContext eglContext, uint32_t buffer_index, void* egl_image);
 #endif
 
@@ -77,7 +77,7 @@ class V4l2Decoder : public V4l2CodecBase
     uint32_t m_outputBufferCountQBuf;
     uint32_t m_outputBufferCountPulse;
     uint32_t m_outputBufferCountGive;
-#if __ENABLE_EGL__
+#ifdef __ENABLE_EGL__
     std::vector <SharedPtr<EglVaapiImage> > m_eglVaapiImages;
 #endif
 };

--- a/v4l2/v4l2_encode.cpp
+++ b/v4l2/v4l2_encode.cpp
@@ -62,7 +62,7 @@ bool V4l2Encoder::start()
     ASSERT(status == YAMI_SUCCESS);
 
     NativeDisplay nativeDisplay;
-#if ANDROID
+#ifdef ANDROID
     nativeDisplay.type = NATIVE_DISPLAY_VA;
     nativeDisplay.handle = (intptr_t)m_vaDisplay;
 #else
@@ -111,7 +111,7 @@ bool V4l2Encoder::inputPulse(uint32_t index)
     if(m_videoParamsChanged )
         UpdateVideoParameters(true);
 
-#if ANDROID
+#ifdef ANDROID
     if (m_memoryType == VIDEO_DATA_MEMORY_TYPE_ANDROID_BUFFER_HANDLE) {
         status = m_encoder->encode(m_videoFrames[index]);
     }
@@ -163,7 +163,7 @@ bool V4l2Encoder::acceptInputBuffer(struct v4l2_buffer *qbuf)
 {
     uint32_t i;
     VideoEncRawBuffer *inputBuffer = &(m_inputFrames[qbuf->index]);
-#if ANDROID
+#ifdef ANDROID
     if (m_memoryType == VIDEO_DATA_MEMORY_TYPE_ANDROID_BUFFER_HANDLE)
         return true;
 #endif
@@ -221,7 +221,7 @@ int32_t V4l2Encoder::ioctl(int command, void* arg)
     DEBUG("fd: %d, ioctl command: %s", m_fd[0], IoctlCommandString(command));
     switch (command) {
     case VIDIOC_QBUF:
-#if ANDROID
+#if defined(ANDROID)
     {
         struct v4l2_buffer* qbuf = static_cast<struct v4l2_buffer*>(arg);
         if (qbuf->type == V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE) {

--- a/v4l2/v4l2_wrapper.cpp
+++ b/v4l2/v4l2_wrapper.cpp
@@ -18,7 +18,7 @@
 #endif
 
 #include "v4l2_wrapper.h"
-#if __ENABLE_V4L2_OPS__
+#if defined(__ENABLE_V4L2_OPS__)
 #include "v4l2codec_device_ops.h"
 #endif
 #include "v4l2_codecbase.h"
@@ -148,8 +148,8 @@ int32_t YamiV4L2_Munmap(void* addr, size_t length)
     return 0;
 }
 
-#if ANDROID
-#elif __ENABLE_WAYLAND__
+#ifdef  ANDROID
+#elif defined(__ENABLE_WAYLAND__)
 int32_t YamiV4L2_SetWaylandDisplay(int32_t fd, struct wl_display* wlDisplay)
 {
     V4l2CodecPtr v4l2Codec = _findCodecFromFd(fd);
@@ -161,7 +161,7 @@ int32_t YamiV4L2_SetWaylandDisplay(int32_t fd, struct wl_display* wlDisplay)
     return ret;
 }
 #else
-#if __ENABLE_X11__
+#if defined(__ENABLE_X11__)
 int32_t YamiV4L2_SetXDisplay(int32_t fd, Display *x11Display)
 {
     V4l2CodecPtr v4l2Codec = _findCodecFromFd(fd);
@@ -174,7 +174,7 @@ int32_t YamiV4L2_SetXDisplay(int32_t fd, Display *x11Display)
      return ret;
 }
 #endif
-#if __ENABLE_EGL__
+#if defined(__ENABLE_EGL__)
 int32_t YamiV4L2_UseEglImage(int fd, /*EGLDisplay*/void* eglDisplay, /*EGLContext*/void* eglContext, unsigned int bufferIndex, void* eglImage)
 {
     V4l2CodecPtr v4l2Codec = _findCodecFromFd(fd);
@@ -194,7 +194,7 @@ int32_t YamiV4L2_SetDrmFd(int32_t fd, int drm_fd)
      return ret;
 }
 #endif
-#if __ENABLE_V4L2_OPS__
+#if defined(__ENABLE_V4L2_OPS__)
 extern "C" int32_t YamiV4L2_SetParameter(int32_t fd, const char* key, const char* value);
 int32_t YamiV4L2_SetParameter(int32_t fd, const char* key, const char* value)
 {
@@ -234,7 +234,7 @@ int32_t YamiV4L2_SetParameter(int32_t fd, const char* key, const char* value)
         struct wl_display* wlDisplay = (struct wl_display*)ptr;
         DEBUG("wlDisplay: %p", wlDisplay);
         ret = v4l2Codec->setWaylandDisplay(wlDisplay);
-#elif __ENABLE_X11__
+#elif defined(__ENABLE_X11__)
     } else if (!strcmp(key, "x11-display")) {
         uintptr_t ptr = (uintptr_t)atoll(value);
         Display* x11Display = (Display*)ptr;
@@ -276,7 +276,7 @@ bool v4l2codecOperationInit(V4l2CodecOps *opFuncs)
     V4L2_DLSYM_OR_RETURN_ON_ERROR(Mmap);
     V4L2_DLSYM_OR_RETURN_ON_ERROR(Munmap);
     V4L2_DLSYM_OR_RETURN_ON_ERROR(SetParameter);
-#if __ENABLE_EGL_
+#if defined(__ENABLE_EGL__)
     V4L2_DLSYM_OR_RETURN_ON_ERROR(UseEglImage);
 #endif
 #undef V4L2_DLSYM_OR_RETURN_ON_ERROR

--- a/v4l2/v4l2_wrapper.h
+++ b/v4l2/v4l2_wrapper.h
@@ -16,9 +16,9 @@
 
 #include <stdint.h>
 #include <stddef.h>
-#if ANDROID
+#ifdef ANDROID
 #else
-    #if __ENABLE_X11__
+    #if defined(__ENABLE_X11__)
     #include <X11/Xlib.h>
     #endif
 #endif
@@ -43,11 +43,11 @@ int32_t YamiV4L2_ClearDevicePollInterrupt(int32_t fd);
 void* YamiV4L2_Mmap(void* addr, size_t length,
                      int prot, int flags, int fd, unsigned int offset);
 int32_t YamiV4L2_Munmap(void* addr, size_t length);
-#if ANDROID
-#elif __ENABLE_WAYLAND__
+#ifdef ANDROID
+#elif defined(__ENABLE_WAYLAND__)
 int32_t YamiV4L2_SetWaylandDisplay(int32_t fd, struct wl_display* wlDisplay);
 #else
-    #if __ENABLE_X11__
+    #ifdef __ENABLE_X11__
     /// it should be called before driver initialization (immediate after _Open()).
     int32_t YamiV4L2_SetXDisplay(int32_t fd, Display *x11Display);
     #endif

--- a/vaapi/vaapidisplay.cpp
+++ b/vaapi/vaapidisplay.cpp
@@ -83,7 +83,7 @@ bool isInvalidDrmHandle(int handle)
     return handle == 0 || handle == -1;
 }
 
-#if __ENABLE_X11__
+#if defined(__ENABLE_X11__)
 class NativeDisplayX11 : public NativeDisplayBase{
   public:
     NativeDisplayX11() :NativeDisplayBase(){ };
@@ -302,7 +302,7 @@ DisplayPtr DisplayCache::createDisplay(const NativeDisplay& nativeDisplay)
 
     switch (nativeDisplay.type) {
     case NATIVE_DISPLAY_AUTO:
-#if __ENABLE_X11__
+#if defined(__ENABLE_X11__)
     case NATIVE_DISPLAY_X11:
         nativeDisplayObj.reset (new NativeDisplayX11());
         if (nativeDisplayObj && nativeDisplayObj->initialize(nativeDisplay))

--- a/vaapi/vaapidisplay_unittest.cpp
+++ b/vaapi/vaapidisplay_unittest.cpp
@@ -47,7 +47,7 @@ protected:
     }
 
     virtual void SetUp() {
-#if __ENABLE_X11__
+#if defined(__ENABLE_X11__)
         m_x11_handle = 0;
 #endif
     }
@@ -71,7 +71,7 @@ protected:
             m_drm_handles.erase(match);
     }
 
-#if __ENABLE_X11__
+#if defined(__ENABLE_X11__)
     intptr_t openX11Handle() {
         m_x11_handle = (intptr_t)XOpenDisplay(NULL);
         return m_x11_handle;
@@ -85,7 +85,7 @@ protected:
             close(*it);
         m_drm_handles.clear();
 
-#if __ENABLE_X11__
+#if defined(__ENABLE_X11__)
         if (m_x11_handle)
             XCloseDisplay((Display*)(m_x11_handle));
 #endif
@@ -93,7 +93,7 @@ protected:
 
     DrmHandles m_drm_handles;
 
-#if __ENABLE_X11__
+#if defined(__ENABLE_X11__)
     intptr_t m_x11_handle;
 #endif
 };
@@ -101,7 +101,7 @@ protected:
 #define VAAPI_DISPLAY_TEST(name) \
     TEST_F(VaapiDisplayTest, name)
 
-#if __ENABLE_X11__
+#if defined(__ENABLE_X11__)
 VAAPI_DISPLAY_TEST(CreateInvalidHandleX11) {
     //this turn off gest warning about multithread
     //you can check details at
@@ -152,7 +152,7 @@ VAAPI_DISPLAY_TEST(CreateInvalidHandleVA) {
     ASSERT_DEATH({ display = VaapiDisplay::create(native); }, "");
 }
 
-#if __ENABLE_X11__
+#if defined(__ENABLE_X11__)
 VAAPI_DISPLAY_TEST(CreateX11) {
     // Let yami create the native display
     NativeDisplay native = {0, NATIVE_DISPLAY_X11};
@@ -248,7 +248,7 @@ VAAPI_DISPLAY_TEST(CreateVA) {
     EXPECT_EQ(display->getID(), display2->getID());
 }
 
-#if __ENABLE_X11__
+#if defined(__ENABLE_X11__)
 VAAPI_DISPLAY_TEST(CompatibleX11) {
     NativeDisplay native = {openX11Handle(), NATIVE_DISPLAY_X11};
     DisplayPtr display = VaapiDisplay::create(native);


### PR DESCRIPTION
"#if MACRO_A || MACRO_B" fail to compile when MACRO_A is not defined

fix a typo for build with __ENABLE_EGL__