### PR TITLE
HEVC ENC:10bit support merged

### DIFF
--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -37,6 +37,7 @@ uint32_t guessFourcc(const char* fileName)
 {
     static const char* possibleFourcc[] = {
         "I420", "NV12", "YV12",
+        "P010",
         "YUY2", "UYVY",
         "RGBX", "BGRX", "XRGB", "XBGR",
         //for jpeg

--- a/interface/VideoEncoderDefs.h
+++ b/interface/VideoEncoderDefs.h
@@ -216,6 +216,7 @@ typedef struct VideoParamsCommon {
     VideoRateControlParams rcParams;
     uint32_t leastInputCount;
     bool enableLowPower;
+    uint8_t bitDepth;
 }VideoParamsCommon;
 
 typedef struct VideoParamsAVC {


### PR DESCRIPTION
add the P010 input
add support for HEVC 10bit encoding
add pixelwidthinbyte to help caculate the width of image when 8/10 bit

Signed-off-by: Pengfei Qu <Pengfei.Qu@intel.com>
Signed-off-by: wudping <dongpingx.wu@intel.com>