### PR TITLE
dec_vp9: support vp9 10bit depth odd resolution

### DIFF
--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -140,7 +140,6 @@ const static ResolutionEntry resolutionEntrys[] = {
     { YAMI_FOURCC_422H, 3, { 2, 1, 1 }, { 2, 2, 2 } },
     { YAMI_FOURCC_422V, 3, { 2, 2, 2 }, { 2, 1, 1 } },
     { YAMI_FOURCC_444P, 3, { 2, 2, 2 }, { 2, 2, 2 } },
-    { YAMI_FOURCC_P010, 2, { 4, 4 }, { 2, 1 } },
     { YAMI_FOURCC_YUY2, 1, { 4 }, { 2 } },
     { YAMI_FOURCC_UYVY, 1, { 4 }, { 2 } },
     { YAMI_FOURCC_RGBX, 1, { 8 }, { 2 } },
@@ -169,6 +168,14 @@ bool getPlaneResolution(uint32_t fourcc, uint32_t pixelWidth, uint32_t pixelHeig
         width[0] = w;
         height[0] = h;
         width[1] = w + (w & 1);
+        height[1] = (h + 1) >> 1;
+        planes = 2;
+        return true;
+    }
+    if (fourcc == YAMI_FOURCC_P010) {
+        width[0] = w * 2;
+        height[0] = h;
+        width[1] = (w + (w & 1)) * 2;
         height[1] = (h + 1) >> 1;
         planes = 2;
         return true;


### PR DESCRIPTION
Change the way to calculate the size of P010;
for the odd resolution, need to change the chrominance's measurements to
even number, but the luminance's need not.
For example, P010 179x223, the size of luminance plan should be:
179x223x2
the size of chrominance plan should be:
180x224
So the size of P010 179x223 is:
179x223x2 + 180x224.

But for the even resolution, the size of P010 is:
Width * Hieght * 3
For example P010 1960x1080, the size is:
1960x1080x3

Signed-off-by: wudping <dongpingx.wu@intel.com>