### PR TITLE
vp9_dec: modify the way to align resolution with 64, fix VIZ-8822

### DIFF
--- a/codecparsers/vp9parser.cpp
+++ b/codecparsers/vp9parser.cpp
@@ -302,8 +302,8 @@ uint32_t get_min_lb_tile_cols(uint32_t sb_cols)
     return log2;
 }
 
-/* align to 64 */
-#define SB_ALIGN(w) (((w | 0x3f) + 1) >> 6)
+/* align to 64, follow specification 6.2.6 Compute image size syntax */
+#define SB_ALIGN(w) (((w) + 63) >> 6)
 static BOOL read_tile_info(Vp9FrameHdr* frame_hdr, BitReader* br)
 {
     const uint32_t sb_cols = SB_ALIGN(frame_hdr->width);


### PR DESCRIPTION
In vp9 decoder, replace "SB_ALIGN(w) (((w | 0x3f) + 1) >> 6)" with
"#define SB_ALIGN(w) (((w) + 63) >> 6)".
Because when "w" is 0, the result of aligning should be 0, but (0|0x3f + 1)>>6 is
1. So when the low six bits of "w" is 0, the result will be wrong.

to fix VIZ-8822

Signed-off-by: wudping <dongpingx.wu@intel.com>