### PR TITLE
encode: Add vaapi version checking to fix compiling

### DIFF
--- a/encoder/vaapiencoder_base.cpp
+++ b/encoder/vaapiencoder_base.cpp
@@ -488,14 +488,6 @@ bool VaapiEncoderBase::initVA()
         attribCount = 1;
     }
 
-    if (m_videoParamCommon.enableLowPower) {
-         if (ipPeriod() > 1) {
-            WARNING("Low power mode can not support B frame encoding");
-            m_videoParamCommon.ipPeriod = 1; // without B frame
-        }
-        m_entrypoint = VAEntrypointEncSliceLP;
-    }
-
     ConfigPtr config = VaapiConfig::create(m_display, m_videoParamCommon.profile, m_entrypoint, pAttrib, attribCount);
     if (!config) {
         ERROR("failed to create config");

--- a/encoder/vaapiencoder_h264.cpp
+++ b/encoder/vaapiencoder_h264.cpp
@@ -997,6 +997,17 @@ void VaapiEncoderH264::checkSvcTempLimitaion()
 
 void VaapiEncoderH264::resetParams ()
 {
+    if (m_videoParamCommon.enableLowPower) {
+#if VA_CHECK_VERSION(0, 39, 2)
+        if (ipPeriod() > 1) {
+            WARNING("Low power mode can not support B frame encoding");
+            m_videoParamCommon.ipPeriod = 1; // without B frame
+        }
+        m_entrypoint = VAEntrypointEncSliceLP;
+#else
+        ERROR("For AVC lowpower mode, please make sure libva version >= 0.39.2");
+#endif
+    }
 
     m_levelIdc = level();
 


### PR DESCRIPTION
1.reset the ipPeriod earlier as ipPeriod will be used in resetParams() functions.
2.add vaapi version checking to fix compiling.
Signed-off-by: jkyu <jiankang.yu@intel.com>