### PR TITLE
common: change return value of guessFourcc

### DIFF
--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -56,7 +56,7 @@ uint32_t guessFourcc(const char* fileName)
         }
     }
 
-    return YAMI_FOURCC_I420;
+    return 0;
 }
 
 bool guessResolution(const char* filename, int& w, int& h)

--- a/common/utils_unittest.cpp
+++ b/common/utils_unittest.cpp
@@ -47,7 +47,7 @@ UTILS_TEST(guessFourcc) {
     EXPECT_EQ(guessFourcc("test.xbgr"), (uint32_t)YAMI_FOURCC_XBGR);
 
     EXPECT_EQ(guessFourcc("test.txt"), (uint32_t)YAMI_FOURCC_I420);
-    EXPECT_EQ(guessFourcc("test"), (uint32_t)YAMI_FOURCC_I420);
+    EXPECT_EQ(guessFourcc("test"), (uint32_t)0);
 
     EXPECT_EQ(guessFourcc("test.I420"), (uint32_t)YAMI_FOURCC_I420);
     EXPECT_EQ(guessFourcc("test.NV12"), (uint32_t)YAMI_FOURCC_NV12);


### PR DESCRIPTION
Replace return value YAMI_FOURCC_I420 with 0 of funciton guessFourcc().
Because we don't know if the return value YAMI_FOURCC_I420 is the default
value or the actual. If we can't guess the fourcc from the file name,
the default value should be set by user according to different use case.

Signed-off-by: wudping <dongpingx.wu@intel.com>