### PR TITLE
interface/VideoCommonDefs.h: include stdbool.h

### DIFF
--- a/interface/VideoCommonDefs.h
+++ b/interface/VideoCommonDefs.h
@@ -19,6 +19,7 @@
 // config.h should NOT be included in header file, especially for the header file used by external
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 
@@ -45,20 +46,6 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
-
-#ifndef __cplusplus
-#ifndef bool
-#define bool  int
-#endif
-
-#ifndef true
-#define true  1
-#endif
-
-#ifndef false
-#define false 0
-#endif
 #endif
 
 #define YAMI_FOURCC(ch0, ch1, ch2, ch3) \


### PR DESCRIPTION
stdbool.h defines 'bool' and it's compatible with C/C++.
Previously, we define bool as int for C compiler, which
is not identical with C++. The former occupies 4 bytes, and
the later occupies 1 bytes at x86_64 platform, which will
cause some unexpected behaviours at using capi.

Reported-by: Zhao, Xinda <xinda.zhao@intel.com>
Signed-off-by: Li Zhijian <zhijianx.li@intel.com>