### PR TITLE
vpp_ProcAmp: add parameter to clear all colorbalance filters

### DIFF
--- a/vpp/vaapipostprocess_scaler.cpp
+++ b/vpp/vaapipostprocess_scaler.cpp
@@ -322,7 +322,7 @@ YamiStatus VaapiPostProcessScaler::setColorBalanceParam(const VPPColorBalancePar
             if (mapToVppColorBalanceMode(vppClrBalanceMode, caps[i].type)) {
                 m_colorBalance[vppClrBalanceMode].range = caps[i].range;
                 m_colorBalance[vppClrBalanceMode].type = caps[i].type;
-                m_colorBalance[vppClrBalanceMode].level = COLORBALANCE_NONE;
+                m_colorBalance[vppClrBalanceMode].level = COLORBALANCE_LEVEL_NONE;
             }
         }
     }

--- a/vpp/vaapipostprocess_scaler.cpp
+++ b/vpp/vaapipostprocess_scaler.cpp
@@ -326,6 +326,17 @@ YamiStatus VaapiPostProcessScaler::setColorBalanceParam(const VPPColorBalancePar
             }
         }
     }
+
+    if(COLORBALANCE_NONE == colorbalance.mode){
+        for (ColorBalanceMapItr itr = m_colorBalance.begin(); itr != m_colorBalance.end(); itr++) {
+            if (itr->second.filter) {
+                itr->second.filter.reset();
+                itr->second.level = COLORBALANCE_LEVEL_NONE;
+            }
+        }
+        return YAMI_SUCCESS;
+    }
+
     ColorBalanceMapItr iteratorClrBalance = m_colorBalance.find(colorbalance.mode);
     if (iteratorClrBalance == m_colorBalance.end()) {
         ERROR("unsupported VppColorBalanceMode: %d", colorbalance.mode);


### PR DESCRIPTION
Implement a functionality for COLORBALANCE_NONE to clear all color
balance filters.

for [VIZ-8466](https://jira01.devtools.intel.com/browse/VIZ-8466)

Signed-off-by: wudping <dongpingx.wu@intel.com>