### PR TITLE
V4L2-INPUT thread crashed after seeking

### DIFF
--- a/decoder/vaapidecoder_h264.cpp
+++ b/decoder/vaapidecoder_h264.cpp
@@ -1683,6 +1683,10 @@ YamiStatus VaapiDecoderH264::createPicture(const SliceHeader* const slice,
     VaapiPictureType picStructure;
     bool isSecondField = false;
 
+    /* skip all non-idr slices if m_prevPic is a NULL */
+    if(!m_prevPic && !nalu->m_idrPicFlag)
+        return YAMI_DECODE_INVALID_DATA;
+
     if (slice->field_pic_flag) {
         if (slice->bottom_field_flag)
             picStructure = VAAPI_PICTURE_BOTTOM_FIELD;


### PR DESCRIPTION
m_prevPic may be NULL if NalUnitType is NAL_SEI. Add a condition check
to make sure m_prevPic is not NULL before calling m_dpb.init.

Change-Id: Ibde719dac254c04e0b5348bffc1c47870bd087be
Signed-off-by: Matthew Lai <matthew.lai@intel.com>