### PR TITLE
add thread abstract for libyami

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -5,6 +5,7 @@ libyami_common_source_c = \
 	surfacepool.cpp \
 	PooledFrameAllocator.cpp \
 	YamiVersion.cpp \
+	Thread.cpp \
 	$(NULL)
 
 libyami_common_source_h = \
@@ -21,12 +22,14 @@ libyami_common_source_h_priv = \
 	nalreader.h \
 	videopool.h \
 	surfacepool.h \
+	Thread.h \
 	$(NULL)
 
 libyami_common_ldflags = \
 	$(LIBYAMI_LT_LDFLAGS) \
 	$(LIBVA_LIBS) \
 	$(LIBVA_DRM_LIBS) \
+	-lpthread \
 	$(NULL)
 
 #to compile within yocto

--- a/common/Makefile.unittest
+++ b/common/Makefile.unittest
@@ -5,6 +5,7 @@ unittest_SOURCES = \
 	factory_unittest.cpp \
 	nalreader_unittest.cpp \
 	utils_unittest.cpp \
+        Thread_unittest.cpp \
 	$(NULL)
 
 unittest_LDFLAGS = \

--- a/common/Thread.cpp
+++ b/common/Thread.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2014 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "Thread.h"
+#include "Functional.h"
+#include "log.h"
+
+#include <assert.h>
+
+namespace YamiMediaCodec {
+
+Thread::Thread(const char* name)
+    : m_name(name)
+    , m_started(false)
+    , m_thread(INVALID_ID)
+    , m_cond(m_lock)
+    , m_sent(m_lock)
+{
+}
+
+bool Thread::start()
+{
+    AutoLock lock(m_lock);
+    if (m_started)
+        return false;
+    if (pthread_create(&m_thread, NULL, init, this)) {
+        ERROR("create thread %s failed", m_name.c_str());
+        m_thread = INVALID_ID;
+        return false;
+    }
+    m_started = true;
+    return true;
+}
+
+void* Thread::init(void* thread)
+{
+    Thread* t = (Thread*)thread;
+    t->loop();
+    return NULL;
+}
+
+void Thread::loop()
+{
+    while (1) {
+        AutoLock lock(m_lock);
+        if (m_queue.empty()) {
+            if (!m_started)
+                return;
+            m_cond.wait();
+        }
+        else {
+            Job& r = m_queue.front();
+            m_lock.release();
+            r();
+            m_lock.acquire();
+            m_queue.pop_front();
+        }
+    }
+}
+
+void Thread::enqueue(const Job& r)
+{
+    m_queue.push_back(r);
+    m_cond.signal();
+}
+
+void Thread::post(const Job& r)
+{
+    AutoLock lock(m_lock);
+    if (!m_started) {
+        ERROR("%s: post job after stop()", m_name.c_str());
+        return;
+    }
+    enqueue(r);
+}
+
+void Thread::sendJob(const Job& r, bool& flag)
+{
+    r();
+
+    //flag need protect here since we check it in other thread
+    AutoLock lock(m_lock);
+    flag = true;
+    m_sent.broadcast();
+}
+
+bool Thread::send(const Job& c)
+{
+    bool flag = false;
+
+    AutoLock lock(m_lock);
+    if (!m_started) {
+        ERROR("%s: sent job after stop()", m_name.c_str());
+        return false;
+    }
+    enqueue(std::bind(&Thread::sendJob, this, std::ref(c), std::ref(flag)));
+    //wait for result;
+    while (!flag) {
+        m_sent.wait();
+    }
+    return true;
+}
+
+void Thread::stop()
+{
+    {
+        AutoLock lock(m_lock);
+        if (!m_started)
+            return;
+        m_started = false;
+        m_cond.signal();
+    }
+    pthread_join(m_thread, NULL);
+    m_thread = INVALID_ID;
+    assert(m_queue.empty());
+}
+
+bool Thread::isCurrent()
+{
+    return pthread_self() == m_thread;
+}
+
+Thread::~Thread()
+{
+    stop();
+}
+}

--- a/common/Thread.h
+++ b/common/Thread.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2014 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef Thread_h
+#define Thread_h
+
+#include "condition.h"
+#include "lock.h"
+#include "Functional.h"
+
+#include <string>
+#include <deque>
+#include <pthread.h>
+
+namespace YamiMediaCodec {
+
+typedef std::function<void(void)> Job;
+
+class Thread {
+public:
+    explicit Thread(const char* name = "");
+    ~Thread();
+    bool start();
+    //stop thread, this will waiting all post/sent job done
+    void stop();
+    //post job to this thread
+    void post(const Job&);
+    //send job and wait it done
+    bool send(const Job&);
+    bool isCurrent();
+
+private:
+    //thread loop
+    static void* init(void*);
+    void loop();
+    void enqueue(const Job& r);
+    void sendJob(const Job& r, bool& flag);
+
+    std::string m_name;
+    bool m_started;
+    pthread_t m_thread;
+
+    Lock m_lock;
+    Condition m_cond;
+    Condition m_sent;
+    std::deque<Job> m_queue;
+
+    static const pthread_t INVALID_ID = (pthread_t)-1;
+
+    DISALLOW_COPY_AND_ASSIGN(Thread);
+};
+};
+
+#endif

--- a/common/Thread_unittest.cpp
+++ b/common/Thread_unittest.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2016 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+// primary header
+#include "Thread.h"
+
+#include "common/unittest.h"
+#include "common/log.h"
+
+namespace YamiMediaCodec {
+
+using namespace std;
+
+#define THREAD_TEST(name) \
+    TEST(ThreadTest, name)
+
+void add(int& v)
+{
+    v++;
+}
+
+void sleepAndAdd(Thread& t, int seconds, int& v)
+{
+    sleep(seconds);
+    EXPECT_FALSE(t.isCurrent());
+    t.post(bind(add, ref(v)));
+}
+
+void checkSum(int& v, int expected)
+{
+    EXPECT_EQ(expected, v);
+}
+
+void isCurrent(Thread& t)
+{
+    EXPECT_TRUE(t.isCurrent());
+}
+
+void emptyJob()
+{
+    /* nothing */
+}
+
+void sendJob(Thread& t, Job job)
+{
+    t.send(job);
+}
+
+THREAD_TEST(FullTest)
+{
+    std::cout << "this may take some time" << std::endl;
+
+    Thread t[3];
+
+    //check start
+    for (int i = 0; i < 3; i++) {
+        EXPECT_TRUE(t[i].start());
+    }
+
+    //post
+    int v = 0;
+    for (int i = 0; i < 5; i++) {
+        t[0].post(bind(sleepAndAdd, ref(t[2]), 1, ref(v)));
+    }
+    for (int i = 0; i < 5; i++) {
+        t[1].post(bind(sleepAndAdd, ref(t[2]), 2, ref(v)));
+    }
+
+    //make sure we can send message from diffrent thread
+    t[0].send(bind(sendJob, ref(t[2]), emptyJob));
+    t[1].send(bind(sendJob, ref(t[2]), emptyJob));
+
+    //is current
+    t[2].send(bind(isCurrent, ref(t[2])));
+
+    for (int i = 0; i < 3; i++) {
+        EXPECT_TRUE(t[i].send(bind(isCurrent, ref(t[i]))));
+        t[i].stop();
+    }
+    EXPECT_EQ(10, v);
+
+    //send after stop
+    EXPECT_FALSE(t[2].send(bind(checkSum, ref(v), 11)));
+}
+}


### PR DESCRIPTION
This will use java's executor pattern, but it only supports one thread. http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/Executor.html
It will post jobs to the work thread, the work thread does not need care about lock and condition, it single thread. this will make multithread programer's life easy, we will use this in v4l2decoder/v4l2encoder in future.