### PR TITLE
265_dec: modify the length of sublayer_hrd_params

### DIFF
--- a/codecparsers/h265Parser.cpp
+++ b/codecparsers/h265Parser.cpp
@@ -1473,10 +1473,17 @@ bool Parser::parseSlice(const NalUnit* nalu, SliceHeader* slice)
             if (!slice->deblocking_filter_disabled_flag) {
                 READ_SE(slice->beta_offset_div2);
                 READ_SE(slice->tc_offset_div2);
-                CHECK_RANGE(slice->beta_offset_div2, -6, 6);
-                CHECK_RANGE(slice->tc_offset_div2, -6, 6);
             }
         }
+        else {
+            slice->deblocking_filter_disabled_flag = pps->pps_deblocking_filter_disabled_flag;
+            if (!slice->deblocking_filter_disabled_flag) {
+                slice->beta_offset_div2 = pps->pps_beta_offset_div2;
+                slice->tc_offset_div2 = pps->pps_tc_offset_div2;
+            }
+        }
+        CHECK_RANGE(slice->beta_offset_div2, -6, 6);
+        CHECK_RANGE(slice->tc_offset_div2, -6, 6);
 
         if (pps->pps_loop_filter_across_slices_enabled_flag
             && (slice->sao_luma_flag

--- a/codecparsers/h265Parser.h
+++ b/codecparsers/h265Parser.h
@@ -137,13 +137,13 @@ namespace H265 {
         uint8_t initial_cpb_removal_delay_length_minus1;
         uint8_t au_cpb_removal_delay_length_minus1;
         uint8_t dpb_output_delay_length_minus1;
-        bool fixed_pic_rate_general_flag[6];
-        bool fixed_pic_rate_within_cvs_flag[6];
-        uint16_t elemental_duration_in_tc_minus1[6]; //[0, 2047]
-        bool low_delay_hrd_flag[6];
-        uint8_t cpb_cnt_minus1[6]; //[0, 31]
+        bool fixed_pic_rate_general_flag[MAXSUBLAYERS];
+        bool fixed_pic_rate_within_cvs_flag[MAXSUBLAYERS];
+        uint16_t elemental_duration_in_tc_minus1[MAXSUBLAYERS]; //[0, 2047]
+        bool low_delay_hrd_flag[MAXSUBLAYERS];
+        uint8_t cpb_cnt_minus1[MAXSUBLAYERS]; //[0, 31]
 
-        SubLayerHRDParameters sublayer_hrd_params[6];
+        SubLayerHRDParameters sublayer_hrd_params[MAXSUBLAYERS];
     };
 
     struct ShortTermRefPicSet {


### PR DESCRIPTION
According to specification 7.4.3.1 and 7.4.3.2.1, the value of
sps_max_sub_layers_minus1 and vps_max_sub_layers_minus1 shall be
in the range of 0 to 6, inclusive, so sublayer_hrd_params[]'s length
should be at least MAXSUBLAYERS(7). Or else, decoding will crash
when decoding some clips.

hevc 8 bit decoding. [VIZ-6406](https://jira01.devtools.intel.com/browse/VIZ-6406?filter=79676)

Signed-off-by: wudping <dongpingx.wu@intel.com>