### PR TITLE
vp9_qp: setting qp to vp9 stream

### DIFF
--- a/encoder/vaapiencoder_vp9.cpp
+++ b/encoder/vaapiencoder_vp9.cpp
@@ -278,7 +278,8 @@ bool VaapiEncoderVP9::fill(VAEncPictureParameterBufferVP9* picParam,
 
     picParam->pic_flags.bits.show_frame = 1;
 
-    picParam->luma_ac_qindex = kDefaultQPValue;
+    picParam->luma_ac_qindex = (initQP() >= minQP() && initQP() <= maxQP()) ? initQP() : kDefaultQPValue;
+
     picParam->luma_dc_qindex_delta = 1;
     picParam->chroma_ac_qindex_delta = 1;
     picParam->chroma_dc_qindex_delta = 1;


### PR DESCRIPTION
Setting the qp to luma_ac_qindex, replace the default value.

to fix issue #696 
Signed-off-by: wudping <dongpingx.wu@intel.com>