### PR TITLE
VPX_enc: implement ipperiod 0 to enc all keyframe

### DIFF
--- a/encoder/vaapiencoder_vp8.cpp
+++ b/encoder/vaapiencoder_vp8.cpp
@@ -79,6 +79,8 @@ YamiStatus VaapiEncoderVP8::getMaxOutSize(uint32_t* maxSize)
 void VaapiEncoderVP8::resetParams()
 {
     m_maxCodedbufSize = width() * height() * 3 / 2 + VP8_HEADER_MAX_SIZE;
+    if (ipPeriod() == 0)
+        m_videoParamCommon.intraPeriod = 1;
 }
 
 YamiStatus VaapiEncoderVP8::start()

--- a/encoder/vaapiencoder_vp9.cpp
+++ b/encoder/vaapiencoder_vp9.cpp
@@ -93,6 +93,10 @@ YamiStatus VaapiEncoderVP9::resetParams()
     // space depending on other quantization parameters during execution. The
     // value below is a good compromise
     m_maxCodedbufSize += kMaxHeaderSize;
+
+    if (ipPeriod() == 0)
+        m_videoParamCommon.intraPeriod = 1;
+
     return YAMI_SUCCESS;
 }
 


### PR DESCRIPTION
when ipperiod is 0, set intraPeriod equal to 1 to encode
all keyframe.

to implement --ipperiod 0 encoding all I frames.

Signed-off-by: wudping <dongpingx.wu@intel.com>