### PR TITLE
264_enc: modify max_frame_num

### DIFF
--- a/encoder/vaapiencoder_h264.cpp
+++ b/encoder/vaapiencoder_h264.cpp
@@ -121,7 +121,7 @@ h264_get_slice_type (VaapiPictureType type)
     return -1;
 }
 
-/* Get log2_max_frame_num value for H.264 specification */
+/* Get log2_max_frame_num value for H.264 specification 7.4.2.1.1 */
 static uint32_t
 h264_get_log2_max_frame_num (uint32_t num)
 {
@@ -133,8 +133,8 @@ h264_get_log2_max_frame_num (uint32_t num)
     }
     if (ret <= 4)
         ret = 4;
-    else if (ret > 10)
-        ret = 10;
+    else if (ret > 16)
+        ret = 16;
     /* must be greater than 4 */
     return ret;
 }

--- a/encoder/vaapiencoder_hevc.cpp
+++ b/encoder/vaapiencoder_hevc.cpp
@@ -128,6 +128,7 @@ static uint32_t log2 (uint32_t num)
     return ret;
 }
 
+/* log2_max_frame_num is in the range[4, 16], specification 7.4.3.2.1 */
 static uint32_t
 hevc_get_log2_max_frame_num (uint32_t num)
 {
@@ -137,8 +138,8 @@ hevc_get_log2_max_frame_num (uint32_t num)
 
     if (ret <= 4)
         ret = 4;
-    else if (ret > 10)
-        ret = 10;
+    else if (ret > 16)
+        ret = 16;
     /* must be greater than 4 */
     return ret;
 }


### PR DESCRIPTION
According to spec, log2_max_frame_num_minus4 should be in
the range[0, 12], so log2_max_frame_num should be in the
range[4, 16].

So as H265.

To fix issue [#679](https://github.com/01org/libyami/issues/679)
Signed-off-by: wudping <dongpingx.wu@intel.com>