### PR TITLE
265dec: set crop left-top coordinate

### DIFF
--- a/codecparsers/h265Parser.cpp
+++ b/codecparsers/h265Parser.cpp
@@ -1047,6 +1047,9 @@ bool Parser::parseSps(const NalUnit* nalu)
         sps->croppedHeight = sps->pic_height_in_luma_samples -
                              subHeightC[sps->chroma_format_idc] *
                              (sps->conf_win_top_offset + sps->conf_win_bottom_offset);
+
+        sps->croppedLeft = subWidthC[sps->chroma_format_idc] * sps->conf_win_left_offset;
+        sps->croppedTop = subHeightC[sps->chroma_format_idc] * sps->conf_win_top_offset;
     }
 
     CHECK_READ_UE(sps->bit_depth_luma_minus8, 0, 8);

--- a/codecparsers/h265Parser.h
+++ b/codecparsers/h265Parser.h
@@ -308,6 +308,8 @@ namespace H265 {
         int32_t width;
         int32_t height;
         //cropped frame
+        uint32_t croppedLeft;
+        uint32_t croppedTop;
         uint32_t croppedWidth;
         uint32_t croppedHeight;
         uint8_t bit_depth_luma_minus8; //[0, 8]

--- a/decoder/vaapidecoder_h265.cpp
+++ b/decoder/vaapidecoder_h265.cpp
@@ -1048,7 +1048,7 @@ SurfacePtr VaapiDecoderH265::createSurface(const SliceHeader* const slice)
     SharedPtr<SPS>& sps = slice->pps->sps;
 
     if (sps->conformance_window_flag)
-        s->setCrop(0, 0, sps->croppedWidth, sps->croppedHeight);
+        s->setCrop(sps->croppedLeft, sps->croppedTop, sps->croppedWidth, sps->croppedHeight);
     else
         s->setCrop(0, 0, sps->width, sps->height);
     return s;


### PR DESCRIPTION
Some 265 bitsstream has crop information, such as:
    conf_win_top_offset
    conf_win_bottom_offset
so add crop coordinate for them.

to fix [VIZ-6406](https://jira01.devtools.intel.com/browse/VIZ-6406)

Signed-off-by: wudping <dongpingx.wu@intel.com>