### PR TITLE
h265dec: use int32 instead of uint16 for poc calculation

### DIFF
--- a/decoder/vaapidecoder_h265.cpp
+++ b/decoder/vaapidecoder_h265.cpp
@@ -188,7 +188,7 @@ bool VaapiDecoderH265::DPB::initLongTermRef(const PicturePtr& picture, const Sli
     }
     //(8-5)
     for (int i = 0; i < num; i++) {
-        uint16_t poc;
+        int32_t poc;
         bool used;
         if (i < slice->num_long_term_sps) {
             poc = sps->lt_ref_pic_poc_lsb_sps[slice->lt_idx_sps[i]];

--- a/decoder/vaapidecoder_h265.h
+++ b/decoder/vaapidecoder_h265.h
@@ -145,7 +145,7 @@ private:
 
     SharedPtr<Parser> m_parser;
     PicturePtr  m_current;
-    uint16_t    m_prevPicOrderCntMsb;
+    int32_t     m_prevPicOrderCntMsb;
     int32_t     m_prevPicOrderCntLsb;
     int32_t     m_nalLengthSize;
     bool        m_associatedIrapNoRaslOutputFlag;


### PR DESCRIPTION
According to spec 7.4.3.2.1, the value of log2_max_pic_order_cnt_lsb_minus4
shall be [0, 12], so MaxPicOrderCntLsb can be 0x10000, out of the range of
uint16_t;
For m_prevPicOrderCntMsb, according to spec 8.3.1, is set value as following:
    picOrderCntMsb = m_prevPicOrderCntMsb + MaxPicOrderCntLsb;
    m_prevPicOrderCntMsb = picOrderCntMsb;
so m_prevPicOrderCntMsb may be greater than MaxPicOrderCntLsb(0x10000),
so use int32_t for it.

For example, there is a clip whose m_prevPicOrderCntMsb is actually equal
to 0x10000.

to fix [VIZ-6406](https://jira01.devtools.intel.com/browse/VIZ-6406)

Signed-off-by: wudping <dongpingx.wu@intel.com>