### PR TITLE
264dec: implement crop seting

### DIFF
--- a/codecparsers/h264Parser.cpp
+++ b/codecparsers/h264Parser.cpp
@@ -497,6 +497,8 @@ bool Parser::parseSps(SharedPtr<SPS>& sps, const NalUnit* nalu)
 
         sps->m_cropRectWidth = width;
         sps->m_cropRectHeight = height;
+        sps->m_cropX = cropUnitX * sps->frame_crop_left_offset;
+        sps->m_cropY = cropUnitY * sps->frame_crop_top_offset;
     }
 
     m_spsMap[sps->sps_id] = sps;

--- a/codecparsers/h264Parser.h
+++ b/codecparsers/h264Parser.h
@@ -283,6 +283,8 @@ struct SPS {
 
     int32_t m_width;
     int32_t m_height;
+    int32_t m_cropX;
+    int32_t m_cropY;
     int32_t m_cropRectWidth;
     int32_t m_cropRectHeight;
 };

--- a/decoder/vaapidecoder_h264.cpp
+++ b/decoder/vaapidecoder_h264.cpp
@@ -1632,7 +1632,7 @@ SurfacePtr VaapiDecoderH264::createSurface(const SliceHeader* const slice)
     SharedPtr<SPS>& sps = slice->m_pps->m_sps;
 
     if (sps->frame_cropping_flag)
-        s->setCrop(0, 0, sps->m_cropRectWidth, sps->m_cropRectHeight);
+        s->setCrop(sps->m_cropX, sps->m_cropY, sps->m_cropRectWidth, sps->m_cropRectHeight);
     else
         s->setCrop(0, 0, sps->m_width, sps->m_height);
     return s;


### PR DESCRIPTION
call setCrop() to set crop information for every frame.

to fix [issue 286](https://github.com/01org/libyami/issues/286#issuecomment-281225930)

Signed-off-by: wudping <dongpingx.wu@intel.com>