### PR TITLE
add get and put surface api to libyami

### DIFF
--- a/decoder/vaapidecsurfacepool.cpp
+++ b/decoder/vaapidecsurfacepool.cpp
@@ -28,19 +28,19 @@
 
 namespace YamiMediaCodec{
 
-YamiStatus VaapiDecSurfacePool::getSurface(void* pool, intptr_t* surface, uint32_t flags)
+YamiStatus VaapiDecSurfacePool::getSurface(SurfaceAllocParams* param, intptr_t* surface)
 {
-    VaapiDecSurfacePool* p = (VaapiDecSurfacePool*)pool;
-    return p->getSurface(surface, flags);
+    VaapiDecSurfacePool* p = (VaapiDecSurfacePool*)param->user;
+    return p->getSurface(surface);
 }
 
-YamiStatus VaapiDecSurfacePool::putSurface(void* pool, intptr_t surface)
+YamiStatus VaapiDecSurfacePool::putSurface(SurfaceAllocParams* param, intptr_t surface)
 {
-    VaapiDecSurfacePool* p = (VaapiDecSurfacePool*)pool;
+    VaapiDecSurfacePool* p = (VaapiDecSurfacePool*)param->user;
     return p->putSurface(surface);
 }
 
-YamiStatus VaapiDecSurfacePool::getSurface(intptr_t* surface, uint32_t /*flags*/)
+YamiStatus VaapiDecSurfacePool::getSurface(intptr_t* surface)
 {
     AutoLock lock(m_lock);
 
@@ -102,6 +102,11 @@ bool VaapiDecSurfacePool::init(VideoDecoderConfig* config,
     uint32_t width = m_allocParams.width;
     uint32_t height = m_allocParams.height;
     uint32_t fourcc = config->fourcc;
+    if (!m_allocParams.getSurface || !m_allocParams.putSurface) {
+        m_allocParams.getSurface = getSurface;
+        m_allocParams.putSurface = putSurface;
+        m_allocParams.user = this;
+    }
 
     for (uint32_t i = 0; i < size; i++) {
         intptr_t s = m_allocParams.surfaces[i];
@@ -143,7 +148,8 @@ struct VaapiDecSurfacePool::SurfaceRecycler
     SurfaceRecycler(const DecSurfacePoolPtr& pool): m_pool(pool) {}
     void operator()(VaapiSurface* surface)
     {
-        putSurface(m_pool.get(), (intptr_t)surface->getID());
+        SurfaceAllocParams& params = m_pool->m_allocParams;
+        params.putSurface(&params, (intptr_t)surface->getID());
     }
 
 private:
@@ -154,7 +160,7 @@ SurfacePtr VaapiDecSurfacePool::acquire()
 {
     SurfacePtr surface;
     intptr_t p;
-    YamiStatus status = getSurface(this, &p, 0);
+    YamiStatus status = m_allocParams.getSurface(&m_allocParams, &p);
     if (status != YAMI_SUCCESS)
         return surface;
     //we only hold this lock after getSurface, since getSurface will do the lock

--- a/decoder/vaapidecsurfacepool.h
+++ b/decoder/vaapidecsurfacepool.h
@@ -78,9 +78,9 @@ private:
     bool init(VideoDecoderConfig* config,
         const SharedPtr<SurfaceAllocator>& allocator);
 
-    static YamiStatus getSurface(void* pool, intptr_t* surface, uint32_t flags);
-    static YamiStatus putSurface(void* pool, intptr_t surface);
-    YamiStatus getSurface(intptr_t* surface, uint32_t flags);
+    static YamiStatus getSurface(SurfaceAllocParams* param, intptr_t* surface);
+    static YamiStatus putSurface(SurfaceAllocParams* param, intptr_t surface);
+    YamiStatus getSurface(intptr_t* surface);
     YamiStatus putSurface(intptr_t surface);
 
     //following member only change in constructor.

--- a/interface/VideoCommonDefs.h
+++ b/interface/VideoCommonDefs.h
@@ -185,7 +185,8 @@ typedef YamiStatus Encode_Status;
 #define ENCODE_NO_MEMORY YAMI_OUT_MEMORY
 /*compatible code end*/
 
-typedef struct {
+typedef struct _SurfaceAllocParams SurfaceAllocParams;
+typedef struct _SurfaceAllocParams {
     //in
     uint32_t fourcc;
     uint32_t width;
@@ -201,6 +202,29 @@ typedef struct {
 
     //out
     intptr_t* surfaces;
+
+    /**
+     * yami will call this when it want new surface to put decode data
+     *
+     * it's optional
+     * @param user SurfaceAllocParams::user
+     * @param surface you want decode to
+     */
+    YamiStatus (*getSurface)(SurfaceAllocParams* thiz, intptr_t* surface);
+
+    /**
+     * yami will call this when all surface usage have been done
+     *
+     * it's optional
+     * @param user SurfaceAllocParams::user
+     * @param surface need to recycle
+     */
+    YamiStatus (*putSurface)(SurfaceAllocParams* thiz, intptr_t surface);
+
+    //you can set your private data for get and put surface
+    //yami will not touch it
+    void* user;
+
 } SurfaceAllocParams;
 
 typedef struct _SurfaceAllocator SurfaceAllocator;

--- a/interface/VideoCommonDefs.h
+++ b/interface/VideoCommonDefs.h
@@ -209,7 +209,7 @@ typedef struct _SurfaceAllocator SurfaceAllocator;
 // 2. reconstruct surface for encoder.
 typedef struct _SurfaceAllocator
 {
-    void*      *user;   /* you can put your private data here, yami will not touch it */
+    void* user; /* you can put your private data here, yami will not touch it */
     /* alloc and free surfaces */
     YamiStatus (*alloc) (SurfaceAllocator* thiz, SurfaceAllocParams* params);
     YamiStatus (*free)  (SurfaceAllocator* thiz, SurfaceAllocParams* params);


### PR DESCRIPTION
add a callback to libyami, help user control which surface can be decode to. This is a critical interface for buffer sharing between decoder and display. We can't decode to screen surface.