### PR TITLE
Modify m_maxTbsize to 32 for hevc encoding

### DIFF
--- a/encoder/vaapiencoder_hevc.cpp
+++ b/encoder/vaapiencoder_hevc.cpp
@@ -857,7 +857,7 @@ VaapiEncoderHEVC::VaapiEncoderHEVC():
     m_ctbSize(8),
     m_cuSize(32),
     m_minTbSize(4),
-    m_maxTbSize(16),
+    m_maxTbSize(32),
     m_reorderState(VAAPI_ENC_REORD_WAIT_FRAMES),
     m_keyPeriod(30)
 {


### PR DESCRIPTION
Keep it as the same as CU max size.

Signed-off-by: peng.chen <peng.c.chen@intel.com>