### PR TITLE
Use zero copy api in v4l2 decoder.

### DIFF
--- a/interface/VideoCommonDefs.h
+++ b/interface/VideoCommonDefs.h
@@ -108,6 +108,7 @@ typedef enum {
     VIDEO_DATA_MEMORY_TYPE_SURFACE_ID,  // it can be used for surface sharing of transcoding, benefits suppressed rendering as well.
                                         //it is discouraged to use it for video rendering.
     VIDEO_DATA_MEMORY_TYPE_ANDROID_BUFFER_HANDLE, // buffer_handle_t for android
+    VIDEO_DATA_MEMORY_TYPE_EXTERNAL_DMA_BUF, //external dma buffer, the buffer is allocate by user
 } VideoDataMemoryType;
 
 typedef struct VideoFrameRawData{

--- a/v4l2/BufferPipe.h
+++ b/v4l2/BufferPipe.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2016 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef BufferPipe_h
+#define BufferPipe_h
+
+#include "common/lock.h"
+#include <deque>
+
+namespace YamiMediaCodec {
+
+template <class T>
+class BufferPipe {
+    typedef T ValueType;
+
+public:
+    //queue to incoming
+    void queue(const ValueType& v)
+    {
+        queue(m_incoming, v);
+    }
+
+    //deque from outgoing
+    bool deque(ValueType& v)
+    {
+        return peek(m_outgoing, v, true);
+    }
+
+    //queue to outgoing
+    void put(const ValueType& v)
+    {
+        queue(m_outgoing, v);
+    }
+
+    //deque from incoming
+    bool get(ValueType& v)
+    {
+        return peek(m_incoming, v, true);
+    }
+
+    //peek from incoming
+    bool peek(ValueType& v)
+    {
+        return peek(m_incoming, v);
+    }
+
+    //clear incoming and outgoing
+    void clearPipe()
+    {
+        clearQueue(m_incoming);
+        clearQueue(m_outgoing);
+    }
+
+private:
+    struct BufferQue {
+        std::deque<ValueType> m_queue;
+        Lock m_lock;
+    };
+    BufferQue m_incoming;
+    BufferQue m_outgoing;
+    static void queue(BufferQue& q, const ValueType& v)
+    {
+        AutoLock l(q.m_lock);
+        q.m_queue.push_back(v);
+    }
+    static bool peek(BufferQue& q, ValueType& v, bool pop = false)
+    {
+        AutoLock l(q.m_lock);
+        if (q.m_queue.empty())
+            return false;
+        v = q.m_queue.front();
+        if (pop)
+            q.m_queue.pop_front();
+        return true;
+    }
+    static void clearQueue(BufferQue& q)
+    {
+        AutoLock l(q.m_lock);
+        q.m_queue.clear();
+    }
+};
+}
+
+#endif //BufferPipe_h

--- a/v4l2/v4l2_codecbase.cpp
+++ b/v4l2/v4l2_codecbase.cpp
@@ -77,6 +77,14 @@ V4l2CodecBase::V4l2CodecBase()
     , m_outputThreadCond(m_frameLock[OUTPUT])
     , m_eosState(EosStateNormal)
 {
+    m_maxBufferCount[INPUT] = 0;
+    m_maxBufferCount[OUTPUT] = 0;
+    m_bufferPlaneCount[INPUT] = 0;
+    m_bufferPlaneCount[OUTPUT] = 0;
+    m_memoryMode[INPUT] = 0;
+    m_memoryMode[OUTPUT] = 0;
+    m_pixelFormat[INPUT] = 0;
+    m_pixelFormat[OUTPUT] = 0;
     m_streamOn[INPUT] = false;
     m_streamOn[OUTPUT] = false;
     m_threadOn[INPUT] = false;
@@ -567,14 +575,6 @@ struct FormatEntry {
     uint32_t format;
     const char* mime;
 };
-
-#ifndef V4L2_PIX_FMT_VP9
-#define V4L2_PIX_FMT_VP9 YAMI_FOURCC('V', 'P', '9', '0')
-#endif
-
-#ifndef V4L2_PIX_FMT_VC1
-#define V4L2_PIX_FMT_VC1 YAMI_FOURCC('V', 'C', '1', '0')
-#endif
 
 static const FormatEntry FormatEntrys[] = {
     {V4L2_PIX_FMT_H264, YAMI_MIME_H264},

--- a/v4l2/v4l2_codecbase.h
+++ b/v4l2/v4l2_codecbase.h
@@ -39,6 +39,14 @@
     #define V4L2_EVENT_RESOLUTION_CHANGE 5
 #endif
 
+#ifndef V4L2_PIX_FMT_VP9
+#define V4L2_PIX_FMT_VP9 YAMI_FOURCC('V', 'P', '9', '0')
+#endif
+
+#ifndef V4L2_PIX_FMT_VC1
+#define V4L2_PIX_FMT_VC1 YAMI_FOURCC('V', 'C', '1', '0')
+#endif
+
 #if defined(INPUT) || defined(OUTPUT)
     #error("conflict define for INPUT/OUTPUT")
 #else

--- a/v4l2/v4l2_codecbase.h
+++ b/v4l2/v4l2_codecbase.h
@@ -34,9 +34,6 @@
 #include "VideoCommonDefs.h"
 #include "vaapi/vaapiptrs.h"
 #include "v4l2codec_device_ops.h"
-#ifdef ANDROID
-#include <va/va_android.h>
-#endif
 
 #ifndef V4L2_EVENT_RESOLUTION_CHANGE
     #define V4L2_EVENT_RESOLUTION_CHANGE 5
@@ -107,10 +104,7 @@ class V4l2CodecBase {
     virtual void clearCodecEvent();
     virtual void releaseCodecLock(bool lockable) {};
     virtual void flush() {}
-#ifdef ANDROID
-    SharedPtr<VideoFrame> createVaSurface(const buffer_handle_t buf_handle, int32_t width, int32_t height);
-    bool mapVideoFrames(int32_t width, int32_t height);
-#elif defined(__ENABLE_WAYLAND__)
+#if defined(__ENABLE_WAYLAND__)
     SharedPtr<VideoFrame> createVaSurface(uint32_t width, uint32_t height);
     bool mapVideoFrames(uint32_t width, uint32_t height);
 #endif
@@ -125,14 +119,10 @@ class V4l2CodecBase {
     int32_t m_fd[2]; // 0 for device event, 1 for interrupt
     bool m_started;
 
-#if defined(ANDROID)
-    std::vector<buffer_handle_t> m_bufferHandle;
-    gralloc_module_t* m_pGralloc;
-#endif
     DisplayPtr m_display;
 
     SharedPtr<IVideoPostProcess> m_vpp;
-#if defined(ANDROID) || defined(__ENABLE_WAYLAND__)
+#if defined(__ENABLE_WAYLAND__)
     uint32_t m_reqBuffCnt;
     std::vector<SharedPtr<VideoFrame> > m_videoFrames;
 #endif

--- a/v4l2/v4l2_codecbase.h
+++ b/v4l2/v4l2_codecbase.h
@@ -104,10 +104,6 @@ class V4l2CodecBase {
     virtual void clearCodecEvent();
     virtual void releaseCodecLock(bool lockable) {};
     virtual void flush() {}
-#if defined(__ENABLE_WAYLAND__)
-    SharedPtr<VideoFrame> createVaSurface(uint32_t width, uint32_t height);
-    bool mapVideoFrames(uint32_t width, uint32_t height);
-#endif
 
     VideoDataMemoryType m_memoryType;
     uint32_t m_maxBufferCount[2];
@@ -119,13 +115,6 @@ class V4l2CodecBase {
     int32_t m_fd[2]; // 0 for device event, 1 for interrupt
     bool m_started;
 
-    DisplayPtr m_display;
-
-    SharedPtr<IVideoPostProcess> m_vpp;
-#if defined(__ENABLE_WAYLAND__)
-    uint32_t m_reqBuffCnt;
-    std::vector<SharedPtr<VideoFrame> > m_videoFrames;
-#endif
     NativeDisplay m_nativeDisplay;
 
     enum EosState{

--- a/v4l2/v4l2_codecbase.h
+++ b/v4l2/v4l2_codecbase.h
@@ -101,7 +101,6 @@ class V4l2CodecBase {
         m_Display = x11Display;
         return true;
     };
-    virtual int32_t usePixmap(uint32_t bufferIndex, Pixmap pixmap) {return 0;};
     #endif
     #if defined(__ENABLE_EGL__)
     virtual int32_t useEglImage(EGLDisplay eglDisplay, EGLContext eglContext, uint32_t buffer_index, void* egl_image) {return 0;};

--- a/v4l2/v4l2_decode.h
+++ b/v4l2/v4l2_decode.h
@@ -55,6 +55,14 @@ class V4l2Decoder : public V4l2CodecBase
     virtual void flush();
 
   private:
+#if __ENABLE_WAYLAND__
+    SharedPtr<VideoFrame> createVaSurface(uint32_t width, uint32_t height);
+    bool mapVideoFrames(uint32_t width, uint32_t height);
+    uint32_t m_reqBuffCnt;
+    std::vector<SharedPtr<VideoFrame> > m_videoFrames;
+#endif
+    DisplayPtr m_display;
+    SharedPtr<IVideoPostProcess> m_vpp;
     DecoderPtr m_decoder;
     std::vector<uint8_t> m_codecData;
     bool m_bindEglImage;

--- a/v4l2/v4l2_decode.h
+++ b/v4l2/v4l2_decode.h
@@ -20,18 +20,16 @@
 
 #include "v4l2_codecbase.h"
 #include "VideoDecoderInterface.h"
-
-#ifdef __ENABLE_EGL__
-namespace YamiMediaCodec {
-    class EglVaapiImage;
-}
-#endif
+#include "common/Thread.h"
+#include "common/Functional.h"
+#include <BufferPipe.h>
 
 using namespace YamiMediaCodec;
 typedef SharedPtr < IVideoDecoder > DecoderPtr;
+typedef std::function<int32_t(void)> Task;
 class V4l2Decoder : public V4l2CodecBase
 {
-  public:
+public:
     V4l2Decoder();
      ~V4l2Decoder();
 
@@ -41,8 +39,14 @@ class V4l2Decoder : public V4l2CodecBase
 #ifdef __ENABLE_EGL__
     virtual int32_t useEglImage(EGLDisplay eglDisplay, EGLContext eglContext, uint32_t buffer_index, void* egl_image);
 #endif
+    virtual int32_t setFrameMemoryType(VideoDataMemoryType memory_type);
 
-  protected:
+    class Output;
+    friend class EglOutput;
+    friend class ExternalBufferOutput;
+    friend class ExternalDmaBufOutput;
+
+protected:
     virtual bool start();
     virtual bool stop();
     virtual bool acceptInputBuffer(struct v4l2_buffer *qbuf);
@@ -54,39 +58,73 @@ class V4l2Decoder : public V4l2CodecBase
     virtual void releaseCodecLock(bool lockable);
     virtual void flush();
 
-  private:
-#if __ENABLE_WAYLAND__
-    SharedPtr<VideoFrame> createVaSurface(uint32_t width, uint32_t height);
-    bool mapVideoFrames(uint32_t width, uint32_t height);
-    uint32_t m_reqBuffCnt;
-    std::vector<SharedPtr<VideoFrame> > m_videoFrames;
-#endif
+private:
+    int32_t onQueueBuffer(v4l2_buffer*);
+    int32_t onDequeBuffer(v4l2_buffer*);
+    int32_t onStreamOn(uint32_t type);
+    int32_t onStreamOff(uint32_t type);
+    int32_t onRequestBuffers(const v4l2_requestbuffers*);
+    int32_t onSetFormat(v4l2_format*);
+    int32_t onQueryBuffer(v4l2_buffer*);
+    int32_t onSubscribeEvent(v4l2_event_subscription*);
+    int32_t onDequeEvent(v4l2_event*);
+    int32_t onGetFormat(v4l2_format*);
+    int32_t onGetCtrl(v4l2_control*);
+    int32_t onEnumFormat(v4l2_fmtdesc*);
+    int32_t onGetCrop(v4l2_crop*);
+    int32_t onCreateBuffers(v4l2_create_buffers* req);
+
+    //jobs send to decoder thread
+    void startDecoderJob();
+    void getInputJob();
+    void inputReadyJob();
+    void getOutputJob();
+    void outputReadyJob();
+    void checkAllocationJob();
+    void flushDecoderJob();
+
+    //tasks send to decoder thread
+    int32_t getFormatTask(v4l2_format*);
+    int32_t getCtrlTask(v4l2_control*);
+    int32_t requestInputBuffers(uint32_t count);
+
+    //help functions
+    int32_t sendTask(Task task);
+    void post(Job job);
+    VideoDecodeBuffer* peekInput();
+    void consumeInput();
+    bool needReallocation(const VideoFormatInfo*);
+
+    bool m_inputOn;
+    v4l2_format m_inputFormat;
+    std::vector<VideoDecodeBuffer> m_inputFrames;
+    std::vector<uint8_t> m_inputSpace;
+    BufferPipe<uint32_t> m_in;
+
+    bool m_outputOn;
+    v4l2_format m_outputFormat;
+
+    //decoder thread
+    Thread m_thread;
+
+    enum State {
+        kUnStarted, //decoder thread is not started.
+        kWaitAllocation, //wait buffer allocation
+        kGetInput,
+        kWaitInput,
+        kWaitSurface, // wait for surface
+        kGetOutput,
+        kWaitOutput,
+        kFormatChanged, // detected format change. Waiting new surfacee.
+        kStopped, // stopped by use
+        kError, // have a error
+    };
+    State m_state;
+    SharedPtr<Output> m_output;
+    BufferPipe<uint32_t> m_out;
+    VideoFormatInfo m_lastFormat;
     DisplayPtr m_display;
-    SharedPtr<IVideoPostProcess> m_vpp;
     DecoderPtr m_decoder;
     std::vector<uint8_t> m_codecData;
-    bool m_bindEglImage;
-    // VideoFormatInfo m_videoFormatInfo;
-    // chrome requires m_maxBufferCount[OUTPUT] to be big enough (dpb size + some extra ones), it is correct when we export YUV buffer direcly
-    // however, we convert YUV frame to temporary RGBX frame; so the RGBX frame pool is not necessary to be that big.
-    uint32_t m_actualOutBufferCount;
-
-    uint32_t m_maxBufferSize[2];
-    uint8_t *m_bufferSpace[2];
-
-    std::vector<VideoDecodeBuffer> m_inputFrames;
-    std::vector<VideoFrameRawData> m_outputRawFrames;
-
-    uint32_t m_videoWidth;
-    uint32_t m_videoHeight;
-    uint32_t m_outputBufferCountOnInit;
-
-    // debug
-    uint32_t m_outputBufferCountQBuf;
-    uint32_t m_outputBufferCountPulse;
-    uint32_t m_outputBufferCountGive;
-#ifdef __ENABLE_EGL__
-    std::vector <SharedPtr<EglVaapiImage> > m_eglVaapiImages;
-#endif
 };
 #endif

--- a/v4l2/v4l2_wrapper.cpp
+++ b/v4l2/v4l2_wrapper.cpp
@@ -221,6 +221,9 @@ int32_t YamiV4L2_SetParameter(int32_t fd, const char* key, const char* value)
             memoryType = VIDEO_DATA_MEMORY_TYPE_SURFACE_ID;
         } else if (!strcmp(value, "android-buffer-handle")) {
             memoryType = VIDEO_DATA_MEMORY_TYPE_ANDROID_BUFFER_HANDLE;
+        }
+        else if (!strcmp(value, "external-dma-buf")) {
+            memoryType = VIDEO_DATA_MEMORY_TYPE_EXTERNAL_DMA_BUF;
         } else {
             ERROR("unknow output frame memory type: %s\n", value);
             return -1;

--- a/v4l2/v4l2_wrapper.cpp
+++ b/v4l2/v4l2_wrapper.cpp
@@ -148,8 +148,7 @@ int32_t YamiV4L2_Munmap(void* addr, size_t length)
     return 0;
 }
 
-#ifdef  ANDROID
-#elif defined(__ENABLE_WAYLAND__)
+#if defined(__ENABLE_WAYLAND__)
 int32_t YamiV4L2_SetWaylandDisplay(int32_t fd, struct wl_display* wlDisplay)
 {
     V4l2CodecPtr v4l2Codec = _findCodecFromFd(fd);

--- a/v4l2/v4l2_wrapper.h
+++ b/v4l2/v4l2_wrapper.h
@@ -16,11 +16,8 @@
 
 #include <stdint.h>
 #include <stddef.h>
-#ifdef ANDROID
-#else
-    #if defined(__ENABLE_X11__)
-    #include <X11/Xlib.h>
-    #endif
+#if defined(__ENABLE_X11__)
+#include <X11/Xlib.h>
 #endif
 #include "VideoCommonDefs.h"
 
@@ -43,8 +40,7 @@ int32_t YamiV4L2_ClearDevicePollInterrupt(int32_t fd);
 void* YamiV4L2_Mmap(void* addr, size_t length,
                      int prot, int flags, int fd, unsigned int offset);
 int32_t YamiV4L2_Munmap(void* addr, size_t length);
-#ifdef ANDROID
-#elif defined(__ENABLE_WAYLAND__)
+#if defined(__ENABLE_WAYLAND__)
 int32_t YamiV4L2_SetWaylandDisplay(int32_t fd, struct wl_display* wlDisplay);
 #else
     #ifdef __ENABLE_X11__


### PR DESCRIPTION
The main target of this pull request is enabling zero copy feature in v4l2decoder. But it does more things beyond this. Current v4l2decoder is a little mess. It full of duplicate and full of #ifdef. It's hard to make it even buildable. So before I add zero copy patch. I use some patch to refact the v4l2decoder to make it more readable.
