### PR TITLE
travis: enable all codec and v4l2 compiling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,21 +27,20 @@ before_install:
   - sudo apt-get install -y libxext-dev
   - sudo apt-get install -y libxfixes-dev
   - sudo apt-get install -y intel-gpu-tools
+  - sudo apt-get install -y libv4l-0
+  - sudo apt-get install -y libv4l-dev
+  - sudo apt-get install -y libcogl-gles2-dev
   - git clone https://github.com/01org/libva.git
   - (cd libva && ./autogen.sh && ./configure --prefix=/usr && sudo make install)
 
  
-install:
-  - git clone https://github.com/01org/libyami.git
-  - (cd libyami && ./autogen.sh --prefix=/opt/yami && make -j8 && make install)
-
 addons:
   coverity_scan:
     project:
       name: "01org/libyami"
       description: "Build submitted via Travis CI"
     notification_email: <email address>
-    build_command_prepend: "./autogen.sh; ./configure --prefix=/opt/yami"
+    build_command_prepend: "./autogen.sh; ./configure --prefix=/opt/yami --enable-h264enc --enable-jpegenc --enable-vp8enc --enable-vp9enc --enable-h265enc --enable-mpeg2dec --enable-vp8dec --enable-vp9dec --enable-jpegdec --enable-h264dec --enable-h265dec --enable-vc1dec --enable-v4l2"
     build_command:   "make -j8"
     branch_pattern: coverity_scan
 
@@ -51,8 +50,9 @@ script:
         echo "Don't build on coverty_scan branch.";
         exit 0;
     fi
-  - ./autogen.sh --prefix=/opt/yami
+  - ./autogen.sh --prefix=/opt/yami --enable-h264enc --enable-jpegenc --enable-vp8enc --enable-vp9enc --enable-h265enc --enable-mpeg2dec --enable-vp8dec --enable-vp9dec --enable-jpegdec --enable-h264dec --enable-h265dec --enable-vc1dec --enable-v4l2
   - make -j8 ; sudo make install
+  - make check
 
 after_success:
         - coveralls --exclude lib --exclude tests --gcov-options '\-lp'


### PR DESCRIPTION
add "--enable-xxx" flag into compiling command line,
to compile all the codecs and v4l2 for every commit.

to fix [VIZ-9125](https://jira01.devtools.intel.com/browse/VIZ-9125).

Signed-off-by: wudping <dongpingx.wu@intel.com>