### PR TITLE
v4l2dec: get formatInfo fail

### DIFF
--- a/v4l2/v4l2_decode.cpp
+++ b/v4l2/v4l2_decode.cpp
@@ -810,6 +810,11 @@ void V4l2Decoder::getInputJob()
         return;
     }
     consumeInput();
+    if (!m_decoder->getFormatInfo()) {
+        DEBUG("need more data to detect output format");
+        post(bind(&V4l2Decoder::getInputJob, this));
+        return;
+    }
     m_state = kGetOutput;
     post(bind(&V4l2Decoder::getOutputJob, this));
 }


### PR DESCRIPTION
Wait for enough frames for decoder to detect output format.

Signed-off-by: wudping <dongpingx.wu@intel.com>