### PR TITLE
vp9dec_capi: modify SharedPtrHold's member variable

### DIFF
--- a/capi/VideoDecoderCapi.cpp
+++ b/capi/VideoDecoderCapi.cpp
@@ -32,7 +32,7 @@ public:
     {
     }
 
-private:
+public:
     SharedPtr<VideoFrame> frame;
 };
 


### PR DESCRIPTION
Change member variable frame's property to public.

to fix vp9 clips decoding error in --capi mode.

Signed-off-by: wudping <dongpingx.wu@intel.com>