### PR TITLE
accept size 0 byte stream in BitReader and NalReader

### DIFF
--- a/codecparsers/bitReader.cpp
+++ b/codecparsers/bitReader.cpp
@@ -42,7 +42,8 @@ BitReader::BitReader(const uint8_t* pdata, uint32_t size)
     , m_loadBytes(0)
     , m_bitsInCache(0)
 {
-    assert(pdata && size);
+    if (size)
+        assert(pdata);
 }
 
 void BitReader::loadDataToCache(uint32_t nbytes)

--- a/codecparsers/bitReader_unittest.cpp
+++ b/codecparsers/bitReader_unittest.cpp
@@ -73,4 +73,27 @@ BITREADER_TEST(NoOverflow)
     EXPECT_EQ(0u, reader.getRemainingBitsCount());
 }
 
+void checkBitreadEmpty(BitReader& reader)
+{
+    EXPECT_TRUE(reader.end());
+    EXPECT_EQ(0u, reader.getPos());
+    EXPECT_EQ(0u,
+        reader.getRemainingBitsCount());
+    bool b;
+    EXPECT_FALSE(reader.readT(b));
+    EXPECT_TRUE(reader.end());
+}
+
+BITREADER_TEST(NullInit)
+{
+    uint8_t data = 0;
+    BitReader r1(&data, 0);
+    checkBitreadEmpty(r1);
+
+    BitReader r2(NULL, 0);
+    checkBitreadEmpty(r2);
+
+    EXPECT_DEATH(BitReader r3(NULL, 1), "");
+}
+
 } // namespace YamiParser

--- a/codecparsers/jpegParser_unittest.cpp
+++ b/codecparsers/jpegParser_unittest.cpp
@@ -240,7 +240,8 @@ JPEG_PARSER_TEST(Construct_InvalidParams)
     std::array<uint8_t, 1> data = {0x00};
 
     // invalid size
-    EXPECT_DEATH(Parser(&data[0], 0), "");
+    Parser parser(&data[0], 0);
+    EXPECT_FALSE(parser.parse());
 }
 
 JPEG_PARSER_TEST(Parse_NoSOI)

--- a/codecparsers/nalReader_unittest.cpp
+++ b/codecparsers/nalReader_unittest.cpp
@@ -55,4 +55,31 @@ NALREADER_TEST(ReadBeyondBoundary)
     EXPECT_EQ(0, reader.readSe());
 }
 
+void checkBitreadEmpty(NalReader& reader)
+{
+    EXPECT_TRUE(reader.end());
+    EXPECT_EQ(0u, reader.getPos());
+    EXPECT_EQ(0u,
+        reader.getRemainingBitsCount());
+
+    uint32_t u;
+    int32_t s;
+    EXPECT_FALSE(reader.readUe(u));
+    EXPECT_FALSE(reader.readSe(s));
+
+    EXPECT_TRUE(reader.end());
+}
+
+NALREADER_TEST(NullInit)
+{
+    uint8_t data = 0;
+    NalReader r1(&data, 0);
+    checkBitreadEmpty(r1);
+
+    NalReader r2(NULL, 0);
+    checkBitreadEmpty(r2);
+
+    EXPECT_DEATH(NalReader r3(NULL, 1), "");
+}
+
 } // namespace YamiParser


### PR DESCRIPTION
When we have some stream from the network, it may have 0 sizes for some chunk. We'd better support 0 sizes and report error later.