### PR TITLE
dec_unittest: fix vp9 decode unittest failure on BSW/SKL

### DIFF
--- a/decoder/DecoderApi_unittest.cpp
+++ b/decoder/DecoderApi_unittest.cpp
@@ -106,6 +106,14 @@ static FrameData g_jpegdata[] = {
     g_EOF,
 };
 
+static const std::string getFullTestName()
+{
+    const ::testing::TestInfo* const info = ::testing::UnitTest::GetInstance()->current_test_info();
+    return std::string(info->test_case_name())
+        + std::string(".")
+        + std::string(info->name());
+}
+
 class TestDecodeFrames {
 public:
     typedef SharedPtr<TestDecodeFrames> Shared;
@@ -297,7 +305,14 @@ TEST_P(DecodeApiTest, Format_Change)
             allocator->onFormatChange(format);
 
             //send buffer again
-            EXPECT_EQ(YAMI_SUCCESS, decoder->decode(&buffer));
+            status = decoder->decode(&buffer);
+            if (YAMI_UNSUPPORTED == status) {
+                RecordProperty("skipped", true);
+                std::cout << "[  SKIPPED ] " << getFullTestName()
+                          << " Hw does not support this decoder." << std::endl;
+                return;
+            }
+            EXPECT_EQ(YAMI_SUCCESS, status);
         }
         else {
             EXPECT_EQ(YAMI_SUCCESS, status);
@@ -364,7 +379,14 @@ TEST_P(DecodeApiTest, Flush)
                 allocator->onFormatChange(format);
 
                 //send buffer again
-                EXPECT_EQ(YAMI_SUCCESS, decoder->decode(&buffer));
+                status = decoder->decode(&buffer);
+                if (YAMI_UNSUPPORTED == status) {
+                    RecordProperty("skipped", true);
+                    std::cout << "[  SKIPPED ] " << getFullTestName()
+                              << " Hw does not support this decoder." << std::endl;
+                    return;
+                }
+                EXPECT_EQ(YAMI_SUCCESS, status);
             }
             else {
                 EXPECT_EQ(YAMI_SUCCESS, status);

--- a/decoder/vaapidecoder_base.cpp
+++ b/decoder/vaapidecoder_base.cpp
@@ -213,12 +213,12 @@ VaapiDecoderBase::setupVA(uint32_t numSurface, VAProfile profile)
     VAConfigAttrib attrib;
     attrib.type = VAConfigAttribRTFormat;
     attrib.value = VA_RT_FORMAT_YUV420;
+    ConfigPtr config;
 
-
-    ConfigPtr config = VaapiConfig::create(m_display, profile, VAEntrypointVLD,&attrib, 1);
-    if (!config) {
+    YamiStatus status = VaapiConfig::create(m_display, profile, VAEntrypointVLD, &attrib, 1, config);
+    if (YAMI_SUCCESS != status) {
         ERROR("failed to create config");
-        return YAMI_FAIL;
+        return status;
     }
 
     if (!m_externalAllocator) {
@@ -328,11 +328,12 @@ YamiStatus VaapiDecoderBase::ensureProfile(VAProfile profile)
     VAConfigAttrib attrib;
     attrib.type = VAConfigAttribRTFormat;
     attrib.value = VA_RT_FORMAT_YUV420;
+    ConfigPtr config;
 
-    ConfigPtr config = VaapiConfig::create(m_display, profile, VAEntrypointVLD, &attrib, 1);
-    if (!config) {
+    status = VaapiConfig::create(m_display, profile, VAEntrypointVLD, &attrib, 1, config);
+    if (YAMI_SUCCESS != status) {
         ERROR("failed to create config");
-        return YAMI_FAIL;
+        return status;
     }
 
     std::vector<VASurfaceID> surfaces;

--- a/encoder/vaapiencoder_base.cpp
+++ b/encoder/vaapiencoder_base.cpp
@@ -539,6 +539,7 @@ void unrefAllocator(SurfaceAllocator* allocator)
 bool VaapiEncoderBase::initVA()
 {
     VAConfigAttrib attrib, *pAttrib = NULL;
+    ConfigPtr config;
     int32_t attribCount = 0;
     FUNC_ENTER();
 
@@ -555,8 +556,8 @@ bool VaapiEncoderBase::initVA()
         attribCount = 1;
     }
 
-    ConfigPtr config = VaapiConfig::create(m_display, m_videoParamCommon.profile, m_entrypoint, pAttrib, attribCount);
-    if (!config) {
+    YamiStatus status = VaapiConfig::create(m_display, m_videoParamCommon.profile, m_entrypoint, pAttrib, attribCount, config);
+    if (YAMI_SUCCESS != status) {
         ERROR("failed to create config");
         return false;
     }

--- a/vaapi/vaapicontext.cpp
+++ b/vaapi/vaapicontext.cpp
@@ -79,27 +79,27 @@ static bool checkProfileCompatible(const DisplayPtr& display, VAProfile& profile
     return true;
 }
 
-ConfigPtr VaapiConfig::create(const DisplayPtr& display,
-                                     VAProfile profile, VAEntrypoint entry,
-                                     VAConfigAttrib *attribList, int numAttribs)
+YamiStatus VaapiConfig::create(const DisplayPtr& display,
+    VAProfile profile, VAEntrypoint entry,
+    VAConfigAttrib* attribList, int numAttribs,
+    ConfigPtr& confg)
 {
-    ConfigPtr ret;
     if (!display)
-        return ret;
+        return YAMI_FAIL;
     VAStatus vaStatus;
     VAConfigID config;
 
     if (!checkProfileCompatible(display, profile)){
         ERROR("Unsupport profile");
-        return ret;
+        return YAMI_UNSUPPORTED;
     }
 
     vaStatus = vaCreateConfig(display->getID(), profile, entry, attribList, numAttribs, &config);
 
     if (!checkVaapiStatus(vaStatus, "vaCreateConfig "))
-        return ret;
-    ret.reset(new VaapiConfig(display, config));
-    return ret;
+        return YAMI_FAIL;
+    confg.reset(new VaapiConfig(display, config));
+    return YAMI_SUCCESS;
 }
 
 VaapiConfig::VaapiConfig(const DisplayPtr& display, VAConfigID config)

--- a/vaapi/vaapicontext.h
+++ b/vaapi/vaapicontext.h
@@ -27,8 +27,8 @@ class VaapiConfig
 {
 friend class VaapiContext;
 public:
-    static ConfigPtr create(const DisplayPtr&, VAProfile, VAEntrypoint,
-                    VAConfigAttrib *attribList, int numAttribs);
+    static YamiStatus create(const DisplayPtr&, VAProfile, VAEntrypoint,
+        VAConfigAttrib* attribList, int numAttribs, ConfigPtr& confg);
     ~VaapiConfig();
 private:
     VaapiConfig(const DisplayPtr&, VAConfigID);

--- a/vpp/vaapipostprocess_base.cpp
+++ b/vpp/vaapipostprocess_base.cpp
@@ -43,8 +43,9 @@ YamiStatus VaapiPostProcessBase::initVA(const NativeDisplay& display)
         return YAMI_DRIVER_FAIL;
     }
 
-    ConfigPtr config = VaapiConfig::create(m_display, VAProfileNone, VAEntrypointVideoProc, NULL, 0);
-    if (!config) {
+    ConfigPtr config;
+    YamiStatus status = VaapiConfig::create(m_display, VAProfileNone, VAEntrypointVideoProc, NULL, 0, config);
+    if (YAMI_SUCCESS != status) {
         ERROR("failed to create config");
         return YAMI_NO_CONFIG;
     }


### PR DESCRIPTION
BSW/SKL do not support VP9 decoding, so vp9 decoding leads to core-dump
in decode unittest.
This patch will skip the unittest when detect that the platform dosen't
support VP9.

to fix issue [741](https://github.com/01org/libyami/issues/741)

Signed-off-by: wudping <dongpingx.wu@intel.com>