### PR TITLE
Svct layerids

### DIFF
--- a/encoder/Makefile.am
+++ b/encoder/Makefile.am
@@ -3,6 +3,7 @@ libyami_encoder_source_c = \
 	vaapiencpicture.cpp \
 	vaapiencoder_base.cpp \
 	vaapiencoder_host.cpp \
+	vaapilayerid.cpp \
 	$(NULL)
 
 if BUILD_H264_ENCODER
@@ -36,6 +37,7 @@ libyami_encoder_source_h_priv = \
 	vaapicodedbuffer.h \
 	vaapiencpicture.h \
 	vaapiencoder_base.h \
+	vaapilayerid.h \
 	$(NULL)
 
 if BUILD_H264_ENCODER

--- a/encoder/vaapiencoder_base.cpp
+++ b/encoder/vaapiencoder_base.cpp
@@ -75,7 +75,6 @@ VaapiEncoderBase::VaapiEncoderBase():
     m_videoParamQualityLevel.level = 0;
     m_vaVideoParamQualityLevel = 0;
     updateMaxOutputBufferCount();
-    memset(m_svctFrameRate, 0, sizeof(m_svctFrameRate));
 }
 
 VaapiEncoderBase::~VaapiEncoderBase()

--- a/encoder/vaapiencoder_base.h
+++ b/encoder/vaapiencoder_base.h
@@ -23,6 +23,7 @@
 #include "common/log.h"
 #include "common/surfacepool.h"
 #include "vaapiencpicture.h"
+#include "vaapilayerid.h"
 #include "vaapi/VaapiBuffer.h"
 #include "vaapi/vaapiptrs.h"
 #include "vaapi/VaapiSurface.h"
@@ -183,7 +184,7 @@ protected:
     uint32_t m_vaVideoParamQualityLevel;
     uint32_t m_maxOutputBuffer; // max count of frames are encoding in parallel, it hurts performance when m_maxOutputBuffer is too big.
     uint32_t m_maxCodedbufSize;
-    VideoFrameRate m_svctFrameRate[TEMPORAL_LAYER_LENGTH_MAX];
+    LayerFrameRates m_svctFrameRate;
 
 private:
     bool initVA();

--- a/encoder/vaapiencoder_h264.cpp
+++ b/encoder/vaapiencoder_h264.cpp
@@ -1026,6 +1026,15 @@ void VaapiEncoderH264::resetParams ()
 
     m_maxRefFrames =
         m_maxRefList0Count + m_maxRefList1Count;
+    if (m_isSvcT) {
+        uint32_t refFrameNum = m_temporalLayerID->getMiniRefFrameNum();
+        if (refFrameNum > m_maxOutputBuffer) {
+            ERROR("Reference frame number %d > output buffer %d", refFrameNum, m_maxOutputBuffer);
+            assert(false);
+        }
+        if (m_maxRefFrames < refFrameNum)
+            m_maxRefFrames = refFrameNum;
+    }
 
     assert((uint32_t)(1 << (m_temporalLayerNum - 1)) <= m_maxOutputBuffer);
     CLIP(m_maxRefFrames, (uint32_t)(1 << (m_temporalLayerNum - 1)), m_maxOutputBuffer);

--- a/encoder/vaapiencoder_h264.h
+++ b/encoder/vaapiencoder_h264.h
@@ -114,6 +114,7 @@ private:
     uint32_t m_mbHeight;
     bool m_isSvcT;
     uint32_t m_temporalLayerNum;
+    TemporalLayerIDPtr m_temporalLayerID;
 
     /* re-ordering */
     std::list<PicturePtr> m_reorderFrameList;

--- a/encoder/vaapilayerid.cpp
+++ b/encoder/vaapilayerid.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2014-2016 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <assert.h>
+#include <string.h>
+#include <algorithm>
+#include "vaapilayerid.h"
+#include "common/log.h"
+
+namespace YamiMediaCodec {
+
+const uint8_t Vp8LayerID::m_vp8TempIds[VP8_MAX_TEMPORAL_LAYER_NUM][VP8_MIN_TEMPORAL_GOP]
+    = { { 0, 0, 0, 0 },
+        { 0, 1, 0, 1 },
+        { 0, 2, 1, 2 } };
+
+const uint8_t AvcLayerID::m_avcTempIds[H264_MAX_TEMPORAL_LAYER_NUM][H264_MIN_TEMPORAL_GOP]
+    = { { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 1, 0, 1, 0, 1, 0, 1 },
+        { 0, 2, 1, 2, 0, 2, 1, 2 },
+        { 0, 3, 2, 3, 1, 3, 2, 3 } };
+
+TemporalLayerID::TemporalLayerID(const VideoFrameRate& frameRate, const VideoTemporalLayerIDs& layerIDs, const uint8_t* defaultIDs, uint8_t defaultIDsLen)
+{
+    if (layerIDs.numIDs) {
+        m_idPeriod = layerIDs.numIDs;
+        for (uint32_t i = 0; i < layerIDs.numIDs; i++)
+            m_ids.push_back(layerIDs.ids[i]);
+    }
+    else { //use the default temporal IDs
+        assert(defaultIDs && defaultIDsLen > 0);
+        m_idPeriod = defaultIDsLen;
+        for (uint32_t i = 0; i < m_idPeriod; i++)
+            m_ids.push_back(defaultIDs[i]);
+    }
+
+    calculateFramerate(frameRate);
+}
+
+void TemporalLayerID::getLayerIds(LayerIDs& ids) const
+{
+    ids = m_ids;
+}
+
+uint8_t TemporalLayerID::getTemporalLayer(uint32_t frameNumInGOP) const
+{
+    return m_ids[frameNumInGOP % m_idPeriod];
+}
+
+void TemporalLayerID::getLayerFrameRates(LayerFrameRates& frameRates) const
+{
+    frameRates = m_frameRates;
+    return;
+}
+
+void TemporalLayerID::calculateFramerate(const VideoFrameRate& frameRate)
+{
+    uint8_t numberOfLayerIDs[TEMPORAL_LAYERIDS_LENGTH_MAX];
+    LayerIDs tempIDs = m_ids;
+    uint8_t i;
+
+    std::sort(tempIDs.begin(), tempIDs.end());
+    memset(numberOfLayerIDs, 0, sizeof(numberOfLayerIDs));
+    for (i = 0; i < tempIDs.size(); i++) {
+        numberOfLayerIDs[tempIDs[i]]++;
+    }
+    m_layerLen = tempIDs[i - 1] + 1;
+    assert(m_layerLen < TEMPORAL_LAYERIDS_LENGTH_MAX);
+
+    VideoFrameRate frameRateTemp;
+    uint32_t denom = m_ids.size();
+    uint32_t num = 0;
+    assert(frameRate.frameRateNum && frameRate.frameRateDenom);
+    frameRateTemp.frameRateDenom = frameRate.frameRateDenom * denom;
+    for (i = 0; i < m_layerLen; i++) {
+        num += numberOfLayerIDs[i];
+        frameRateTemp.frameRateNum = num * frameRate.frameRateNum;
+        m_frameRates.push_back(frameRateTemp);
+    }
+
+    return;
+}
+
+void TemporalLayerID::checkLayerIDs(uint8_t maxLayerLength) const
+{
+    LayerIDs tempIDs = m_ids;
+    const uint8_t LAYERID0 = 0;
+    assert(LAYERID0 == tempIDs[0]);
+    if (m_idPeriod > TEMPORAL_LAYERIDS_LENGTH_MAX) {
+        ERROR("m_idPeriod(%d) should be in (0, %d]", m_idPeriod, TEMPORAL_LAYERIDS_LENGTH_MAX);
+        assert(false);
+    }
+    //check if the layerID is complete
+    std::sort(tempIDs.begin(), tempIDs.end());
+    for (uint8_t i = 1; i < m_idPeriod; i++) {
+        if (tempIDs[i] - tempIDs[i - 1] > 1) {
+            ERROR("layer IDs illegal, no layer: %d.\n", (tempIDs[i - 1] + tempIDs[i]) / 2);
+            assert(false);
+        }
+    }
+    if ((m_layerLen > maxLayerLength) || (m_layerLen < 2)) {
+        ERROR("m_layerLen(%d) should be in [2, %d]", m_layerLen, maxLayerLength);
+        assert(false);
+    }
+    return;
+}
+
+Vp8LayerID::Vp8LayerID(const VideoFrameRate& frameRate, const VideoTemporalLayerIDs& layerIDs, uint8_t layerIndex)
+    : TemporalLayerID(frameRate, layerIDs, m_vp8TempIds[layerIndex], VP8_MIN_TEMPORAL_GOP)
+{
+    checkLayerIDs(VP8_MAX_TEMPORAL_LAYER_NUM);
+}
+
+AvcLayerID::AvcLayerID(const VideoFrameRate& frameRate, const VideoTemporalLayerIDs& layerIDs, uint8_t layerIndex)
+    : TemporalLayerID(frameRate, layerIDs, m_avcTempIds[layerIndex], H264_MIN_TEMPORAL_GOP)
+{
+    checkLayerIDs(H264_MAX_TEMPORAL_LAYER_NUM);
+}
+}

--- a/encoder/vaapilayerid.h
+++ b/encoder/vaapilayerid.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2014-2016 Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef vaapilayerid_h
+#define vaapilayerid_h
+
+#include <vector>
+#include "VideoEncoderDefs.h"
+
+namespace YamiMediaCodec {
+
+#define VP8_MAX_TEMPORAL_LAYER_NUM 3
+#define VP8_MIN_TEMPORAL_GOP 4
+#define H264_MIN_TEMPORAL_GOP 8
+#define H264_MAX_TEMPORAL_LAYER_NUM 4
+
+class TemporalLayerID;
+
+typedef std::vector<uint8_t> LayerIDs;
+typedef std::vector<VideoFrameRate> LayerFrameRates;
+typedef SharedPtr<TemporalLayerID> TemporalLayerIDPtr;
+
+class TemporalLayerID {
+public:
+    TemporalLayerID(const VideoFrameRate& frameRate, const VideoTemporalLayerIDs& layerIDs, const uint8_t* defaultIDs, uint8_t defaultIDsLen);
+    virtual void getLayerIds(LayerIDs& ids) const;
+    virtual uint8_t getTemporalLayer(uint32_t frameNum) const;
+    virtual void getLayerFrameRates(LayerFrameRates& frameRates) const;
+    virtual uint8_t getLayerNum() const { return m_layerLen; }
+    virtual uint8_t getMiniRefFrameNum() const;
+
+    void checkLayerIDs(uint8_t maxLayerLength = 0) const;
+
+private:
+    void calculateFramerate(const VideoFrameRate& frameRate);
+
+protected:
+    uint8_t m_layerLen;
+    LayerIDs m_ids;
+    LayerFrameRates m_frameRates;
+    uint8_t m_idPeriod;
+    uint8_t m_miniRefFrameNum;
+};
+
+class Vp8LayerID : public TemporalLayerID {
+public:
+    Vp8LayerID(const VideoFrameRate& frameRate, const VideoTemporalLayerIDs& layerIDs, uint8_t layerIndex);
+
+public:
+    static const uint8_t m_vp8TempIds[VP8_MAX_TEMPORAL_LAYER_NUM][VP8_MIN_TEMPORAL_GOP];
+};
+
+class AvcLayerID : public TemporalLayerID {
+public:
+    AvcLayerID(const VideoFrameRate& frameRate, const VideoTemporalLayerIDs& layerIDs, uint8_t layerIndex);
+
+private:
+    void calculateMiniRefNum();
+
+public:
+    static const uint8_t m_avcTempIds[H264_MAX_TEMPORAL_LAYER_NUM][H264_MIN_TEMPORAL_GOP];
+};
+}
+
+#endif

--- a/interface/VideoEncoderDefs.h
+++ b/interface/VideoEncoderDefs.h
@@ -229,6 +229,7 @@ typedef struct VideoParamsCommon {
     VideoResolution resolution;
     VideoFrameRate frameRate;
     VideoTemporalLayers temporalLayers;
+    VideoTemporalLayerIDs temporalLayerIDs;
     uint32_t intraPeriod;
     uint32_t ipPeriod;
     uint32_t numRefFrames;

--- a/interface/VideoEncoderDefs.h
+++ b/interface/VideoEncoderDefs.h
@@ -92,6 +92,7 @@ typedef enum {
 #define VIDEO_PARAMS_QUALITYLEVEL_MIN 1
 #define VIDEO_PARAMS_QUALITYLEVEL_MAX 7
 #define TEMPORAL_LAYER_LENGTH_MAX 32
+#define TEMPORAL_LAYERIDS_LENGTH_MAX 32
 
 typedef struct VideoEncOutputBuffer {
     uint8_t *data;
@@ -153,6 +154,7 @@ typedef struct VideoFrameRate {
     uint32_t frameRateNum;
     uint32_t frameRateDenom;
 }VideoFrameRate;
+
 typedef struct VideoTemporalLayers {
     //layer 0 bitrate is bitRate[0]
     //...
@@ -160,6 +162,11 @@ typedef struct VideoTemporalLayers {
     uint8_t numLayersMinus1;
     uint32_t bitRate[TEMPORAL_LAYER_LENGTH_MAX];
 } VideoTemporalLayers;
+
+typedef struct VideoTemporalLayerIDs {
+    uint8_t numIDs;
+    uint8_t ids[TEMPORAL_LAYERIDS_LENGTH_MAX];
+} VideoTemporalLayerIDs;
 
 typedef struct VideoResolution {
     uint32_t width;


### PR DESCRIPTION
AVC/VP8_enc: Implement layerID settings in SVC-T mode for AVC/VP8

Allow to set temporal layerID for each frame in SVC-T.