### PR TITLE
compile: Fix deprecated warnings for libva2.0

### DIFF
--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -17,8 +17,6 @@
 #include "config.h"
 #endif
 
-#include "utils.h"
-
 #include "common/common_def.h"
 #include "common/log.h"
 
@@ -34,6 +32,8 @@
 #include <cstdlib>
 #include <limits>
 
+//put it after va.h to fix the I420 redefine issue
+#include "utils.h"
 namespace YamiMediaCodec{
 
 uint32_t guessFourcc(const char* fileName)

--- a/decoder/vaapidecoder_h264.cpp
+++ b/decoder/vaapidecoder_h264.cpp
@@ -1370,11 +1370,6 @@ bool VaapiDecoderH264::fillPicture(const PicturePtr& picture,
     picParam->seq_fields.bits.delta_pic_order_always_zero_flag
         = sps->delta_pic_order_always_zero_flag;
 
-    picParam->num_slice_groups_minus1 = pps->num_slice_groups_minus1;
-    picParam->slice_group_map_type = pps->slice_group_map_type;
-    picParam->slice_group_change_rate_minus1
-        = pps->slice_group_change_rate_minus1;
-
     picParam->pic_init_qp_minus26 = pps->pic_init_qp_minus26;
     picParam->pic_init_qs_minus26 = pps->pic_init_qs_minus26;
     picParam->chroma_qp_index_offset = pps->chroma_qp_index_offset;


### PR DESCRIPTION
Fix deprecated warnings for libva2.0
Signed-off-by: jkyu <jiankang.yu@intel.com>