### PR TITLE
jpegd: support monochrome jpeg image decode

### DIFF
--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -159,6 +159,7 @@ const static ResolutionEntry resolutionEntrys[] = {
     { YAMI_FOURCC_422H, 3, { 2, 1, 1 }, { 2, 2, 2 } },
     { YAMI_FOURCC_422V, 3, { 2, 2, 2 }, { 2, 1, 1 } },
     { YAMI_FOURCC_444P, 3, { 2, 2, 2 }, { 2, 2, 2 } },
+    { YAMI_FOURCC_Y800, 1, { 2 }, { 2 } },
     { YAMI_FOURCC_YUY2, 1, { 4 }, { 2 } },
     { YAMI_FOURCC_UYVY, 1, { 4 }, { 2 } },
     { YAMI_FOURCC_RGBX, 1, { 8 }, { 2 } },

--- a/decoder/vaapiDecoderJPEG.cpp
+++ b/decoder/vaapiDecoderJPEG.cpp
@@ -357,8 +357,11 @@ YamiStatus VaapiDecoderJPEG::decode(VideoDecodeBuffer* buffer)
 //get frame fourcc, return 0 for unsupport format
 static uint32_t getFourcc(const FrameHeader::Shared& frame)
 {
+    if (frame->components.size() == 1) // monochrome image
+        RETURN_FORMAT(YAMI_FOURCC_Y800);
+
     if (frame->components.size() != 3) {
-        ERROR("unsupported compoent size %d", (int)frame->components.size());
+        ERROR("unsupported component size %d", (int)frame->components.size());
         return 0;
     }
     int h1 = frame->components[0]->hSampleFactor;

--- a/vaapi/VaapiUtils.cpp
+++ b/vaapi/VaapiUtils.cpp
@@ -47,6 +47,8 @@ void unmapImage(VADisplay display, const VAImage& image)
 uint32_t getRtFormat(uint32_t fourcc)
 {
     switch (fourcc) {
+    case YAMI_FOURCC_Y800:
+        return VA_RT_FORMAT_YUV400;
     case YAMI_FOURCC_NV12:
     case YAMI_FOURCC_I420:
     case YAMI_FOURCC_YV12:


### PR DESCRIPTION
add support to jpeg decoder to decode monochrome (YUV400)
images.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>