### PR TITLE
decoder/base: always clear output buffer on destruct

### DIFF
--- a/decoder/vaapidecoder_base.cpp
+++ b/decoder/vaapidecoder_base.cpp
@@ -356,6 +356,7 @@ YamiStatus VaapiDecoderBase::ensureProfile(VAProfile profile)
 YamiStatus VaapiDecoderBase::terminateVA(void)
 {
     INFO("base: terminate VA");
+    m_output.clear();
     m_config.resetConfig();
     m_surfacePool.reset();
     m_allocator.reset();


### PR DESCRIPTION
Decoded frames in the output buffer hold a reference to Surface
objects.  If the output buffer is not flushed before vaTerminate
is called (which happens because DisplayPtr goes away), then this
causes vaDestroySurface to fail (seg fault) when that output buffer
is flushed and surfaces are destroyed.   This can happen during
decoder destruction where user does not explicitly flush output.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>