### PR TITLE
jpegd: attempt to decode images even if EOI is missing

### DIFF
--- a/codecparsers/jpegParser.h
+++ b/codecparsers/jpegParser.h
@@ -256,6 +256,7 @@ private:
 
     bool m_sawSOI;
     bool m_sawEOI;
+    bool m_sawSOS;
 
     unsigned m_restartInterval;
 };

--- a/codecparsers/jpegParser_unittest.cpp
+++ b/codecparsers/jpegParser_unittest.cpp
@@ -128,6 +128,7 @@ protected:
     MEMBER_VARIABLE(Parser::Callbacks, m_callbacks);
     MEMBER_VARIABLE(bool, m_sawSOI);
     MEMBER_VARIABLE(bool, m_sawEOI);
+    MEMBER_VARIABLE(bool, m_sawSOS);
     MEMBER_VARIABLE(unsigned, m_restartInterval);
 
 #undef MEMBER_VARIABLE
@@ -520,7 +521,18 @@ JPEG_PARSER_TEST(Parse_SimpleTruncated)
 
     for (size_t i(1); i < size; ++i) {
         Parser parser(&g_SimpleJPEG[0], i);
-        EXPECT_FALSE(parser.parse());
+
+        const bool result = parser.parse();
+
+        if (!m_sawSOS(parser)) {
+            EXPECT_FALSE(result) << i;
+        } else {
+            // If parser successfully parses an SOS but does not encounter an
+            // EOI marker at the end of the input, then it will insert a fake EOI
+            // marker and succeed to allow decoders to still attempt to decode
+            // the available entropy-coded data.
+            EXPECT_TRUE(result) << i;
+        }
     }
 }
 

--- a/decoder/vaapiDecoderJPEG.cpp
+++ b/decoder/vaapiDecoderJPEG.cpp
@@ -135,8 +135,13 @@ private:
                 + m_parser->current().length;
             break;
         case M_EOI:
-            m_slice.length = m_parser->current().position - m_slice.start;
-            m_decodeStatus = m_finishHandler();
+            if (m_slice.start >= m_parser->current().position) {
+                // we can't have zero or negative length
+                m_decodeStatus = YAMI_FAIL;
+            } else {
+                m_slice.length = m_parser->current().position - m_slice.start;
+                m_decodeStatus = m_finishHandler();
+            }
             break;
         case M_DQT:
             m_quantizationTables = m_parser->quantTables();


### PR DESCRIPTION
By standard, a missing EOI technically means the image
is corrupt.  However, there are many images in the wild where
a missing EOI is the only corruption to the image (i.e. the
entropy-coded data and headers are still intact).  This can
happen, for example, when the image was encoded by a buggy
application that forgets to append the EOI to the final
image.  If a missing EOI is the only issue, then decoders can
still successfully decode it.  However, a missing EOI does
not necessarily mean the rest of the image is intact.  That
is, there is no guarantee that the final decoded output will
produce the desired result.  Either way, we insert a fake
EOI marker here to give decoders a chance to decode the
image.

VIZ-8219

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>