### PR TITLE
v4l2dec: fix link issues for --enable-X11 --enable-v4l2 --disable-way…

### DIFF
--- a/v4l2/v4l2_decode.cpp
+++ b/v4l2/v4l2_decode.cpp
@@ -631,17 +631,10 @@ bool V4l2Decoder::inputPulse(uint32_t index)
     return true; // always return true for decode; simply ignored unsupported nal
 }
 
-#ifdef __ENABLE_WAYLAND__
 bool V4l2Decoder::outputPulse(uint32_t& index)
 {
     return true;
 }
-#elif __ENABLE_EGL__
-bool V4l2Decoder::outputPulse(uint32_t& index)
-{
-    return true;
-}
-#endif
 
 bool V4l2Decoder::recycleOutputBuffer(int32_t index)
 {


### PR DESCRIPTION
…land --disable-egl

after https://github.com/01org/libyami/pull/720, we never use V4l2Decoder::outputPulse,
the outputPulse just to make the base class happy, we will remove it after the V4L2Encoder
refacted. For temporary solution, just make it available for every compile flag

this will fix https://github.com/01org/libyami/issues/795