### PR TITLE
Allow User Defined JPEG Encode Quality Level

### DIFF
--- a/encoder/vaapiencoder_jpeg.h
+++ b/encoder/vaapiencoder_jpeg.h
@@ -60,8 +60,6 @@ private:
 
     void resetParams();
 
-    unsigned char quality;
-
     /**
      * VaapiEncoderFactory registration result. This encoder is registered in
      * vaapiencoder_host.cpp


### PR DESCRIPTION
Default jpeg encode quality level remains at 50.  User can now configure it in the range [1, 100].

Fixes #769