### PR TITLE
265_enc: add a macro to enable yami on studio va

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -401,6 +401,8 @@ AC_ARG_ENABLE(media-studio-va,
     [], [enable_media_studio_va="no"])
 
 if test "$enable_media_studio_va" = "yes"; then
+    AC_DEFINE([__ENABLE_STUDIO_VA__], [1],
+        [Defined to 1 to enable yami based on studio va])
     AC_DEFINE([__ENABLE_H265_ENC_ON_STUDIO_VA__], [1],
         [Defined to 1 to enable H265 encoding when --enable-media-studio-va="yes"])
 fi

--- a/vaapi/vaapistreamable.h
+++ b/vaapi/vaapistreamable.h
@@ -105,8 +105,10 @@ operator<<(std::ostream& os, const VAEntrypoint& entrypoint)
         return os << "VAEntrypointEncSliceLP";
     case VAEntrypointEncPicture:
         return os << "VAEntrypointEncPicture";
+#ifndef __ENABLE_STUDIO_VA__
     case VAEntrypointFEI:
         return os << "VAEntrypointFEI";
+#endif
     default:
         return os << "Unknown VAEntrypoint: " << static_cast<int>(entrypoint);
     }


### PR DESCRIPTION
Because the studio va dosen't define "VAEntrypointFEI",
we must comment the pice of code which using "VAEntrypointFEI"
during compiling.
This patch add a macro to performance this action.

Signed-off-by: dongping wu <dongpingx.wu@intel.com>