### PR TITLE
vaapi: VAEntrypointFEI not defined until libva-2.0

### DIFF
--- a/vaapi/vaapistreamable.h
+++ b/vaapi/vaapistreamable.h
@@ -105,8 +105,10 @@ operator<<(std::ostream& os, const VAEntrypoint& entrypoint)
         return os << "VAEntrypointEncSliceLP";
     case VAEntrypointEncPicture:
         return os << "VAEntrypointEncPicture";
+#if VA_CHECK_VERSION(1, 0, 0)
     case VAEntrypointFEI:
         return os << "VAEntrypointFEI";
+#endif
     default:
         return os << "Unknown VAEntrypoint: " << static_cast<int>(entrypoint);
     }


### PR DESCRIPTION
Don't handle VAEntrypointFEI unless VAAPI >= 1.0 (libva-2.0)

Fixes #812
