### PR TITLE
Drop deprecated symbols to fix the build of 1.1.0

### DIFF
--- a/decoder/vaapidecoder_h264.cpp
+++ b/decoder/vaapidecoder_h264.cpp
@@ -1345,11 +1345,6 @@ bool VaapiDecoderH264::fillPicture(const PicturePtr& picture,
     picParam->seq_fields.bits.delta_pic_order_always_zero_flag
         = sps->delta_pic_order_always_zero_flag;
 
-    picParam->num_slice_groups_minus1 = pps->num_slice_groups_minus1;
-    picParam->slice_group_map_type = pps->slice_group_map_type;
-    picParam->slice_group_change_rate_minus1
-        = pps->slice_group_change_rate_minus1;
-
     picParam->pic_init_qp_minus26 = pps->pic_init_qp_minus26;
     picParam->pic_init_qs_minus26 = pps->pic_init_qs_minus26;
     picParam->chroma_qp_index_offset = pps->chroma_qp_index_offset;

--- a/encoder/vaapiencoder_base.cpp
+++ b/encoder/vaapiencoder_base.cpp
@@ -436,7 +436,6 @@ struct ProfileMapItem {
 };
 
 const ProfileMapItem g_profileMap[] = {
-    { PROFILE_H264_BASELINE, VAProfileH264Baseline },
     { PROFILE_H264_CONSTRAINED_BASELINE, VAProfileH264ConstrainedBaseline },
     { PROFILE_H264_MAIN, VAProfileH264Main },
     { PROFILE_H264_HIGH, VAProfileH264High },

--- a/encoder/vaapiencoder_h264.cpp
+++ b/encoder/vaapiencoder_h264.cpp
@@ -919,9 +919,6 @@ void VaapiEncoderH264::checkProfileLimitation()
     VAProfile& profile = m_videoParamCommon.profile;
 
     switch (profile) {
-    case VAProfileH264Baseline:
-        // only Constrained Baseline supported right now
-        profile = VAProfileH264ConstrainedBaseline;
     case VAProfileH264ConstrainedBaseline:
         if (ipPeriod() > 1) {
             WARNING("H264 baseline profile can not support B frame encoding");

--- a/vaapi/vaapicontext.cpp
+++ b/vaapi/vaapicontext.cpp
@@ -42,16 +42,10 @@ static bool checkH264Profile(VAProfile& profile, vector<VAProfile>& profileList)
 
     if (result != profileList.end()){
         profile = *result;
-    } else{
-        // VAProfileH264Baseline is super profile for VAProfileH264ConstrainedBaseline
-        // old i965 driver incorrectly claims supporting VAProfileH264Baseline, but not VAProfileH264ConstrainedBaseline
-        if (profile == VAProfileH264ConstrainedBaseline && std::count(profileList.begin(), profileList.end(), VAProfileH264Baseline))
-            profile = VAProfileH264Baseline;
-        else
-            return false;
+        return true;
     }
 
-    return true;
+    return false;
 }
 
 static bool checkProfileCompatible(const DisplayPtr& display, VAProfile& profile)


### PR DESCRIPTION
Drop usage of the deprecated following deprecated symbols as is done in 1.3.0:
- VAProfileH264Baseline
- VAPictureParameterBufferH264::num_slice_groups_minus1
- VAPictureParameterBufferH264::slice_group_map_type
- VAPictureParameterBufferH264::slice_group_change_rate_minus1

This fixes build errors.