### PR TITLE
Vpp rotation and fix color balance bug

### DIFF
--- a/vpp/vaapipostprocess_scaler.cpp
+++ b/vpp/vaapipostprocess_scaler.cpp
@@ -65,6 +65,7 @@ VaapiPostProcessScaler::VaapiPostProcessScaler()
 {
     m_denoise.level = DENOISE_LEVEL_NONE;
     m_sharpening.level = SHARPENING_LEVEL_NONE;
+    m_transform = VPP_TRANSFORM_NONE;
 }
 
 bool VaapiPostProcessScaler::getFilters(std::vector<VABufferID>& filters)
@@ -125,8 +126,22 @@ VaapiPostProcessScaler::process(const SharedPtr<VideoFrame>& src,
         vppParam->filters = &filters[0];
         vppParam->num_filters = (unsigned int)filters.size();
     }
+    vppParam->rotation_state = mapToVARotationState(m_transform);
 
     return picture.process() ? YAMI_SUCCESS : YAMI_FAIL;
+}
+uint32_t VaapiPostProcessScaler::mapToVARotationState(VppTransform vppTransform)
+{
+    switch (vppTransform) {
+    case VPP_TRANSFORM_ROT_90:
+        return VA_ROTATION_90;
+    case VPP_TRANSFORM_ROT_180:
+        return VA_ROTATION_180;
+    case VPP_TRANSFORM_ROT_270:
+        return VA_ROTATION_270;
+    default:
+        return VA_ROTATION_NONE;
+    }
 }
 
 bool VaapiPostProcessScaler::mapToRange(
@@ -394,7 +409,15 @@ VaapiPostProcessScaler::setParameters(VppParamType type, void* vppParam)
 
         return setColorBalanceParam(*colorbalance);
     }
+    else if (type == VppParamTypeTransform) {
+        VppParamTransform* param = (VppParamTransform*)vppParam;
+        if (param->size != sizeof(VppParamTransform)) {
+            return YAMI_INVALID_PARAM;
+        }
+        m_transform = (VppTransform)param->transform;
+
+        return YAMI_SUCCESS;
+    }
     return VaapiPostProcessBase::setParameters(type, vppParam);
 }
-
 }

--- a/vpp/vaapipostprocess_scaler.h
+++ b/vpp/vaapipostprocess_scaler.h
@@ -58,6 +58,7 @@ private:
 
     typedef std::map<VppColorBalanceMode, ColorBalanceParam> ColorBalanceMap;
     typedef ColorBalanceMap::iterator ColorBalanceMapItr;
+    uint32_t mapToVARotationState(VppTransform vppTransform);
 
     bool mapToRange(float& value, float min, float max,
         int32_t level, int32_t minLevel, int32_t maxLevel);
@@ -83,6 +84,7 @@ private:
     ProcParams m_sharpening;
     DeinterlaceParams m_deinterlace;
     ColorBalanceMap m_colorBalance;
+    VppTransform m_transform;
 
     /**
      * VaapiPostProcessFactory registration result. This postprocess is


### PR DESCRIPTION
1, add function of YUV image clockwise rotation;
2, fix the color-balance bug of only supporting to set one of those attributes: HUE, SATURATION, BRIGHTNESS, CONTRAST. Now it supports to set several of those attributes.
