### PR TITLE
Makefile.am: point to build dir for generated headers

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -40,6 +40,7 @@ extra_includes = \
 libyami_common_cppflags = \
 	$(LIBVA_CFLAGS) \
 	-I$(top_srcdir)/interface \
+	-I$(top_builddir)/interface \
 	$(extra_includes) \
 	$(NULL)
 


### PR DESCRIPTION
Otherwise it will give out errors for missing YamiVersion.h when build
dir is different from source dir.

Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>