### PR TITLE
Fix guess resolution overflow

### DIFF
--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -73,7 +73,7 @@ bool guessResolution(const char* filename, int& w, int& h)
 {
     enum {
         STATE_START,
-        STATE_WDITH,
+        STATE_WIDTH,
         STATE_X,
         STATE_HEIGHT,
         STATE_END,
@@ -88,12 +88,11 @@ bool guessResolution(const char* filename, int& w, int& h)
             {
                 if (isdigit(*p)) {
                     tokStart = p;
-                    state = STATE_WDITH;
+                    state = STATE_WIDTH;
                 }
                 break;
             }
-            case STATE_WDITH:
-            {
+            case STATE_WIDTH: {
                 if (*p == 'x' || *p == 'X') {
                     state = STATE_X;
                     if (!getInt(tokStart, w)) {

--- a/common/utils_unittest.cpp
+++ b/common/utils_unittest.cpp
@@ -129,15 +129,6 @@ UTILS_TEST(guessResolutionOverflow) {
     EXPECT_FALSE(guessResolution(sstream.str().c_str(), w, h));
     EXPECT_EQ(w, 0);
     EXPECT_EQ(h, 0);
-
-    sstream.str("");
-    sstream << long(std::numeric_limits<int>::max()) * 2 + 3
-            << "x"
-            << long(std::numeric_limits<int>::max()) * 3 + 2;
-
-    EXPECT_FALSE(guessResolution(sstream.str().c_str(), w, h));
-    EXPECT_EQ(w, 0);
-    EXPECT_EQ(h, 0);
 }
 
 struct BppEntry {

--- a/common/utils_unittest.cpp
+++ b/common/utils_unittest.cpp
@@ -127,8 +127,11 @@ UTILS_TEST(guessResolutionOverflow) {
             << std::numeric_limits<long>::max();
 
     EXPECT_FALSE(guessResolution(sstream.str().c_str(), w, h));
-    EXPECT_EQ(w, 0);
-    EXPECT_EQ(h, 0);
+
+    sstream.str("");
+    sstream << long(std::numeric_limits<int>::max()) * 2 + 3 << "x"
+            << long(std::numeric_limits<int>::max()) * 3 + 2;
+    EXPECT_FALSE(guessResolution(sstream.str().c_str(), w, h));
 }
 
 struct BppEntry {


### PR DESCRIPTION
Instead of use a088df6, I think this fix may be better. 
1. It avoids change with and heigh to long long in https://github.com/intel/libyami/pull/836/files#r178894788. 
2. it's inplace operation, avoid the new allocation string object