### PR TITLE
Remove bad memset on SPS, PPS and SliceHeader

### DIFF
--- a/codecparsers/h264Parser_unittest.cpp
+++ b/codecparsers/h264Parser_unittest.cpp
@@ -124,7 +124,6 @@ namespace H264 {
         void checkH264Sps(Parser& parser, const NalUnit* nalu)
         {
             SharedPtr<SPS> sps(new SPS());
-            memset(sps.get(), 0, sizeof(SPS));
 
             ASSERT_EQ(NAL_SPS, nalu->nal_unit_type);
             ASSERT_TRUE(parser.parseSps(sps, nalu));
@@ -147,7 +146,6 @@ namespace H264 {
         void checkH264Pps(Parser& parser, const NalUnit* nalu)
         {
             SharedPtr<PPS> pps(new PPS());
-            memset(pps.get(), 0, sizeof(PPS));
 
             ASSERT_EQ(NAL_PPS, nalu->nal_unit_type);
             ASSERT_TRUE(parser.parsePps(pps, nalu));
@@ -173,7 +171,6 @@ namespace H264 {
         void checkH264SliceHeader(Parser& parser, NalUnit* nalu)
         {
             SharedPtr<SliceHeader> slice(new SliceHeader);
-            memset(slice.get(), 0, sizeof(SliceHeader));
 
             ASSERT_EQ(NAL_SLICE_IDR, nalu->nal_unit_type);
             ASSERT_TRUE(slice->parseHeader(&parser, nalu));


### PR DESCRIPTION
The SPS, PPS and SliceHeader structs contain non-POD types and thus
memset should be used with care to clear them properly.  Since
the SPS, PPS and SliceHeader constructors already do it the right
way, remove the unnecessary and erroneous memset for these
objects in the unit tests.  GCC 8.0.1 generates error with
-Werror=class-memaccess otherwise.

Fixes #845

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>