### PR TITLE
Fix low latency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ m4_define([yami_api_major_version], 0)
 # update this for every release when micro version large than zero
 m4_define([yami_api_minor_version], 5)
 # change this for any api change
-m4_define([yami_api_micro_version], 4)
+m4_define([yami_api_micro_version], 5)
 m4_define([yami_api_version],
     [yami_api_major_version.yami_api_minor_version.yami_api_micro_version])
 

--- a/decoder/vaapidecoder_h264.cpp
+++ b/decoder/vaapidecoder_h264.cpp
@@ -1831,6 +1831,10 @@ YamiStatus VaapiDecoderH264::decode(VideoDecodeBuffer* buffer)
                 return status;
         }
     }
+    if (buffer->flag & VIDEO_DECODE_BUFFER_FLAG_FRAME_END) {
+        //send current buffer to libva
+        decodeCurrent();
+    }
     return lastError;
 }
 

--- a/decoder/vaapidecoder_h264.h
+++ b/decoder/vaapidecoder_h264.h
@@ -67,7 +67,7 @@ private:
                   bool newStream, bool contextChanged,
                   uint32_t maxDecFrameBuffering);
         bool add(const PicturePtr&);
-        bool outputReadyFrames();
+        void outputReadyFrame(const PicturePtr&);
         void initReference(const PicturePtr&, const SliceHeader* const);
         void flush();
 
@@ -127,8 +127,6 @@ private:
         uint32_t m_maxNumRefFrames;
         uint32_t m_maxDecFrameBuffering;
         YamiParser::H264::DecRefPicMarking m_decRefPicMarking;
-        bool m_isOutputStarted;
-        int32_t m_lastOutputPoc;
     };
 
     YamiStatus decodeNalu(NalUnit*);

--- a/decoder/vaapidecoder_h265.cpp
+++ b/decoder/vaapidecoder_h265.cpp
@@ -1187,6 +1187,11 @@ YamiStatus VaapiDecoderH265::decode(VideoDecodeBuffer* buffer)
             }
         }
     }
+
+    if (buffer->flag & VIDEO_DECODE_BUFFER_FLAG_FRAME_END) {
+        //send current buffer to libva
+        decodeCurrent();
+    }
     return lastError;
 }
 

--- a/interface/VideoDecoderDefs.h
+++ b/interface/VideoDecoderDefs.h
@@ -35,6 +35,13 @@ typedef enum {
     HAS_VA_PROFILE = 0x08,
 } VIDEO_BUFFER_FLAG;
 
+typedef enum {
+    //this will tell decoder, we have the whole frame.
+    //so the decoder can do decode immediately
+    //else they may need to wait for next frame boundary
+    VIDEO_DECODE_BUFFER_FLAG_FRAME_END = 0x1,
+} VIDEO_DECODE_BUFFER_FLAG;
+
 typedef struct {
     uint8_t *data;
     size_t size;


### PR DESCRIPTION
two things done to fix low latency mode.
1. output output-able frame immediately when we add a frame to dpb. Do not check "current poc - previous poc == 1", this will introduce problem for poc "0, 2, 4, 6, 8"
2. add a flag VIDEO_DECODE_BUFFER_FLAG_FRAME_END to tell decoder to stop search next frame, so the decoder can decode current frame ASAP
this fixes https://github.com/intel/libyami/issues/844 and https://github.com/intel/libyami/issues/847