### PR TITLE
Fix compile issue for Android Celadon project

### DIFF
--- a/capi/Android.mk
+++ b/capi/Android.mk
@@ -15,7 +15,8 @@ LOCAL_C_INCLUDES:= \
 
 LOCAL_SHARED_LIBRARIES := \
         liblog \
-        libc++
+        libc++ \
+        libva \
 
 LOCAL_ALLOW_UNDEFINED_SYMBOLS := true
 

--- a/codecparsers/h265Parser.h
+++ b/codecparsers/h265Parser.h
@@ -318,7 +318,7 @@ namespace H265 {
         bool sps_sub_layer_ordering_info_present_flag;
         uint8_t sps_max_dec_pic_buffering_minus1[MAXSUBLAYERS];
         uint8_t sps_max_num_reorder_pics[MAXSUBLAYERS];
-        uint8_t sps_max_latency_increase_plus1[MAXSUBLAYERS];
+        uint32_t sps_max_latency_increase_plus1[MAXSUBLAYERS];
         uint8_t log2_min_luma_coding_block_size_minus3;
         uint8_t log2_diff_max_min_luma_coding_block_size;
         uint8_t log2_min_transform_block_size_minus2;

--- a/codecparsers/h265Parser.h
+++ b/codecparsers/h265Parser.h
@@ -428,8 +428,7 @@ namespace H265 {
         SharedPtr<SPS> sps;
     };
 
-    class NalUnit {
-    public:
+    struct NalUnit {
         enum {
             NALU_HEAD_SIZE = 2,
             NALU_MIN_SIZE = 4
@@ -486,7 +485,6 @@ namespace H265 {
         /* nal should be a complete nal unit without start code or length bytes */
         bool parseNaluHeader(const uint8_t* nal, size_t size);
 
-    public:
         const uint8_t* m_data;
         uint32_t m_size;
 

--- a/codecparsers/jpegParser.cpp
+++ b/codecparsers/jpegParser.cpp
@@ -667,7 +667,7 @@ bool Parser::parseDAC()
 
         length -= 2;
 
-        if (index < 0 || index >= (2 * NUM_ARITH_TBLS)) {
+        if (index >= (2 * NUM_ARITH_TBLS)) {
             ERROR("Invalid DAC Index");
             return false;
         }
@@ -775,7 +775,7 @@ bool Parser::parseDHT()
             huffTables = &m_dcHuffTables;
         }
 
-        if (index < 0 || index >= NUM_HUFF_TBLS) {
+        if (index >= NUM_HUFF_TBLS) {
             ERROR("Bad Huff Table Index");
             return false;
         }

--- a/codecparsers/mpeg2_parser.cpp
+++ b/codecparsers/mpeg2_parser.cpp
@@ -702,7 +702,8 @@ namespace MPEG2 {
 
         if (!readQuantMatrixOrDefault(quantMatrices->load_non_intra_quantiser_matrix,
                                  quantMatrices->non_intra_quantiser_matrix,
-                                 &kDefaultNonIntraBlockMatrix[0]));
+                                 &kDefaultNonIntraBlockMatrix[0]))
+            return false;
 
         DEBUG("horizontal_size_value            : %x",
               m_sequenceHdr.horizontal_size_value);

--- a/common.mk
+++ b/common.mk
@@ -1,4 +1,4 @@
-LOCAL_CFLAGS := -D__ENABLE_DEBUG__ -Wno-sign-compare -Wno-unused-parameter -Wno-missing-braces -O2
-LOCAL_CPPFLAGS := -D__ENABLE_DEBUG__ -Wno-sign-compare -Wno-unused-parameter -Wno-missing-braces -O2 -std=c++11
+LOCAL_CFLAGS := -D__ENABLE_DEBUG__ -Wno-sign-compare -Wno-unused-parameter -Wno-missing-braces -Wno-overloaded-virtual -O2
+LOCAL_CPPFLAGS := -D__ENABLE_DEBUG__ -Wno-sign-compare -Wno-unused-parameter -Wno-missing-braces -Wno-overloaded-virtual -O2 -std=c++11
 
 ENABLE-V4L2-OPS=true

--- a/common.mk
+++ b/common.mk
@@ -1,4 +1,4 @@
-LOCAL_CFLAGS := -D__ENABLE_DEBUG__ -Wno-sign-compare -Wno-unused-parameter -O2
-LOCAL_CPPFLAGS := -D__ENABLE_DEBUG__ -Wno-sign-compare -Wno-unused-parameter -O2 -std=c++11
+LOCAL_CFLAGS := -D__ENABLE_DEBUG__ -Wno-sign-compare -Wno-unused-parameter -Wno-missing-braces -O2
+LOCAL_CPPFLAGS := -D__ENABLE_DEBUG__ -Wno-sign-compare -Wno-unused-parameter -Wno-missing-braces -O2 -std=c++11
 
 ENABLE-V4L2-OPS=true

--- a/decoder/Android.mk
+++ b/decoder/Android.mk
@@ -51,7 +51,8 @@ LOCAL_CFLAGS := \
 
 LOCAL_SHARED_LIBRARIES := \
         liblog \
-        libc++
+        libc++ \
+        libva \
 
 LOCAL_ALLOW_UNDEFINED_SYMBOLS := true
 

--- a/decoder/vaapiDecoderJPEG.cpp
+++ b/decoder/vaapiDecoderJPEG.cpp
@@ -108,7 +108,7 @@ public:
         return m_parser->scanHeader();
     }
 
-    const unsigned restartInterval() const
+    unsigned restartInterval() const
     {
         return m_parser->restartInterval();
     }

--- a/decoder/vaapidecoder_base.h
+++ b/decoder/vaapidecoder_base.h
@@ -26,7 +26,6 @@
 #include <deque>
 #include <pthread.h>
 #include <va/va.h>
-#include <va/va_tpi.h>
 #ifdef HAVE_VA_X11
 #include <va/va_x11.h>
 #else

--- a/decoder/vaapidecoder_h264.cpp
+++ b/decoder/vaapidecoder_h264.cpp
@@ -612,6 +612,7 @@ bool VaapiDecoderH264::DPB::modifyReferenceList(const PicturePtr& picture,
         refPicListModify = slice->ref_pic_list_modification_l1;
     } else {
         assert(0);
+        return false;
     }
 
     if (!refPicListModifyFlag)

--- a/encoder/Android.mk
+++ b/encoder/Android.mk
@@ -42,7 +42,8 @@ LOCAL_CFLAGS := \
 
 LOCAL_SHARED_LIBRARIES := \
         liblog \
-        libc++
+        libc++ \
+        libva \
 
 LOCAL_PROPRIETARY_MODULE := true
 LOCAL_MODULE := libyami_encoder

--- a/encoder/vaapiencoder_h264.cpp
+++ b/encoder/vaapiencoder_h264.cpp
@@ -151,7 +151,7 @@ h264_get_cpb_nal_factor(VideoProfile profile)
 
 static uint8_t h264_get_profile_idc(VideoProfile profile)
 {
-    uint8_t idc;
+    uint8_t idc = 66;
     switch (profile) {
     case PROFILE_H264_CONSTRAINED_BASELINE:
         idc = 66;

--- a/encoder/vaapiencoder_h264.cpp
+++ b/encoder/vaapiencoder_h264.cpp
@@ -494,7 +494,8 @@ bit_writer_write_sps(BitWriter* bitwriter,
         }
         /* vcl_hrd_parameters_present_flag */
         bitwriter->writeBits(0, 1);
-        if (nal_hrd_parameters_present_flag || 0/*vcl_hrd_parameters_present_flag*/) {
+        bool vcl_hrd_parameters_present_flag = false;
+        if (nal_hrd_parameters_present_flag || vcl_hrd_parameters_present_flag) {
             /* low_delay_hrd_flag */
             bitwriter->writeBits(0, 1);
         }

--- a/encoder/vaapiencoder_hevc.cpp
+++ b/encoder/vaapiencoder_hevc.cpp
@@ -145,7 +145,7 @@ hevc_get_log2_max_frame_num (uint32_t num)
 
 static uint8_t hevc_get_profile_idc(VideoProfile profile)
 {
-    uint8_t idc;
+    uint8_t idc = 1;
     switch (profile) {
     case PROFILE_H265_MAIN:
         idc =  1;
@@ -1300,7 +1300,7 @@ void VaapiEncoderHEVC::shortRfsUpdate(const PicturePtr& picture)
             m_shortRFS.num_positive_pics      = 1;
             m_shortRFS.delta_poc_s1_minus1[0]  = m_refList1[0]->m_poc - picture->m_poc - 1;
             m_shortRFS.used_by_curr_pic_s1_flag[0]            = 1;
-			
+
             DEBUG("m_refList1_size is %zu\n", m_refList1.size());
         }
     }

--- a/vaapi/vaapidisplay.h
+++ b/vaapi/vaapidisplay.h
@@ -19,7 +19,6 @@
 
 #include "vaapi/vaapiptrs.h"
 #include <va/va.h>
-#include <va/va_tpi.h>
 #ifdef HAVE_VA_X11
 #include <va/va_x11.h>
 #endif


### PR DESCRIPTION
Celadon use clang compiler, the compiler command is strict than gcc default.
we use this serials patches to fix the compile issue on Celadon.

More detail about Celadon you can find on
https://github.com/projectceladon/manifest/wiki