### PR TITLE
libyami-1.3.1 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,18 @@
-libyami NEWS -- summary of changes.  2017-04-19
+libyami NEWS -- summary of changes.  2018-09-19
 Copyright (c) 2010, The WebM Project authors.
-Copyright (C) 2011-2017 Intel Corporation
+Copyright (C) 2011-2018 Intel Corporation
 Copyright (C) 2015-2016 Alibaba
+
+libyami 1.3.1(API:0.6.0) release, work with libva 2.2.1.pre1 release
+=====================
+Major improvements:
++af43e95 h264dec: fix low lantecy mode
++160286a Add flags for SDL signoff called SDL325 - Compile With Defenses Enabled
++727db97 common: add RGB 10 bits support
++46c15b1 common: add RGB565 support
++946b7ac common: add XRGB, ARGB, XBGR, ABGR support
++9e1fc1d android: re-enable android build
++3745982 yamivpp: add rotation function for vpp
 
 libyami 1.2.0(API:0.5.0) release, work with libva 1.8.1 release
 =====================

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ and decodes them leverage hardware acceleration.
 
   * Copyright (c) 2010, The WebM Project authors.
 
-  * Copyright (C) 2011-2017 Intel Corporation
+  * Copyright (C) 2011-2018 Intel Corporation
 
   * Copyright (C) 2015-2016 Alibaba
 

--- a/configure.ac
+++ b/configure.ac
@@ -6,9 +6,9 @@ AC_PREREQ([2.68])
 # YAMI-API version for api headers, only change it when the api interface is changed.
 m4_define([yami_api_major_version], 0)
 # update this for every release when micro version large than zero
-m4_define([yami_api_minor_version], 5)
+m4_define([yami_api_minor_version], 6)
 # change this for any api change
-m4_define([yami_api_micro_version], 5)
+m4_define([yami_api_micro_version], 0)
 m4_define([yami_api_version],
     [yami_api_major_version.yami_api_minor_version.yami_api_micro_version])
 
@@ -16,7 +16,7 @@ m4_define([yami_api_version],
 m4_define([libyami_major_version], 1)
 m4_define([libyami_minor_version], 3)
 # even number of micro_version means a release after full validation cycle
-m4_define([libyami_micro_version], 0)
+m4_define([libyami_micro_version], 1)
 m4_define([libyami_version],
                     [libyami_major_version.libyami_minor_version.libyami_micro_version])
 


### PR DESCRIPTION
update configure.ac and bump the api from 0.5.5 to 0.6.0 for 1.3.1 release 