### PR TITLE
add conner test case for YamiParser::NalReader::getPos, fix the issue

### DIFF
--- a/codecparsers/nalReader.cpp
+++ b/codecparsers/nalReader.cpp
@@ -143,4 +143,20 @@ void NalReader::rbspTrailingBits()
         skip(1); /*rbsp_alignment_zero_bit, equal to 0*/
 }
 
+uint64_t NalReader::getPos() const
+{
+    uint32_t count = m_bitsInCache / 8;
+    const uint8_t* p = m_stream + m_loadBytes - 1;
+    uint32_t epb = 0;
+    while (count > 0) {
+        if (isEmulationBytes(p))
+            epb++;
+        else
+            count--;
+        p--;
+    }
+    //some epb loaded in cache, but we are not reach it yet
+    return (static_cast<uint64_t>(m_loadBytes - epb) << 3) - m_bitsInCache;
+}
+
 } /*namespace YamiParser*/

--- a/codecparsers/nalReader.h
+++ b/codecparsers/nalReader.h
@@ -40,6 +40,9 @@ public:
     bool moreRbspData() const;
     void rbspTrailingBits();
     uint32_t getEpbCnt() { return m_epb; }
+
+    uint64_t getPos() const;
+
 private:
     void loadDataToCache(uint32_t nbytes);
     inline bool isEmulationBytes(const uint8_t *p) const;

--- a/codecparsers/nalReader_unittest.cpp
+++ b/codecparsers/nalReader_unittest.cpp
@@ -82,4 +82,35 @@ NALREADER_TEST(NullInit)
     EXPECT_DEATH(NalReader r3(NULL, 1), "");
 }
 
+NALREADER_TEST(GetPosForEPB)
+{
+    //0x0, 0x0, 0x3, is emulation prevention byte
+    const uint8_t data[] = {
+        0x0, 0x0, 0x3, 0x0,
+        0x0, 0x0, 0x0, 0x0,
+        0x1
+    };
+    NalReader r(data, sizeof(data));
+    EXPECT_EQ(0u, r.getPos());
+
+    r.skip(1);
+    EXPECT_EQ(1u, r.getPos());
+
+    r.skip(7);
+    EXPECT_EQ(8u, r.getPos());
+
+    r.skip(8);
+    //we are reach the epb
+    EXPECT_EQ(24u, r.getPos());
+
+    r.skip(8);
+    EXPECT_EQ(32u, r.getPos());
+
+    r.skip(32);
+
+    uint8_t b;
+    EXPECT_TRUE(r.readT(b));
+    EXPECT_EQ(1u, b);
+}
+
 } // namespace YamiParser


### PR DESCRIPTION
getPos is complex when we have epb, if we do not reach the epb,
the getPos does not need to include it. 
The first commit will expose the following issue.
The second, commit fixed it

    [ RUN      ] NalReaderTest.GetPosForEPB
    nalReader_unittest.cpp:97: Failure
          Expected: 1u
          Which is: 1
    To be equal to: r.getPos()
          Which is: 9
    nalReader_unittest.cpp:100: Failure
          Expected: 8u
          Which is: 8
    To be equal to: r.getPos()
          Which is: 16
    [  FAILED  ] NalReaderTest.GetPosForEPB (0 ms)
