### PR TITLE
refact vc1 parser to make code more read able.

### DIFF
--- a/codecparsers/Android.mk
+++ b/codecparsers/Android.mk
@@ -6,6 +6,7 @@ LOCAL_SRC_FILES := \
         bitReader.cpp \
         bitWriter.cpp \
         EpbReader.cpp \
+        RbduReader.cpp \
         nalReader.cpp \
         h264Parser.cpp \
         h265Parser.cpp \

--- a/codecparsers/Android.mk
+++ b/codecparsers/Android.mk
@@ -5,11 +5,12 @@ include $(LOCAL_PATH)/../common.mk
 LOCAL_SRC_FILES := \
         bitReader.cpp \
         bitWriter.cpp \
+        EpbReader.cpp \
+        nalReader.cpp \
         h264Parser.cpp \
         h265Parser.cpp \
         jpegParser.cpp \
         mpeg2_parser.cpp \
-        nalReader.cpp \
         vc1Parser.cpp \
         vp8_bool_decoder.cpp \
         vp8_parser.cpp \

--- a/codecparsers/EpbReader.cpp
+++ b/codecparsers/EpbReader.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "EpbReader.h"
+#include <assert.h>
+
+namespace YamiParser {
+
+EpbReader::EpbReader(const uint8_t* pdata, uint32_t size)
+    : BitReader(pdata, size)
+    , m_epb(0)
+{
+}
+
+void EpbReader::loadDataToCache(uint32_t nbytes)
+{
+    const uint8_t* pStart = m_stream + m_loadBytes;
+    const uint8_t* p;
+    const uint8_t* pEnd = m_stream + m_size;
+    /*the numbers of emulation prevention three byte in current load block*/
+    uint32_t epb = 0;
+
+    unsigned long int tmp = 0;
+    uint32_t size = 0;
+    for (p = pStart; p < pEnd && size < nbytes; p++) {
+        if (!isEmulationPreventionByte(p)) {
+            tmp <<= 8;
+            tmp |= *p;
+            size++;
+        } else {
+            epb++;
+        }
+    }
+    m_cache = tmp;
+    m_loadBytes += p - pStart;
+    m_bitsInCache = size << 3;
+    m_epb += epb;
+}
+
+uint64_t EpbReader::getPos() const
+{
+    uint32_t count = m_bitsInCache / 8;
+    const uint8_t* p = m_stream + m_loadBytes - 1;
+    uint32_t epb = 0;
+    while (count > 0) {
+        if (isEmulationPreventionByte(p))
+            epb++;
+        else
+            count--;
+        p--;
+    }
+    //some epb loaded in cache, but we are not reach it yet
+    //we need exclude it
+    return (static_cast<uint64_t>(m_loadBytes - epb) << 3) - m_bitsInCache;
+}
+
+} /*namespace YamiParser*/

--- a/codecparsers/EpbReader.h
+++ b/codecparsers/EpbReader.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef EpbReader_h
+#define EpbReader_h
+
+#include "bitReader.h"
+#include "common/log.h"
+
+namespace YamiParser {
+
+//this reader will skip the emulation prevention byte(epb)
+class EpbReader : public BitReader {
+public:
+    EpbReader(const uint8_t* data, uint32_t size);
+
+    uint32_t getEpbCnt() { return m_epb; }
+
+    uint64_t getPos() const;
+
+protected:
+    virtual bool isEmulationPreventionByte(const uint8_t* p) const = 0;
+
+private:
+    void loadDataToCache(uint32_t nbytes);
+
+    uint32_t m_epb; /*the number of emulation prevention bytes*/
+};
+
+} /*namespace YamiParser*/
+
+#endif

--- a/codecparsers/Makefile.am
+++ b/codecparsers/Makefile.am
@@ -2,6 +2,7 @@ libyami_codecparser_source_c = \
 	bitReader.cpp \
 	bitWriter.cpp \
 	EpbReader.cpp \
+	RbduReader.cpp \
 	nalReader.cpp \
 	dboolhuff.c \
 	$(NULL)

--- a/codecparsers/Makefile.am
+++ b/codecparsers/Makefile.am
@@ -1,6 +1,7 @@
 libyami_codecparser_source_c = \
 	bitReader.cpp \
 	bitWriter.cpp \
+	EpbReader.cpp \
 	nalReader.cpp \
 	dboolhuff.c \
 	$(NULL)

--- a/codecparsers/Makefile.unittest
+++ b/codecparsers/Makefile.unittest
@@ -5,6 +5,7 @@ unittest_SOURCES = \
 	bitReader_unittest.cpp \
 	nalReader_unittest.cpp \
 	bitWriter_unittest.cpp \
+	RbduReader_unittest.cpp \
 	$(NULL)
 
 if BUILD_VP8_DECODER

--- a/codecparsers/RbduReader.cpp
+++ b/codecparsers/RbduReader.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "RbduReader.h"
+#include <assert.h>
+
+namespace YamiParser {
+
+RbduReader::RbduReader(const uint8_t* pdata, uint32_t size)
+    : EpbReader(pdata, size)
+{
+}
+
+//table 255
+bool RbduReader::isEmulationPreventionByte(const uint8_t* p) const
+{
+
+    if (*p != 0x03)
+        return false;
+
+    uint32_t pos = p - m_stream;
+
+    if (pos < 2)
+        return false;
+    if (*(p - 1) != 0x00 || *(p - 2) != 0x00)
+        return false;
+
+    if ((pos + 1) >= m_size)
+        return false;
+    uint8_t next = *(p + 1);
+    if (next > 0x03)
+        return false;
+
+    return true;
+}
+
+} /*namespace YamiParser*/

--- a/codecparsers/RbduReader.h
+++ b/codecparsers/RbduReader.h
@@ -28,6 +28,7 @@ public:
     RbduReader(const uint8_t* data, uint32_t size);
 
 private:
+    friend class RbduReaderTest;
     bool isEmulationPreventionByte(const uint8_t* p) const;
 };
 

--- a/codecparsers/RbduReader.h
+++ b/codecparsers/RbduReader.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RbduReader_h
+#define RbduReader_h
+
+#include "EpbReader.h"
+#include "common/log.h"
+
+namespace YamiParser {
+
+//RBDU reader for vc1, it will skip the emulation prevention bytes.
+class RbduReader : public EpbReader {
+public:
+    RbduReader(const uint8_t* data, uint32_t size);
+
+private:
+    bool isEmulationPreventionByte(const uint8_t* p) const;
+};
+
+} /*namespace YamiParser*/
+
+#endif

--- a/codecparsers/RbduReader_unittest.cpp
+++ b/codecparsers/RbduReader_unittest.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2016 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+3B *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+// primary header
+#include "RbduReader.h"
+
+// library headers
+#include "common/unittest.h"
+
+namespace YamiParser {
+
+class RbduReaderTest
+    : public ::testing::Test {
+
+public:
+    static bool isEpb(const RbduReader& r, const uint8_t* p)
+    {
+        return r.isEmulationPreventionByte(p);
+    }
+};
+
+#define RBDUREADER_TEST(name) \
+    TEST_F(RbduReaderTest, name)
+
+#define DIM(a) (sizeof(a) / sizeof(a[0]))
+
+RBDUREADER_TEST(GetPosForEPB)
+{
+    const uint8_t data[4][8] = {
+        { 0x0, 0x0, 0x3, 0x0, 0x1, 0x2, 0x3, 0x4 },
+        { 0x0, 0x0, 0x3, 0x1, 0x1, 0x2, 0x3, 0x4 },
+        { 0x0, 0x0, 0x3, 0x2, 0x1, 0x2, 0x3, 0x4 },
+        { 0x0, 0x0, 0x3, 0x3, 0x1, 0x2, 0x3, 0x4 }
+    };
+
+    for (uint32_t i = 0; i < DIM(data); i++) {
+        RbduReader r(data[i], sizeof(data[i]));
+        EXPECT_EQ(0u, r.getPos());
+
+        r.skip(1);
+        EXPECT_EQ(1u, r.getPos());
+
+        r.skip(7);
+        EXPECT_EQ(8u, r.getPos());
+
+        r.skip(8);
+        //we are reach the epb
+        EXPECT_EQ(24u, r.getPos());
+
+        r.skip(8);
+        EXPECT_EQ(32u, r.getPos());
+
+        r.skip(24);
+
+        uint8_t b;
+        EXPECT_TRUE(r.readT(b));
+        EXPECT_EQ(4u, b);
+    }
+}
+
+RBDUREADER_TEST(GetPos)
+{
+    const uint8_t data[4][8] = {
+        { 0x0, 0x0, 0x3, 0x4, 0x1, 0x2, 0x3, 0x4 },
+        { 0x0, 0x0, 0x3, 0xFF, 0x1, 0x2, 0x3, 0x4 },
+        { 0x1, 0x0, 0x3, 0x2, 0x1, 0x2, 0x3, 0x4 },
+        { 0x0, 0x0, 0x0, 0x3, 0x5, 0x2, 0x3, 0x4 }
+    };
+
+    for (uint32_t i = 0; i < DIM(data); i++) {
+        RbduReader r(data[i], sizeof(data[i]));
+        EXPECT_EQ(0u, r.getPos());
+
+        r.skip(1);
+        EXPECT_EQ(1u, r.getPos());
+
+        r.skip(7);
+        EXPECT_EQ(8u, r.getPos());
+
+        r.skip(16);
+        EXPECT_EQ(24u, r.getPos());
+
+        r.skip(8);
+        EXPECT_EQ(32u, r.getPos());
+
+        r.skip(24);
+
+        uint8_t b;
+        EXPECT_TRUE(r.readT(b));
+        EXPECT_EQ(4u, b);
+    }
+}
+
+RBDUREADER_TEST(isEpb)
+{
+    const uint8_t data[] = {
+        0x0, 0x0, 0x3, 0x0,
+        0x3, 0x0, 0x0, 0x0,
+        0x0, 0x0, 0x0, 0x3
+    };
+    RbduReader r(data, DIM(data));
+    for (uint32_t i = 0; i < DIM(data); i++) {
+        bool epb = RbduReaderTest::isEpb(r, &data[i]);
+        if (i == 2)
+            EXPECT_TRUE(epb);
+        else
+            EXPECT_FALSE(epb);
+    }
+}
+
+} // namespace YamiParser

--- a/codecparsers/nalReader.cpp
+++ b/codecparsers/nalReader.cpp
@@ -29,43 +29,16 @@ uint32_t getHalfCeil(uint32_t n)
     return ((n + 1) >> 1);
 }
 
-NalReader::NalReader(const uint8_t *pdata, uint32_t size)
-    : BitReader(pdata, size)
-    , m_epb(0)
+NalReader::NalReader(const uint8_t* pdata, uint32_t size)
+    : EpbReader(pdata, size)
 {
 }
 
-inline bool NalReader::isEmulationBytes(const uint8_t *p) const
+bool NalReader::isEmulationPreventionByte(const uint8_t* p) const
 {
     return *p == 0x03
             && (p - m_stream) >= 2
             && *(p - 1) == 0x00 && *(p - 2) == 0x00;
-}
-
-void NalReader::loadDataToCache(uint32_t nbytes)
-{
-    const uint8_t *pStart = m_stream + m_loadBytes;
-    const uint8_t *p;
-    const uint8_t *pEnd = m_stream + m_size;
-    /*the numbers of emulation prevention three byte in current load block*/
-    uint32_t epb = 0;
-
-    unsigned long int tmp = 0;
-    uint32_t size = 0;
-    for (p = pStart; p < pEnd && size < nbytes; p++) {
-        if(!isEmulationBytes(p)) {
-            tmp <<= 8;
-            tmp |= *p;
-            size++;
-        } else {
-            epb++;
-        }
-
-    }
-    m_cache = tmp;
-    m_loadBytes += p - pStart;
-    m_bitsInCache = size << 3;
-    m_epb += epb;
 }
 
 /*according to 9.1 of h264 spec*/
@@ -141,22 +114,6 @@ void NalReader::rbspTrailingBits()
     skip(1);
     while(getPos() & 7)
         skip(1); /*rbsp_alignment_zero_bit, equal to 0*/
-}
-
-uint64_t NalReader::getPos() const
-{
-    uint32_t count = m_bitsInCache / 8;
-    const uint8_t* p = m_stream + m_loadBytes - 1;
-    uint32_t epb = 0;
-    while (count > 0) {
-        if (isEmulationBytes(p))
-            epb++;
-        else
-            count--;
-        p--;
-    }
-    //some epb loaded in cache, but we are not reach it yet
-    return (static_cast<uint64_t>(m_loadBytes - epb) << 3) - m_bitsInCache;
 }
 
 } /*namespace YamiParser*/

--- a/codecparsers/nalReader.h
+++ b/codecparsers/nalReader.h
@@ -17,13 +17,12 @@
 #ifndef nalReader_h
 #define nalReader_h
 
+#include "EpbReader.h"
 #include "common/log.h"
-#include "bitReader.h"
 
 namespace YamiParser {
 
-class NalReader : public BitReader
-{
+class NalReader : public EpbReader {
 public:
     NalReader(const uint8_t *data, uint32_t size);
 
@@ -39,15 +38,9 @@ public:
 
     bool moreRbspData() const;
     void rbspTrailingBits();
-    uint32_t getEpbCnt() { return m_epb; }
-
-    uint64_t getPos() const;
 
 private:
-    void loadDataToCache(uint32_t nbytes);
-    inline bool isEmulationBytes(const uint8_t *p) const;
-
-    uint32_t m_epb; /*the number of emulation prevention bytes*/
+    bool isEmulationPreventionByte(const uint8_t* p) const;
 };
 
 bool NalReader::readUe(uint8_t& v)

--- a/codecparsers/vc1Parser.h
+++ b/codecparsers/vc1Parser.h
@@ -272,6 +272,22 @@ namespace VC1 {
         bool parseFrameHeaderAdvanced(BitReader*);
         std::vector<uint8_t> m_rbdu;
     };
+
+    struct RBDU {
+        enum {
+            SLICE_HEADER = 0X0B,
+            FIELD_HEADER = 0X0C,
+            FRAME_HEADER = 0x0D,
+            ENTRY_POINT_HEADER = 0x0E,
+            SEQUENCE_HEADER = 0x0F,
+            FORBIDDEN_START = 0x80,
+            FORBIDDEN_END = 0xFF,
+        };
+        bool parse(const uint8_t* rbdu, int32_t rbduSize);
+        uint8_t type;
+        const uint8_t* data;
+        uint32_t size;
+    };
 }
 }
 #endif

--- a/codecparsers/vc1Parser.h
+++ b/codecparsers/vc1Parser.h
@@ -17,9 +17,9 @@
 #ifndef __VC1_PARSER_H__
 #define __VC1_PARSER_H__
 
+#include "RbduReader.h"
 #include <stdint.h>
 #include <stdlib.h>
-#include "bitReader.h"
 #include <vector>
 
 namespace YamiParser {
@@ -240,9 +240,8 @@ namespace VC1 {
         Parser();
         ~Parser();
         bool parseCodecData(uint8_t*, uint32_t);
-        bool parseFrameHeader(uint8_t*&, uint32_t&);
-        bool parseSliceHeader(uint8_t*, uint32_t);
-        int32_t searchStartCode(uint8_t*, uint32_t);
+        bool parseFrameHeader(const uint8_t* data, uint32_t size);
+        bool parseSliceHeader(const uint8_t* data, uint32_t size);
         SeqHdr m_seqHdr;
         FrameHdr m_frameHdr;
         SliceHdr m_sliceHdr;
@@ -253,24 +252,23 @@ namespace VC1 {
 
     private:
         void mallocBitPlanes();
-        bool getRefDist(BitReader*, uint8_t& refDist);
-        int32_t getFirst01Bit(BitReader*, bool, uint32_t);
-        uint8_t getMVMode(BitReader*, uint8_t, bool);
-        bool decodeBFraction(BitReader*);
+        bool getRefDist(RbduReader&, uint8_t& refDist);
+        int32_t getFirst01Bit(RbduReader&, bool, uint32_t);
+        uint8_t getMVMode(RbduReader&, uint8_t, bool);
+        bool decodeBFraction(RbduReader&);
         bool convertToRbdu(uint8_t*&, uint32_t&);
-        bool decodeVLCTable(BitReader*, uint16_t*, const VLCTable*, uint32_t);
-        bool decodeRowskipMode(BitReader*, uint8_t*, uint32_t, uint32_t);
-        bool decodeColskipMode(BitReader*, uint8_t*, uint32_t, uint32_t);
-        bool decodeNorm2Mode(BitReader*, uint8_t*, uint32_t, uint32_t);
-        bool decodeNorm6Mode(BitReader*, uint8_t*, uint32_t, uint32_t);
-        bool decodeBitPlane(BitReader*, uint8_t*, bool*);
+        bool decodeVLCTable(RbduReader&, uint16_t*, const VLCTable*, uint32_t);
+        bool decodeRowskipMode(RbduReader&, uint8_t*, uint32_t, uint32_t);
+        bool decodeColskipMode(RbduReader&, uint8_t*, uint32_t, uint32_t);
+        bool decodeNorm2Mode(RbduReader&, uint8_t*, uint32_t, uint32_t);
+        bool decodeNorm6Mode(RbduReader&, uint8_t*, uint32_t, uint32_t);
+        bool decodeBitPlane(RbduReader&, uint8_t*, bool*);
         void inverseDiff(uint8_t*, uint32_t, uint32_t, uint32_t);
-        bool parseVopdquant(BitReader*, uint8_t);
+        bool parseVopdquant(RbduReader&, uint8_t);
         bool parseSequenceHeader(const uint8_t*, uint32_t);
         bool parseEntryPointHeader(const uint8_t*, uint32_t);
-        bool parseFrameHeaderSimpleMain(BitReader*);
-        bool parseFrameHeaderAdvanced(BitReader*);
-        std::vector<uint8_t> m_rbdu;
+        bool parseFrameHeaderSimpleMain(RbduReader&);
+        bool parseFrameHeaderAdvanced(RbduReader&);
     };
 
     struct RBDU {

--- a/decoder/vaapidecoder_vc1.h
+++ b/decoder/vaapidecoder_vc1.h
@@ -39,8 +39,16 @@ private:
     friend class FactoryTest<IVideoDecoder, VaapiDecoderVC1>;
     friend class VaapiDecoderVC1Test;
     YamiStatus ensureContext();
-    YamiStatus decode(uint8_t*, uint32_t, uint64_t);
-    bool ensureSlice(PicturePtr&, void*, int);
+
+    YamiStatus decodeFrame(PicturePtr& picture,
+        const uint8_t* data, uint32_t size, uint64_t pts);
+    YamiStatus decodeField(const PicturePtr& picture,
+        const uint8_t* data, uint32_t size);
+    YamiStatus decodeSlice(const PicturePtr& picture,
+        const uint8_t* data, uint32_t size);
+
+    YamiStatus ensureSlice(const PicturePtr&, const uint8_t* data, uint32_t size,
+        uint32_t mbOffset, uint32_t sliceAddr = 0);
     bool ensurePicture(PicturePtr&);
     bool makeBitPlanes(PicturePtr&, VAPictureParameterBufferVC1*);
     YamiStatus outputPicture(const PicturePtr&);
@@ -65,7 +73,6 @@ private:
     };
 
     DPB m_dpb;
-    bool m_sliceFlag;
 
     /**
      * VaapiDecoderFactory registration result. This decoder is registered in


### PR DESCRIPTION
Made following improvement:
1. remove memory copy for rbdu, we only need few headers. And hw can handle emulation bytes by him self.Copy and remove emulation byte in the entire stream is unnecessary. 
2. isolate dpb and reference management logical to DPB class. it will make the code more readable..
3. introduce RDBU class, to hide rdbu parser details.