### PR TITLE
h26xparser: Fix build error with GCC9

### DIFF
--- a/codecparsers/h264Parser.cpp
+++ b/codecparsers/h264Parser.cpp
@@ -137,7 +137,7 @@ static bool scalingList(NalReader& br, uint8_t* sl, uint32_t size, uint32_t inde
 
 PPS::PPS()
 {
-    memset(this, 0, offsetof(PPS, m_sps));
+    memset((void*)this, 0, offsetof(PPS, m_sps));
 }
 
 PPS::~PPS()
@@ -683,7 +683,7 @@ Parser::searchSps(uint8_t id) const
 
 SliceHeader::SliceHeader()
 {
-    memset(this, 0, offsetof(SliceHeader, m_pps));
+    memset((void*)this, 0, offsetof(SliceHeader, m_pps));
 }
 
 bool SliceHeader::refPicListModification(NalReader& br, RefPicListModification* pm0,

--- a/codecparsers/h265Parser.cpp
+++ b/codecparsers/h265Parser.cpp
@@ -162,7 +162,7 @@ static const uint8_t DefaultScalingList2[64] = {
 
 VPS::VPS()
 {
-    memset(this, 0, offsetof(VPS, hrd_layer_set_idx));
+    memset((void*)this, 0, offsetof(VPS, hrd_layer_set_idx));
 }
 
 VPS::~VPS()
@@ -171,17 +171,17 @@ VPS::~VPS()
 
 SPS::SPS()
 {
-    memset(this, 0, offsetof(SPS, vps));
+    memset((void*)this, 0, offsetof(SPS, vps));
 }
 
 PPS::PPS()
 {
-    memset(this, 0, offsetof(PPS, sps));
+    memset((void*)this, 0, offsetof(PPS, sps));
 }
 
 SliceHeader::SliceHeader()
 {
-    memset(this, 0, offsetof(SliceHeader, pps));
+    memset((void*)this, 0, offsetof(SliceHeader, pps));
 }
 
 SliceHeader::~SliceHeader()

--- a/codecparsers/mpeg2_parser.cpp
+++ b/codecparsers/mpeg2_parser.cpp
@@ -33,6 +33,7 @@
 #include "common/log.h"
 #include "mpeg2_parser.h"
 #include <inttypes.h>
+#include <cstddef>
 
 namespace YamiParser {
 namespace MPEG2 {
@@ -173,7 +174,7 @@ namespace MPEG2 {
 
     SeqExtension::SeqExtension() { memset(this, 0, sizeof(*this)); }
 
-    SeqHeader::SeqHeader() { memset(this, 0, sizeof(*this)); }
+    SeqHeader::SeqHeader() { memset((void*)this, 0, offsetof(SeqHeader, quantizationMatrices)); }
 
 
     Parser::Parser()


### PR DESCRIPTION
GCC9 causing build failure:

| ../../git/codecparsers/h264Parser.cpp: In constructor 'YamiParser::H264::PPS::PPS()':
| ../../git/codecparsers/h264Parser.cpp:140:41: error: 'void* memset(void*, int, size_t)' clearing an object of type 'struct YamiParser::H264::PPS' with no trivial copy-assignment; use assignment or value-initialization instead [-Werror=class-memaccess]
|   140 |     memset(this, 0, offsetof(PPS, m_sps));
|       |                                         ^
| In file included from ../../git/codecparsers/h264Parser.cpp:21:
| ../../git/codecparsers/h264Parser.h:292:8: note: 'struct YamiParser::H264::PPS' declared here
|   292 | struct PPS {
|       |        ^~~
| ../../git/codecparsers/h264Parser.cpp: In constructor 'YamiParser::H264::SliceHeader::SliceHeader()':
| ../../git/codecparsers/h264Parser.cpp:686:49: error: 'void* memset(void*, int, size_t)' clearing an object of type 'class YamiParser::H264::SliceHeader' with no trivial copy-assignment; use assignment or value-initialization instead [-Werror=class-memaccess]
|   686 |     memset(this, 0, offsetof(SliceHeader, m_pps));
|       |                                                 ^
| In file included from ../../git/codecparsers/h264Parser.cpp:21:
| ../../git/codecparsers/h264Parser.h:371:7: note: 'class YamiParser::H264::SliceHeader' declared here
|   371 | class SliceHeader {
|       |       ^~~~~~~~~~~
| ../../git/codecparsers/h265Parser.cpp: In constructor 'YamiParser::H265::VPS::VPS()':
| ../../git/codecparsers/h265Parser.cpp:165:53: error: 'void* memset(void*, int, size_t)' clearing an object of type 'struct YamiParser::H265::VPS' with no trivial copy-assignment; use assignment or value-initialization instead [-Werror=class-memaccess]
|   165 |     memset(this, 0, offsetof(VPS, hrd_layer_set_idx));
|       |                                                     ^
| In file included from ../../git/codecparsers/h265Parser.cpp:21:
| ../../git/codecparsers/h265Parser.h:256:12: note: 'struct YamiParser::H265::VPS' declared here
|   256 |     struct VPS {
|       |            ^~~
| ../../git/codecparsers/h265Parser.cpp: In constructor 'YamiParser::H265::SPS::SPS()':
| ../../git/codecparsers/h265Parser.cpp:174:39: error: 'void* memset(void*, int, size_t)' clearing an object of type 'struct YamiParser::H265::SPS' with no trivial copy-assignment; use assignment or value-initialization instead [-Werror=class-memaccess]
|   174 |     memset(this, 0, offsetof(SPS, vps));
|       |                                       ^
| In file included from ../../git/codecparsers/h265Parser.cpp:21:
| ../../git/codecparsers/h265Parser.h:290:12: note: 'struct YamiParser::H265::SPS' declared here
|   290 |     struct SPS {
|       |            ^~~
| ../../git/codecparsers/h265Parser.cpp: In constructor 'YamiParser::H265::PPS::PPS()':
| ../../git/codecparsers/h265Parser.cpp:179:39: error: 'void* memset(void*, int, size_t)' clearing an object of type 'struct YamiParser::H265::PPS' with no trivial copy-assignment; use assignment or value-initialization instead [-Werror=class-memaccess]
|   179 |     memset(this, 0, offsetof(PPS, sps));
|       |                                       ^
| In file included from ../../git/codecparsers/h265Parser.cpp:21:
| ../../git/codecparsers/h265Parser.h:362:12: note: 'struct YamiParser::H265::PPS' declared here
|   362 |     struct PPS {
|       |            ^~~
| ../../git/codecparsers/h265Parser.cpp: In constructor 'YamiParser::H265::SliceHeader::SliceHeader()':
| ../../git/codecparsers/h265Parser.cpp:184:47: error: 'void* memset(void*, int, size_t)' clearing an object of type 'struct YamiParser::H265::SliceHeader' with no trivial copy-assignment; use assignment or value-initialization instead [-Werror=class-memaccess]
|   184 |     memset(this, 0, offsetof(SliceHeader, pps));
|       |                                               ^
| In file included from ../../git/codecparsers/h265Parser.cpp:21:
| ../../git/codecparsers/h265Parser.h:499:12: note: 'struct YamiParser::H265::SliceHeader' declared here
|   499 |     struct SliceHeader {
|       |            ^~~~~~~~~~~
| cc1plus: all warnings being treated as errors

By typecasting structure pointer to void pointer, GCC9 does normal memset operation where offsetof() give correct
number of bytes to set.

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>