### PR TITLE
vaDeriveImage returns operation failed

### DIFF
--- a/encoder/vaapiencoder_base.cpp
+++ b/encoder/vaapiencoder_base.cpp
@@ -412,7 +412,8 @@ SurfacePtr VaapiEncoderBase::createSurface(VideoFrameRawData* frame)
 
     VAImage image;
     VADisplay display = m_display->getID();
-    uint8_t* dest = mapSurfaceToImage(display, surface->getID(), image);
+    uint8_t* dest = mapSurfaceToImage(display, surface->getID(), image, 
+        frame->width, frame->height, fourcc);
     if (!dest) {
         ERROR("map image failed");
         return nil;

--- a/vaapi/VaapiUtils.h
+++ b/vaapi/VaapiUtils.h
@@ -22,7 +22,8 @@
 
 namespace YamiMediaCodec {
 
-uint8_t* mapSurfaceToImage(VADisplay display, intptr_t surface, VAImage& image);
+uint8_t* mapSurfaceToImage(VADisplay display, intptr_t surface, VAImage& image, 
+    uint32_t width = 0, uint32_t height = 0, uint32_t fourcc = 0);
 
 void unmapImage(VADisplay display, const VAImage& image);
 


### PR DESCRIPTION
Hi, vaDeriveImage returns VA_STATUS_ERROR_OPERATION_FAILED on my laptop (AMD Ryzen 5 3500u with Radeon vega 8 GPU).
I tried to fix it with the [fix suggested here](https://android.googlesource.com/platform/hardware/intel/common/libva/+/lollipop-mr1-dev/va/va.h#2937) and it worked. Probably this is not the best way (potential performance issues?), so I will be glad of any help with this.